### PR TITLE
fix: use installedFrom path for venv detection in status skill

### DIFF
--- a/commands/status.md
+++ b/commands/status.md
@@ -24,7 +24,7 @@ Configuration:
   [check] enVector: <endpoint or "not set">
 
 Infrastructure:
-  [check] Python venv: <path or "not found">
+  [check] Python venv: <installedFrom>/.venv (read installedFrom from config metadata)
   [check] MCP server logs: <recent or "stale/missing">
 
 Recommendations:


### PR DESCRIPTION
The status skill was not specifying where to find the Python venv, causing the agent to guess ~/.rune/venv instead of the correct path at <installedFrom>/.venv from config metadata.