### PR TITLE
fix: rename /rune:remember to /rune:memorize

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ Feature requests should include:
 
 4. **Commands**
    - Test `/rune:status` in both states
-   - Test `/rune:remember` with various inputs
+   - Test `/rune:memorize` with various inputs
    - Test `/rune:recall` with various queries
    - Test `/rune:reset` with confirmation
 

--- a/README.md
+++ b/README.md
@@ -248,10 +248,10 @@ Validate infrastructure and switch to Active state
 /rune:activate
 ```
 
-### `/rune:remember <context>`
+### `/rune:memorize <context>`
 Manually store context that Scribe's automatic capture missed (Active state only)
 ```
-/rune:remember "We chose PostgreSQL for better JSON support"
+/rune:memorize "We chose PostgreSQL for better JSON support"
 ```
 
 ### `/rune:recall <query>`
@@ -286,9 +286,9 @@ Or use the explicit command as an override:
 ```
 
 ### Manual Context Storage
-If Scribe missed something, use `/rune:remember` to force-store:
+If Scribe missed something, use `/rune:memorize` to force-store:
 ```
-/rune:remember "We chose PostgreSQL for better JSON support"
+/rune:memorize "We chose PostgreSQL for better JSON support"
 ```
 
 ## Security

--- a/SKILL.md
+++ b/SKILL.md
@@ -105,7 +105,7 @@ Recommendations:
   - Check full status: scripts/check-infrastructure.sh
 ```
 
-### `/rune:remember <context>`
+### `/rune:memorize <context>`
 **Purpose**: Manually store organizational context when Scribe's automatic capture missed it or the user wants to force-store specific information.
 
 **When to use**: Scribe automatically captures significant decisions from conversation (see Automatic Behavior below). This command is an **override** for cases where:
@@ -119,7 +119,7 @@ Recommendations:
 
 **Example**:
 ```
-/rune:remember "We chose PostgreSQL over MongoDB for better ACID guarantees"
+/rune:memorize "We chose PostgreSQL over MongoDB for better ACID guarantees"
 ```
 
 ### `/rune:recall <query>`

--- a/commands/memorize.md
+++ b/commands/memorize.md
@@ -3,7 +3,7 @@ description: Store organizational context to encrypted memory
 allowed-tools: Bash(python3:*), Bash(cat ~/.rune/*), Read, mcp__plugin_rune_envector__*
 ---
 
-# /rune:remember — Store Context
+# /rune:memorize — Store Context
 
 Manually store organizational context to encrypted memory.
 
@@ -17,7 +17,7 @@ The argument `$ARGUMENTS` contains the context to store.
 
 ## When Active
 
-1. Parse `$ARGUMENTS` as the context to remember.
+1. Parse `$ARGUMENTS` as the context to memorize.
 2. Add metadata: timestamp, domain classification (infer from content).
 3. Use the envector MCP tools to embed and store the context.
 4. Confirm what was stored with a brief summary.
@@ -25,5 +25,5 @@ The argument `$ARGUMENTS` contains the context to store.
 ## Example
 
 ```
-/rune:remember We chose PostgreSQL over MongoDB for better ACID guarantees
+/rune:memorize We chose PostgreSQL over MongoDB for better ACID guarantees
 ```

--- a/examples/usage-patterns.md
+++ b/examples/usage-patterns.md
@@ -49,33 +49,33 @@ Claude: [Records team process]
 
 ## Manual Context Storage
 
-Scribe captures most decisions automatically from conversation. Use `/rune:remember` when Scribe missed something or you want to store context that isn't part of the current conversation:
+Scribe captures most decisions automatically from conversation. Use `/rune:memorize` when Scribe missed something or you want to store context that isn't part of the current conversation:
 
 ### Security Policies
 
 ```
-/rune:remember "All API keys must be stored in environment variables,
+/rune:memorize "All API keys must be stored in environment variables,
 never hardcoded. Use AWS Secrets Manager for production."
 ```
 
 ### Design Patterns
 
 ```
-/rune:remember "We use the Repository pattern for data access.
+/rune:memorize "We use the Repository pattern for data access.
 Each entity has a corresponding repository interface in the domain layer."
 ```
 
 ### Performance Decisions
 
 ```
-/rune:remember "Database queries must use pagination. Maximum page size
+/rune:memorize "Database queries must use pagination. Maximum page size
 is 100 items. Always include total count in response."
 ```
 
 ### Onboarding Information
 
 ```
-/rune:remember "New developers should read docs/ARCHITECTURE.md first,
+/rune:memorize "New developers should read docs/ARCHITECTURE.md first,
 then set up their environment with scripts/dev-setup.sh"
 ```
 
@@ -271,14 +271,14 @@ Supported redaction patterns:
 Import existing documentation:
 
 ```
-/rune:remember "$(cat docs/ARCHITECTURE.md)"
+/rune:memorize "$(cat docs/ARCHITECTURE.md)"
 ```
 
 Import decision records:
 
 ```
 for file in docs/decisions/*.md; do
-  /rune:remember "$(cat $file)"
+  /rune:memorize "$(cat $file)"
 done
 ```
 
@@ -321,7 +321,7 @@ Decision made after 2-week trial with both databases."
 When circumstances change:
 
 ```
-/rune:remember "Updated database decision: We migrated from PostgreSQL
+/rune:memorize "Updated database decision: We migrated from PostgreSQL
 to MongoDB in Q2 2025. Reason: Document model evolved to be too complex
 for relational schema. PostgreSQL worked well initially but became
 bottleneck at scale."
@@ -347,9 +347,9 @@ Claude: [Summarizes captured decisions from last 3 months]
 
 **Why**: Scribe uses pattern matching and significance scoring (threshold 0.7) to decide what to capture. Some context may fall below the threshold if it lacks clear decision-language triggers like "we decided...", "we chose X over Y because...", etc.
 
-**Solution**: Use `/rune:remember` as a manual override:
+**Solution**: Use `/rune:memorize` as a manual override:
 ```
-/rune:remember "Previous decision: [repeat the important context]"
+/rune:memorize "Previous decision: [repeat the important context]"
 ```
 
 ### Too Much Noise
@@ -372,9 +372,9 @@ Use: "Why did we choose PostgreSQL over MySQL for the user service?"
 
 **Issue**: Retrieved context is outdated.
 
-**Solution**: State the updated decision in conversation (Scribe will capture it), or use `/rune:remember` to force-store:
+**Solution**: State the updated decision in conversation (Scribe will capture it), or use `/rune:memorize` to force-store:
 ```
-/rune:remember "Updated: [new information that supersedes old decision]"
+/rune:memorize "Updated: [new information that supersedes old decision]"
 ```
 
 ---
@@ -428,7 +428,7 @@ Source: Captured from infra team 2 months ago"
 
 **Automatic Capture (Scribe)**: Automatically identifies and captures significant decisions from conversation — the primary capture path.
 **Automatic Retrieval (Retriever)**: Automatically detects recall-intent queries in natural conversation — the primary retrieval path.
-**Manual Override (`/rune:remember`)**: Force-store context that Scribe missed — use sparingly.
+**Manual Override (`/rune:memorize`)**: Force-store context that Scribe missed — use sparingly.
 **Manual Override (`/rune:recall`)**: Explicitly search memory bypassing Retriever's intent detection — use when natural language doesn't trigger recall.
 **Team Collaboration**: All team members share same organizational memory.
 **Security**: FHE encryption ensures zero-knowledge privacy.

--- a/openclaw/src/commands.ts
+++ b/openclaw/src/commands.ts
@@ -342,9 +342,9 @@ export function registerRuneCommands(api: OpenClawPluginApi): void {
     },
   });
 
-  // ── rune-remember ────────────────────────────────────────────────────
+  // ── rune-memorize ────────────────────────────────────────────────────
   api.registerCommand({
-    name: "rune-remember",
+    name: "rune-memorize",
     description: "Store organizational context to encrypted memory",
     acceptsArgs: true,
     handler: async (ctx) => {
@@ -354,7 +354,7 @@ export function registerRuneCommands(api: OpenClawPluginApi): void {
 
       const text = ctx.args?.trim() ?? "";
       if (!text) {
-        return { text: "Usage: /rune-remember <context to store>\nExample: /rune-remember We chose PostgreSQL for ACID guarantees" };
+        return { text: "Usage: /rune-memorize <context to store>\nExample: /rune-memorize We chose PostgreSQL for ACID guarantees" };
       }
 
       const client = getMcpClient();

--- a/setup/check-prerequisites.md
+++ b/setup/check-prerequisites.md
@@ -96,7 +96,7 @@ Claude: According to organizational memory from 2 weeks ago:
 
 **Manual override** — only when automatic capture missed something:
 ```
-You: /rune:remember "All API endpoints must use JWT authentication"
+You: /rune:memorize "All API endpoints must use JWT authentication"
 Claude: Stored in organizational memory
 ```
 


### PR DESCRIPTION
## Summary
- Resolve naming collision between slash command and MCP tool (fixes #20)
- `/rune:memorize` = store (calls capture) — correct semantics
- MCP `remember` = retrieve — unchanged, already correct

## Changes
- `commands/remember.md` → `commands/memorize.md`
- `openclaw/src/commands.ts` — command registration
- `SKILL.md`, `README.md`, `CONTRIBUTING.md` — documentation
- `examples/usage-patterns.md`, `setup/check-prerequisites.md` — examples

## NOT changed
- `mcp/server/server.py` — MCP remember tool (retrieval)
- `openclaw/src/tools.ts` — rune_remember tool (retrieval)

## Test plan
- [x] grep confirms zero `rune:remember` hits in .md/.ts files
- [x] grep confirms `rune:memorize` present in all expected files
- [x] MCP `remember` tool references intact (`rune_remember` in tools.ts)
- [x] `commands/memorize.md` exists, `commands/remember.md` removed

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)