### PR TITLE
Vault-secured search pipeline, fix metadata index bug, lower thresholds

### DIFF
--- a/agents/SLACK_SETUP.md
+++ b/agents/SLACK_SETUP.md
@@ -70,8 +70,8 @@ Alternatively, create a config file at `~/.rune/config.json`:
   "scribe": {
     "slack_webhook_port": 8080,
     "slack_signing_secret": "<Signing Secret>",
-    "similarity_threshold": 0.5,
-    "auto_capture_threshold": 0.8,
+    "similarity_threshold": 0.35,
+    "auto_capture_threshold": 0.7,
     "tier2_enabled": true
   },
   "envector": {

--- a/agents/common/config.py
+++ b/agents/common/config.py
@@ -49,8 +49,8 @@ class EmbeddingConfig:
 class ScribeConfig:
     """Scribe agent configuration"""
     slack_webhook_port: int = 8080
-    similarity_threshold: float = 0.5  # Tier 1: wider net (Tier 2 LLM handles precision)
-    auto_capture_threshold: float = 0.8
+    similarity_threshold: float = 0.35  # Tier 1: wider net (Tier 2 LLM handles precision)
+    auto_capture_threshold: float = 0.7
     tier2_enabled: bool = True  # Tier 2: Haiku-based policy filter
     tier2_model: str = "claude-haiku-4-5-20251001"
     patterns_path: str = str(PATTERNS_DIR / "capture-triggers.md")
@@ -110,8 +110,8 @@ def _parse_scribe_config(data: dict) -> ScribeConfig:
     scribe_data = data.get("scribe", {})
     return ScribeConfig(
         slack_webhook_port=scribe_data.get("slack_webhook_port", 8080),
-        similarity_threshold=scribe_data.get("similarity_threshold", 0.5),
-        auto_capture_threshold=scribe_data.get("auto_capture_threshold", 0.8),
+        similarity_threshold=scribe_data.get("similarity_threshold", 0.35),
+        auto_capture_threshold=scribe_data.get("auto_capture_threshold", 0.7),
         tier2_enabled=scribe_data.get("tier2_enabled", True),
         tier2_model=scribe_data.get("tier2_model", "claude-haiku-4-5-20251001"),
         patterns_path=scribe_data.get("patterns_path", str(PATTERNS_DIR / "capture-triggers.md")),

--- a/agents/common/envector_client.py
+++ b/agents/common/envector_client.py
@@ -206,6 +206,53 @@ class EnVectorClient:
 
         return self.insert(index_name, vectors, metadata)
 
+    def score(
+        self,
+        index_name: str,
+        query_vector: List[float],
+    ) -> Dict[str, Any]:
+        """
+        Encrypted similarity scoring (Vault-secured pipeline step 1).
+
+        Returns encrypted score blobs for Vault decryption.
+
+        Args:
+            index_name: Index to score against
+            query_vector: Query embedding vector
+
+        Returns:
+            Result dict with encrypted_blobs list
+        """
+        self._ensure_initialized()
+        return self._adapter.call_score(
+            index_name=index_name,
+            query=[query_vector],
+        )
+
+    def remind(
+        self,
+        index_name: str,
+        indices: List[Dict[str, Any]],
+        output_fields: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Retrieve metadata for indices returned by Vault (Vault-secured pipeline step 3).
+
+        Args:
+            index_name: Index to fetch metadata from
+            indices: List of dicts with shard_idx, row_idx, score
+            output_fields: Fields to include (default: ["metadata"])
+
+        Returns:
+            Result dict with metadata entries
+        """
+        self._ensure_initialized()
+        return self._adapter.call_remind(
+            index_name=index_name,
+            indices=indices,
+            output_fields=output_fields,
+        )
+
     def search(
         self,
         index_name: str,

--- a/agents/retriever/searcher.py
+++ b/agents/retriever/searcher.py
@@ -2,16 +2,20 @@
 Searcher
 
 Searches organizational memory via enVector.
+Uses the Vault-secured pipeline: scoring → decrypt → metadata.
 Returns Decision Records with their payload.text for synthesis.
 """
 
 import json
+import logging
 from typing import List, Dict, Any, Optional
 from dataclasses import dataclass, field
 
 from ..common.envector_client import EnVectorClient
 from ..common.embedding_service import EmbeddingService
 from .query_processor import ParsedQuery, TimeScope
+
+logger = logging.getLogger("rune.retriever.searcher")
 
 
 @dataclass
@@ -41,6 +45,9 @@ class Searcher:
     """
     Searches organizational memory using enVector.
 
+    Uses the Vault-secured pipeline (scoring → decrypt → metadata)
+    when a vault_client is provided. Falls back to direct search otherwise.
+
     Features:
     - Multi-query expansion for better recall
     - Time filtering
@@ -53,6 +60,7 @@ class Searcher:
         envector_client: EnVectorClient,
         embedding_service: EmbeddingService,
         index_name: str,
+        vault_client=None,
     ):
         """
         Initialize searcher.
@@ -61,12 +69,14 @@ class Searcher:
             envector_client: EnVector client for vector search
             embedding_service: For embedding queries
             index_name: enVector index name (provided by Vault)
+            vault_client: VaultClient for Vault-secured search pipeline
         """
         self._client = envector_client
         self._embedding = embedding_service
         self._index_name = index_name
+        self._vault = vault_client
 
-    def search(
+    async def search(
         self,
         query: ParsedQuery,
         topk: Optional[int] = None
@@ -88,7 +98,7 @@ class Searcher:
         seen_ids = set()
 
         for expanded_query in query.expanded_queries[:3]:  # Limit expansions
-            results = self._search_single(expanded_query, topk)
+            results = await self._search_single(expanded_query, topk)
 
             for result in results:
                 if result.record_id not in seen_ids:
@@ -97,7 +107,7 @@ class Searcher:
 
         # Also search with original query
         if query.original not in query.expanded_queries:
-            results = self._search_single(query.original, topk)
+            results = await self._search_single(query.original, topk)
             for result in results:
                 if result.record_id not in seen_ids:
                     seen_ids.add(result.record_id)
@@ -113,10 +123,80 @@ class Searcher:
         # Return top results
         return all_results[:topk]
 
-    def _search_single(self, query_text: str, topk: int) -> List[SearchResult]:
-        """Execute a single search query"""
+    async def _search_single(self, query_text: str, topk: int) -> List[SearchResult]:
+        """Execute a single search query via the appropriate pipeline."""
+        if self._vault:
+            return await self._search_via_vault(query_text, topk)
+        return self._search_direct(query_text, topk)
+
+    async def _search_via_vault(self, query_text: str, topk: int) -> List[SearchResult]:
+        """
+        Vault-secured search pipeline:
+        1. Embed query → encrypted similarity scoring on enVector Cloud
+        2. Vault decrypts result ciphertext, selects top-k
+        3. Retrieve encrypted metadata from enVector Cloud
+        4. Vault decrypts metadata
+        """
         try:
-            # Search enVector
+            # Embed query
+            query_vector = self._embedding.embed_single(query_text)
+
+            # Step 1: encrypted similarity scoring → result ciphertext
+            scoring_result = self._client.score(self._index_name, query_vector)
+            if not scoring_result.get("ok"):
+                logger.warning("Scoring failed: %s", scoring_result.get("error"))
+                return []
+
+            blobs = scoring_result.get("encrypted_blobs", [])
+            if not blobs:
+                return []
+
+            # Step 2: Vault decrypts scores + top-k
+            vault_result = await self._vault.decrypt_search_results(
+                encrypted_blob_b64=blobs[0],
+                top_k=topk,
+            )
+            if not vault_result.ok:
+                logger.warning("Vault decrypt failed: %s", vault_result.error)
+                return []
+
+            if not vault_result.results:
+                return []
+
+            # Step 3: Retrieve encrypted metadata
+            metadata_result = self._client.remind(
+                self._index_name,
+                vault_result.results,
+                output_fields=["metadata"],
+            )
+            if not metadata_result.get("ok"):
+                logger.warning("Metadata retrieval failed: %s", metadata_result.get("error"))
+                return []
+
+            # Step 4: Decrypt metadata via Vault
+            encrypted_entries = metadata_result.get("results", [])
+            encrypted_blobs = [entry.get("data", "") for entry in encrypted_entries]
+
+            if encrypted_blobs and any(encrypted_blobs):
+                non_empty = [(idx, b) for idx, b in enumerate(encrypted_blobs) if b]
+                decrypted_metadata = await self._vault.decrypt_metadata(
+                    encrypted_metadata_list=[b for _, b in non_empty]
+                )
+                for dec_idx, (entry_idx, _) in enumerate(non_empty):
+                    if dec_idx < len(decrypted_metadata):
+                        encrypted_entries[entry_idx]["metadata"] = decrypted_metadata[dec_idx]
+                for entry in encrypted_entries:
+                    entry.pop("data", None)
+
+            return [self._to_search_result(r) for r in encrypted_entries]
+
+        except Exception as e:
+            logger.error("Vault search error: %s", e, exc_info=True)
+            return []
+
+    def _search_direct(self, query_text: str, topk: int) -> List[SearchResult]:
+        """Fallback: direct search without Vault (for non-Vault deployments)."""
+        try:
             raw_result = self._client.search_with_text(
                 index_name=self._index_name,
                 query_text=query_text,
@@ -125,15 +205,14 @@ class Searcher:
             )
 
             if not raw_result.get("ok"):
-                print(f"[Searcher] Search failed: {raw_result.get('error')}")
+                logger.warning("Direct search failed: %s", raw_result.get("error"))
                 return []
 
-            # Parse results
             parsed = self._client.parse_search_results(raw_result)
             return [self._to_search_result(r) for r in parsed]
 
         except Exception as e:
-            print(f"[Searcher] Search error: {e}")
+            logger.error("Direct search error: %s", e)
             return []
 
     def _to_search_result(self, raw: Dict[str, Any]) -> SearchResult:
@@ -219,14 +298,14 @@ class Searcher:
 
         return filtered
 
-    def search_by_id(self, record_id: str) -> Optional[SearchResult]:
+    async def search_by_id(self, record_id: str) -> Optional[SearchResult]:
         """
         Search for a specific record by ID.
 
         Useful for retrieving full context of a referenced record.
         """
         # Search with the ID as query (will match in payload.text)
-        results = self._search_single(f"ID: {record_id}", topk=5)
+        results = await self._search_single(f"ID: {record_id}", topk=5)
 
         # Find exact match
         for result in results:
@@ -235,7 +314,7 @@ class Searcher:
 
         return None
 
-    def get_related(
+    async def get_related(
         self,
         record_id: str,
         topk: int = 5
@@ -246,12 +325,12 @@ class Searcher:
         Useful for "See also" suggestions.
         """
         # First get the record
-        record = self.search_by_id(record_id)
+        record = await self.search_by_id(record_id)
         if not record:
             return []
 
         # Search using its payload.text as query
-        results = self._search_single(record.payload_text[:500], topk + 1)
+        results = await self._search_single(record.payload_text[:500], topk + 1)
 
         # Exclude the original record
         return [r for r in results if r.record_id != record_id][:topk]

--- a/agents/scribe/detector.py
+++ b/agents/scribe/detector.py
@@ -39,8 +39,8 @@ class DecisionDetector:
     def __init__(
         self,
         pattern_cache: PatternCache,
-        threshold: float = 0.7,
-        high_confidence_threshold: float = 0.8
+        threshold: float = 0.35,
+        high_confidence_threshold: float = 0.7
     ):
         """
         Initialize decision detector.

--- a/agents/tests/test_retriever.py
+++ b/agents/tests/test_retriever.py
@@ -140,45 +140,49 @@ class TestSearcher:
         from agents.retriever.searcher import Searcher
         return Searcher(mock_client, mock_embedding, "test-collection")
 
-    def test_search_returns_results(self, searcher):
+    @pytest.mark.asyncio
+    async def test_search_returns_results(self, searcher):
         from agents.retriever.query_processor import QueryProcessor
 
         processor = QueryProcessor()
         query = processor.parse("Why PostgreSQL?")
 
-        results = searcher.search(query)
+        results = await searcher.search(query)
 
         assert len(results) > 0
         assert results[0].record_id == "dec_2024-01-01_arch_postgres"
 
-    def test_search_result_has_payload_text(self, searcher):
+    @pytest.mark.asyncio
+    async def test_search_result_has_payload_text(self, searcher):
         from agents.retriever.query_processor import QueryProcessor
 
         processor = QueryProcessor()
         query = processor.parse("Why PostgreSQL?")
 
-        results = searcher.search(query)
+        results = await searcher.search(query)
 
         assert results[0].payload_text != ""
         assert "Decision Record" in results[0].payload_text
 
-    def test_search_result_has_certainty(self, searcher):
+    @pytest.mark.asyncio
+    async def test_search_result_has_certainty(self, searcher):
         from agents.retriever.query_processor import QueryProcessor
 
         processor = QueryProcessor()
         query = processor.parse("Why PostgreSQL?")
 
-        results = searcher.search(query)
+        results = await searcher.search(query)
 
         assert results[0].certainty == "supported"
 
-    def test_is_reliable_check(self, searcher):
+    @pytest.mark.asyncio
+    async def test_is_reliable_check(self, searcher):
         from agents.retriever.query_processor import QueryProcessor
 
         processor = QueryProcessor()
         query = processor.parse("Why PostgreSQL?")
 
-        results = searcher.search(query)
+        results = await searcher.search(query)
 
         # Supported certainty should be reliable
         assert results[0].is_reliable is True

--- a/config/README.md
+++ b/config/README.md
@@ -68,8 +68,8 @@ The config file also supports optional sections for agent configuration:
   },
   "scribe": {
     "slack_webhook_port": 8080,
-    "similarity_threshold": 0.5,
-    "auto_capture_threshold": 0.8,
+    "similarity_threshold": 0.35,
+    "auto_capture_threshold": 0.7,
     "tier2_enabled": true,
     "tier2_model": "claude-haiku-4-5-20251001"
   },

--- a/scripts/setup-slack-app.sh
+++ b/scripts/setup-slack-app.sh
@@ -89,8 +89,8 @@ if [ ! -f "$CONFIG_FILE" ]; then
   "scribe": {
     "slack_webhook_port": 8080,
     "slack_signing_secret": "",
-    "similarity_threshold": 0.5,
-    "auto_capture_threshold": 0.8,
+    "similarity_threshold": 0.35,
+    "auto_capture_threshold": 0.7,
     "tier2_enabled": true
   },
   "envector": {


### PR DESCRIPTION
Add score()/remind() to EnVectorClient for Vault-secured search. Refactor Searcher to async with Vault pipeline (score → decrypt → metadata) and direct-search fallback. Fix metadata index mismatch when filtered empty blobs caused decrypted results to map to wrong entries (both searcher.py and server.py tool_remember). Lower default thresholds (0.5→0.35 similarity, 0.8→0.7 auto-capture) to improve pattern capture recall.