### PR TITLE
feat: per-agent DEK model for metadata encryption

### DIFF
--- a/agents/common/envector_client.py
+++ b/agents/common/envector_client.py
@@ -31,9 +31,11 @@ class EnVectorClient:
         self,
         address: str = "localhost:50050",
         key_path: str = "~/.rune/keys",
-        key_id: str = "rune_key",
+        key_id: str = None,
         access_token: Optional[str] = None,
         auto_key_setup: bool = True,
+        agent_id: Optional[str] = None,
+        agent_dek: Optional[bytes] = None,
     ):
         """
         Initialize EnVector client.
@@ -44,12 +46,16 @@ class EnVectorClient:
             key_id: Key identifier
             access_token: Cloud access token (for enVector Cloud)
             auto_key_setup: Auto-generate keys if not found
+            agent_id: Per-agent identifier for app-layer metadata encryption
+            agent_dek: Per-agent AES-256 DEK (32 bytes) from Vault
         """
         self._address = address
         self._key_path = Path(key_path).expanduser()
         self._key_id = key_id
         self._access_token = access_token
         self._auto_key_setup = auto_key_setup
+        self._agent_id = agent_id
+        self._agent_dek = agent_dek
         self._adapter = None
         self._initialized = False
 
@@ -72,6 +78,8 @@ class EnVectorClient:
                 query_encryption=False,  # Plain queries for simplicity
                 access_token=self._access_token,
                 auto_key_setup=self._auto_key_setup,
+                agent_id=self._agent_id,
+                agent_dek=self._agent_dek,
             )
             self._initialized = True
             logger.info("Connected to %s", self._address)

--- a/mcp/adapter/envector_sdk.py
+++ b/mcp/adapter/envector_sdk.py
@@ -37,7 +37,7 @@ _original_metadata_key_path_fget = KeyParameter.metadata_key_path.fget
 
 def _safe_sec_key_getter(self):
     """Return None when SecKey.json is absent instead of crashing."""
-    if getattr(self, '_sec_key_stream', None):
+    if getattr(self, 'sec_key_stream', None):
         return _original_sec_key_fget(self)
     path = _original_sec_key_path_fget(self)
     if path and not os.path.exists(path):


### PR DESCRIPTION
Vault now provides key_id, agent_id, and agent_dek dynamically so the client no longer needs hardcoded defaults.  App-layer metadata encryption uses per-agent AES-256 DEKs derived from the Vault master key, balancing policy enforcement with insert throughput.

- Add Vault-model safety patches for pyenvector KeyParameter
- Propagate agent_id/agent_dek through client → adapter → server
- Remove hardcoded DEFAULT_KEY_ID; key_id discovered from Vault