### PR TITLE
Feat/reasoning chain

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "rune",
       "description": "FHE-encrypted organizational memory for teams. Capture and retrieve institutional knowledge with zero-knowledge privacy.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "source": "./",
       "author": {
         "name": "Sunchul Jung",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rune",
   "description": "FHE-encrypted organizational memory for teams. Capture and retrieve institutional knowledge with zero-knowledge privacy.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Sunchul Jung",
     "email": "zotanika@cryptolab.co.kr"

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -16,4 +16,4 @@ Usage:
     from agents.retriever import Searcher, Synthesizer
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/agents/common/schemas/__init__.py
+++ b/agents/common/schemas/__init__.py
@@ -22,6 +22,7 @@ from .decision_record import (
     Certainty,
     ReviewState,
     generate_record_id,
+    generate_group_id,
 )
 from .templates import render_payload_text, render_display_text, PAYLOAD_TEMPLATE, PAYLOAD_HEADERS
 
@@ -43,6 +44,7 @@ __all__ = [
     "Certainty",
     "ReviewState",
     "generate_record_id",
+    "generate_group_id",
     "render_payload_text",
     "render_display_text",
     "PAYLOAD_TEMPLATE",

--- a/agents/common/schemas/decision_record.py
+++ b/agents/common/schemas/decision_record.py
@@ -237,7 +237,7 @@ def generate_record_id(timestamp: datetime, domain: Domain, title: str) -> str:
 
 
 def generate_group_id(timestamp: datetime, domain: Domain, title: str) -> str:
-    """Generate a shared group ID for a phase chain"""
+    """Generate a shared group ID for related records (phase_chain or bundle)"""
     date_str = timestamp.strftime("%Y-%m-%d")
     words = title.lower().split()[:3]
     slug = "_".join(w for w in words if w.isalnum() or w.replace("_", "").isalnum())

--- a/agents/common/schemas/decision_record.py
+++ b/agents/common/schemas/decision_record.py
@@ -188,6 +188,11 @@ class DecisionRecord(BaseModel):
     links: List[dict] = Field(default_factory=list, description="Related links (ADR, PR, etc.)")
     tags: List[str] = Field(default_factory=list)
 
+    # Phase Chain fields — for linked long-term memory
+    group_id: Optional[str] = Field(default=None, description="Shared ID linking all phases of one reasoning chain")
+    phase_seq: Optional[int] = Field(default=None, description="0-indexed position within the group")
+    phase_total: Optional[int] = Field(default=None, description="Total number of phases in the group")
+
     quality: Quality = Field(default_factory=Quality)
     payload: Payload = Field(default_factory=Payload)
 
@@ -228,3 +233,11 @@ def generate_record_id(timestamp: datetime, domain: Domain, title: str) -> str:
     words = title.lower().split()[:3]
     slug = "_".join(w for w in words if w.isalnum() or w.replace("_", "").isalnum())
     return f"dec_{date_str}_{domain.value}_{slug}"
+
+
+def generate_group_id(timestamp: datetime, domain: Domain, title: str) -> str:
+    """Generate a shared group ID for a phase chain"""
+    date_str = timestamp.strftime("%Y-%m-%d")
+    words = title.lower().split()[:3]
+    slug = "_".join(w for w in words if w.isalnum() or w.replace("_", "").isalnum())
+    return f"grp_{date_str}_{domain.value}_{slug}"

--- a/agents/common/schemas/decision_record.py
+++ b/agents/common/schemas/decision_record.py
@@ -188,10 +188,11 @@ class DecisionRecord(BaseModel):
     links: List[dict] = Field(default_factory=list, description="Related links (ADR, PR, etc.)")
     tags: List[str] = Field(default_factory=list)
 
-    # Phase Chain fields — for linked long-term memory
-    group_id: Optional[str] = Field(default=None, description="Shared ID linking all phases of one reasoning chain")
+    # Group fields — for linked long-term memory
+    group_id: Optional[str] = Field(default=None, description="Shared ID linking all records in a group")
+    group_type: Optional[str] = Field(default=None, description="Group type: 'phase_chain' (sequential reasoning) or 'bundle' (detail facets)")
     phase_seq: Optional[int] = Field(default=None, description="0-indexed position within the group")
-    phase_total: Optional[int] = Field(default=None, description="Total number of phases in the group")
+    phase_total: Optional[int] = Field(default=None, description="Total number of records in the group")
 
     quality: Quality = Field(default_factory=Quality)
     payload: Payload = Field(default_factory=Payload)

--- a/agents/common/schemas/templates.py
+++ b/agents/common/schemas/templates.py
@@ -169,12 +169,13 @@ def render_payload_text(record: "DecisionRecord") -> str:
     if record.why.missing_info:
         rationale += "\n\nMissing Information:\n" + "\n".join(f"- {m}" for m in record.why.missing_info)
 
-    # Phase chain info (only for phased records)
+    # Group info (phase_chain or bundle)
     phase_line = ""
     if getattr(record, 'group_id', None):
         seq = (getattr(record, 'phase_seq', None) or 0) + 1
         total = getattr(record, 'phase_total', None) or "?"
-        phase_line = f"\nPhase: {seq} of {total} | Group: {record.group_id}"
+        gtype = getattr(record, 'group_type', None) or "phase_chain"
+        phase_line = f"\nPart: {seq} of {total} | Type: {gtype} | Group: {record.group_id}"
 
     # Render template
     text = PAYLOAD_TEMPLATE.format(

--- a/agents/common/schemas/templates.py
+++ b/agents/common/schemas/templates.py
@@ -169,6 +169,13 @@ def render_payload_text(record: "DecisionRecord") -> str:
     if record.why.missing_info:
         rationale += "\n\nMissing Information:\n" + "\n".join(f"- {m}" for m in record.why.missing_info)
 
+    # Phase chain info (only for phased records)
+    phase_line = ""
+    if getattr(record, 'group_id', None):
+        seq = (getattr(record, 'phase_seq', None) or 0) + 1
+        total = getattr(record, 'phase_total', None) or "?"
+        phase_line = f"\nPhase: {seq} of {total} | Group: {record.group_id}"
+
     # Render template
     text = PAYLOAD_TEMPLATE.format(
         title=record.title,
@@ -190,6 +197,15 @@ def render_payload_text(record: "DecisionRecord") -> str:
         links=links,
         tags=tags,
     )
+
+    # Insert phase line after ID line
+    if phase_line:
+        lines = text.split("\n")
+        for i, line in enumerate(lines):
+            if line.startswith("ID: "):
+                lines.insert(i + 1, phase_line.lstrip("\n"))
+                break
+        text = "\n".join(lines)
 
     # Clean up multiple blank lines
     while "\n\n\n" in text:

--- a/agents/retriever/searcher.py
+++ b/agents/retriever/searcher.py
@@ -29,8 +29,9 @@ class SearchResult:
     status: str
     score: float
     metadata: Dict[str, Any] = field(default_factory=dict)
-    # Phase chain fields
+    # Group fields (phase_chain or bundle)
     group_id: Optional[str] = None
+    group_type: Optional[str] = None
     phase_seq: Optional[int] = None
     phase_total: Optional[int] = None
 
@@ -41,7 +42,7 @@ class SearchResult:
 
     @property
     def is_phase(self) -> bool:
-        """Check if this result is part of a phase chain"""
+        """Check if this result is part of a group (phase_chain or bundle)"""
         return self.group_id is not None
 
     @property
@@ -263,8 +264,9 @@ class Searcher:
             if isinstance(decision, dict):
                 payload_text = decision.get("what", "")
 
-        # Extract phase chain fields
+        # Extract group fields
         group_id = metadata.get("group_id")
+        group_type = metadata.get("group_type")
         phase_seq = metadata.get("phase_seq")
         phase_total = metadata.get("phase_total")
 
@@ -278,6 +280,7 @@ class Searcher:
             score=raw.get("score", 0.0),
             metadata=metadata,
             group_id=group_id,
+            group_type=group_type,
             phase_seq=phase_seq,
             phase_total=phase_total,
         )

--- a/agents/retriever/searcher.py
+++ b/agents/retriever/searcher.py
@@ -140,7 +140,7 @@ class Searcher:
         if expand_phases:
             all_results = await self._expand_phase_chains(all_results)
 
-        return all_results
+        return all_results[:topk]
 
     async def _search_single(self, query_text: str, topk: int) -> List[SearchResult]:
         """Execute a single search query via the appropriate pipeline."""
@@ -324,7 +324,7 @@ class Searcher:
         for group_id in groups_to_expand:
             # Search by group_id (embedded in payload.text)
             siblings = await self._search_single(f"Group: {group_id}", topk=10)
-            chain = [s for s in siblings if s.group_id == group_id]
+            chain = [s for s in siblings if s.group_id == group_id and s.record_id not in existing_ids]
             # Sort by phase_seq
             chain.sort(key=lambda s: s.phase_seq if s.phase_seq is not None else 0)
             group_siblings[group_id] = chain

--- a/agents/scribe/llm_extractor.py
+++ b/agents/scribe/llm_extractor.py
@@ -18,6 +18,9 @@ logger = logging.getLogger("rune.scribe.llm_extractor")
 # Texts longer than this threshold trigger multi-phase extraction
 PHASE_SPLIT_THRESHOLD = 800
 
+# Texts longer than this, or with many detail items, trigger bundle split
+BUNDLE_SPLIT_THRESHOLD = 1500
+
 
 @dataclass
 class ExtractedFields:
@@ -45,8 +48,9 @@ class PhaseExtractedFields:
 
 @dataclass
 class ExtractionResult:
-    """Result of LLM extraction — may be single or multi-phase"""
+    """Result of LLM extraction — may be single, multi-phase, or bundle"""
     group_title: str = ""
+    group_type: str = ""  # "phase_chain", "bundle", or "" (single)
     status_hint: str = ""
     tags: List[str] = field(default_factory=list)
     single: Optional[ExtractedFields] = None
@@ -55,6 +59,10 @@ class ExtractionResult:
     @property
     def is_multi_phase(self) -> bool:
         return self.phases is not None and len(self.phases) > 1
+
+    @property
+    def is_bundle(self) -> bool:
+        return self.group_type == "bundle" and self.phases is not None and len(self.phases) > 1
 
 
 EXTRACTION_PROMPT = """You are a structured information extractor for organizational decision records.
@@ -123,6 +131,56 @@ Message to extract from:
 JSON:"""
 
 
+BUNDLE_SPLIT_PROMPT = """You are a structured information extractor for organizational decision records.
+
+Given a message describing a SINGLE decision with rich details (which may be in any language), split it into a CORE record plus DETAIL FACETS. This is NOT about sequential reasoning — it's about organizing the supporting material of one decision.
+
+IMPORTANT:
+- The first item MUST be the "Core Decision" — a concise summary of the main decision.
+- Subsequent items are detail facets: alternatives analysis, trade-offs, implementation plan, rationale deep-dive, etc.
+- All output values MUST be in English (translate if needed).
+- Aim for 2-4 facets total (including core). Do not create more than 5.
+- Each facet should be self-contained and meaningful on its own.
+
+Respond with a valid JSON object:
+{{
+    "group_title": "Overall title for the decision (5-60 chars, English)",
+    "status_hint": "proposed" or "accepted" or "rejected",
+    "tags": ["relevant", "topic", "tags"],
+    "phases": [
+        {{
+            "phase_title": "Core Decision",
+            "phase_decision": "The main decision statement — concise",
+            "phase_rationale": "Brief summary of why",
+            "phase_problem": "The problem being solved",
+            "alternatives": [],
+            "trade_offs": [],
+            "tags": []
+        }},
+        {{
+            "phase_title": "Alternatives Analysis",
+            "phase_decision": "Detailed comparison of alternatives considered",
+            "phase_rationale": "Why the chosen option was selected over others",
+            "phase_problem": "",
+            "alternatives": ["alt1", "alt2", "alt3"],
+            "trade_offs": ["trade-off for each"],
+            "tags": []
+        }}
+    ]
+}}
+
+Rules:
+- Translate ALL values to English
+- First facet is always "Core Decision" with the essential what/why
+- Other facets organize the supporting detail (alternatives, trade-offs, implementation, evidence, etc.)
+- Each phase_decision should be self-contained — readable without other facets
+
+Message to extract from:
+{text}
+
+JSON:"""
+
+
 class LLMExtractor:
     """Extracts structured fields from text using Claude API.
 
@@ -153,31 +211,58 @@ class LLMExtractor:
         return self._client is not None
 
     def extract(self, text: str) -> ExtractionResult:
-        """Extract structured fields, auto-detecting if phase splitting is needed.
+        """Extract structured fields, auto-detecting split strategy.
+
+        Split strategy:
+        - Short text (<=800 chars): single extraction, then bundle check
+        - Long text (>800 chars): phase extraction first, bundle fallback
 
         Args:
             text: Input text (any language)
 
         Returns:
-            ExtractionResult (check .is_multi_phase for phase chain)
+            ExtractionResult (check .is_multi_phase or .is_bundle)
         """
         if not self.is_available:
             return ExtractionResult(single=ExtractedFields())
 
         if len(text) <= PHASE_SPLIT_THRESHOLD:
             fields = self._extract_single(text)
-            return ExtractionResult(
+            result = ExtractionResult(
                 group_title=fields.title,
                 status_hint=fields.status_hint,
                 tags=fields.tags,
                 single=fields,
             )
+            # Check if even short text has overflow details
+            if self._needs_bundle_split(text, fields):
+                try:
+                    return self._extract_bundle(text)
+                except Exception as e:
+                    logger.warning("Bundle extraction failed for short text: %s", e)
+            return result
 
-        # Long text: try phase extraction
+        # Long text: try phase extraction first
         try:
-            return self._extract_phases(text)
+            result = self._extract_phases(text)
+            if result.is_multi_phase:
+                result.group_type = "phase_chain"
+                return result
+            # Phase returned single — check if bundle needed
+            if self._needs_bundle_split(text, result.single):
+                try:
+                    return self._extract_bundle(text)
+                except Exception as e:
+                    logger.warning("Bundle extraction failed after phase: %s", e)
+            return result
         except Exception as e:
-            logger.warning("Phase extraction failed, falling back to single: %s", e)
+            logger.warning("Phase extraction failed: %s", e)
+            # Try bundle before falling back to single
+            if len(text) > BUNDLE_SPLIT_THRESHOLD:
+                try:
+                    return self._extract_bundle(text)
+                except Exception as e2:
+                    logger.warning("Bundle extraction also failed: %s", e2)
             fields = self._extract_single(text)
             return ExtractionResult(
                 group_title=fields.title,
@@ -256,6 +341,71 @@ class LLMExtractor:
 
         return ExtractionResult(
             group_title=group_title,
+            status_hint=status_hint,
+            tags=tags,
+            phases=phases,
+        )
+
+    def _needs_bundle_split(self, text: str, fields: Optional[ExtractedFields]) -> bool:
+        """Check if content has detail overflow that warrants bundle splitting."""
+        # Long text that exceeds single record capacity
+        if len(text) > BUNDLE_SPLIT_THRESHOLD:
+            return True
+        # Moderate text with many detail items in multiple categories
+        if fields and len(fields.alternatives) > 3 and len(fields.trade_offs) > 3:
+            return True
+        return False
+
+    def _extract_bundle(self, text: str) -> ExtractionResult:
+        """Bundle extraction: split a single decision into detail facets."""
+        prompt = BUNDLE_SPLIT_PROMPT.format(text=text)
+        response = self._client.messages.create(
+            model=self._model,
+            max_tokens=2048,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        raw = response.content[0].text.strip()
+        data = self._parse_json(raw)
+
+        phases_data = data.get("phases", [])
+        group_title = str(data.get("group_title", ""))[:60]
+        status_hint = str(data.get("status_hint", "")).lower()
+        tags = [str(t).lower() for t in data.get("tags", []) if t]
+
+        # If LLM returned 0 or 1 facet, not a real bundle
+        if len(phases_data) <= 1:
+            p = phases_data[0] if phases_data else {}
+            return ExtractionResult(
+                group_title=group_title,
+                status_hint=status_hint,
+                tags=tags,
+                single=ExtractedFields(
+                    title=str(p.get("phase_title", group_title))[:60],
+                    rationale=str(p.get("phase_rationale", "")),
+                    problem=str(p.get("phase_problem", "")),
+                    alternatives=[str(a) for a in p.get("alternatives", []) if a],
+                    trade_offs=[str(t) for t in p.get("trade_offs", []) if t],
+                    status_hint=status_hint,
+                    tags=tags,
+                ),
+            )
+
+        # Multi-facet bundle — reuse PhaseExtractedFields structure
+        phases = []
+        for p in phases_data[:5]:  # cap at 5 facets
+            phases.append(PhaseExtractedFields(
+                phase_title=str(p.get("phase_title", ""))[:60],
+                phase_decision=str(p.get("phase_decision", "")),
+                phase_rationale=str(p.get("phase_rationale", "")),
+                phase_problem=str(p.get("phase_problem", "")),
+                alternatives=[str(a) for a in p.get("alternatives", []) if a],
+                trade_offs=[str(t) for t in p.get("trade_offs", []) if t],
+                tags=[str(t).lower() for t in p.get("tags", []) if t],
+            ))
+
+        return ExtractionResult(
+            group_title=group_title,
+            group_type="bundle",
             status_hint=status_hint,
             tags=tags,
             phases=phases,

--- a/agents/scribe/llm_extractor.py
+++ b/agents/scribe/llm_extractor.py
@@ -3,11 +3,20 @@ LLM-based Field Extractor
 
 Extracts structured decision record fields from non-English text using LLM.
 All outputs are translated to English for embedding consistency.
+
+Supports phase-aware extraction: long reasoning processes (>800 chars) are
+automatically split into logical phases, each becoming a linked DecisionRecord.
 """
 
 import json
+import logging
 from dataclasses import dataclass, field
 from typing import List, Optional
+
+logger = logging.getLogger("rune.scribe.llm_extractor")
+
+# Texts longer than this threshold trigger multi-phase extraction
+PHASE_SPLIT_THRESHOLD = 800
 
 
 @dataclass
@@ -20,6 +29,32 @@ class ExtractedFields:
     trade_offs: List[str] = field(default_factory=list)
     status_hint: str = ""       # "proposed" | "accepted" | "rejected"
     tags: List[str] = field(default_factory=list)
+
+
+@dataclass
+class PhaseExtractedFields:
+    """Fields for a single phase within a multi-phase reasoning chain"""
+    phase_title: str = ""
+    phase_decision: str = ""
+    phase_rationale: str = ""
+    phase_problem: str = ""
+    alternatives: List[str] = field(default_factory=list)
+    trade_offs: List[str] = field(default_factory=list)
+    tags: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ExtractionResult:
+    """Result of LLM extraction — may be single or multi-phase"""
+    group_title: str = ""
+    status_hint: str = ""
+    tags: List[str] = field(default_factory=list)
+    single: Optional[ExtractedFields] = None
+    phases: Optional[List[PhaseExtractedFields]] = None
+
+    @property
+    def is_multi_phase(self) -> bool:
+        return self.phases is not None and len(self.phases) > 1
 
 
 EXTRACTION_PROMPT = """You are a structured information extractor for organizational decision records.
@@ -48,8 +83,51 @@ Message to extract from:
 JSON:"""
 
 
+PHASE_EXTRACTION_PROMPT = """You are a structured information extractor for organizational decision records.
+
+Given a long message containing a multi-part reasoning process (which may be in any language), split it into LOGICAL PHASES and extract structured information for each phase.
+
+IMPORTANT:
+- Split by LOGICAL REASONING PHASES, not by paragraph or character count.
+- Each phase should represent a distinct sub-decision, conclusion, or reasoning step.
+- All output values MUST be in English (translate if needed).
+- Aim for 2-5 phases. Do not create more than 7 phases.
+- If the text is actually a single decision (not multi-phase), return a single phase.
+
+Respond with a valid JSON object:
+{{
+    "group_title": "Overall title for the entire reasoning chain (5-60 chars, English)",
+    "status_hint": "proposed" or "accepted" or "rejected",
+    "tags": ["relevant", "topic", "tags"],
+    "phases": [
+        {{
+            "phase_title": "Short title for this phase (e.g., 'Target Market Analysis')",
+            "phase_decision": "The key decision or conclusion of this phase",
+            "phase_rationale": "Why this conclusion was reached",
+            "phase_problem": "The sub-problem this phase addresses",
+            "alternatives": ["alternatives considered in this phase"],
+            "trade_offs": ["trade-offs for this phase"],
+            "tags": ["phase-specific tags"]
+        }}
+    ]
+}}
+
+Rules:
+- Translate ALL values to English
+- Each phase_decision should be self-contained and meaningful on its own
+- phase_title should indicate the topic/aspect (e.g., "Positioning Strategy", "Pricing Model", "Go-to-Market Timeline")
+
+Message to extract from:
+{text}
+
+JSON:"""
+
+
 class LLMExtractor:
-    """Extracts structured fields from non-English text using Claude API."""
+    """Extracts structured fields from text using Claude API.
+
+    Supports phase-aware extraction for long reasoning chains.
+    """
 
     def __init__(
         self,
@@ -65,66 +143,148 @@ class LLMExtractor:
                 import anthropic
                 self._client = anthropic.Anthropic(api_key=anthropic_api_key)
             except ImportError:
-                print("[LLMExtractor] Warning: anthropic package not installed")
+                logger.warning("anthropic package not installed")
             except Exception as e:
-                print(f"[LLMExtractor] Warning: Failed to init Anthropic client: {e}")
+                logger.warning("Failed to init Anthropic client: %s", e)
 
     @property
     def is_available(self) -> bool:
         """Check if LLM client is ready"""
         return self._client is not None
 
-    def extract(self, text: str) -> ExtractedFields:
-        """Extract structured fields from text using LLM.
+    def extract(self, text: str) -> ExtractionResult:
+        """Extract structured fields, auto-detecting if phase splitting is needed.
 
         Args:
             text: Input text (any language)
 
         Returns:
-            ExtractedFields with English-translated values
+            ExtractionResult (check .is_multi_phase for phase chain)
         """
         if not self.is_available:
-            return ExtractedFields()
+            return ExtractionResult(single=ExtractedFields())
 
+        if len(text) <= PHASE_SPLIT_THRESHOLD:
+            fields = self._extract_single(text)
+            return ExtractionResult(
+                group_title=fields.title,
+                status_hint=fields.status_hint,
+                tags=fields.tags,
+                single=fields,
+            )
+
+        # Long text: try phase extraction
+        try:
+            return self._extract_phases(text)
+        except Exception as e:
+            logger.warning("Phase extraction failed, falling back to single: %s", e)
+            fields = self._extract_single(text)
+            return ExtractionResult(
+                group_title=fields.title,
+                status_hint=fields.status_hint,
+                tags=fields.tags,
+                single=fields,
+            )
+
+    def extract_single(self, text: str) -> ExtractedFields:
+        """Extract as single record (backward-compatible entry point)."""
+        if not self.is_available:
+            return ExtractedFields()
+        return self._extract_single(text)
+
+    def _extract_single(self, text: str) -> ExtractedFields:
+        """Single-phase extraction (original logic)."""
         try:
             prompt = EXTRACTION_PROMPT.format(text=text)
-
             response = self._client.messages.create(
                 model=self._model,
                 max_tokens=512,
-                messages=[
-                    {"role": "user", "content": prompt}
-                ],
+                messages=[{"role": "user", "content": prompt}],
             )
-
             raw = response.content[0].text.strip()
-            return self._parse_response(raw)
+            return self._parse_single_response(raw)
         except Exception as e:
-            print(f"[LLMExtractor] Extraction failed: {e}")
+            logger.warning("Single extraction failed: %s", e)
             return ExtractedFields()
 
-    def _parse_response(self, raw: str) -> ExtractedFields:
-        """Parse LLM JSON response into ExtractedFields."""
-        # Strip markdown code fences if present
+    def _extract_phases(self, text: str) -> ExtractionResult:
+        """Multi-phase extraction for long reasoning chains."""
+        prompt = PHASE_EXTRACTION_PROMPT.format(text=text)
+        response = self._client.messages.create(
+            model=self._model,
+            max_tokens=2048,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        raw = response.content[0].text.strip()
+        data = self._parse_json(raw)
+
+        phases_data = data.get("phases", [])
+        group_title = str(data.get("group_title", ""))[:60]
+        status_hint = str(data.get("status_hint", "")).lower()
+        tags = [str(t).lower() for t in data.get("tags", []) if t]
+
+        # If LLM returned 0 or 1 phase, treat as single
+        if len(phases_data) <= 1:
+            p = phases_data[0] if phases_data else {}
+            return ExtractionResult(
+                group_title=group_title,
+                status_hint=status_hint,
+                tags=tags,
+                single=ExtractedFields(
+                    title=str(p.get("phase_title", group_title))[:60],
+                    rationale=str(p.get("phase_rationale", "")),
+                    problem=str(p.get("phase_problem", "")),
+                    alternatives=[str(a) for a in p.get("alternatives", []) if a],
+                    trade_offs=[str(t) for t in p.get("trade_offs", []) if t],
+                    status_hint=status_hint,
+                    tags=tags,
+                ),
+            )
+
+        # Multi-phase
+        phases = []
+        for p in phases_data[:7]:  # cap at 7
+            phases.append(PhaseExtractedFields(
+                phase_title=str(p.get("phase_title", ""))[:60],
+                phase_decision=str(p.get("phase_decision", "")),
+                phase_rationale=str(p.get("phase_rationale", "")),
+                phase_problem=str(p.get("phase_problem", "")),
+                alternatives=[str(a) for a in p.get("alternatives", []) if a],
+                trade_offs=[str(t) for t in p.get("trade_offs", []) if t],
+                tags=[str(t).lower() for t in p.get("tags", []) if t],
+            ))
+
+        return ExtractionResult(
+            group_title=group_title,
+            status_hint=status_hint,
+            tags=tags,
+            phases=phases,
+        )
+
+    def _parse_json(self, raw: str) -> dict:
+        """Parse JSON from LLM response, handling code fences."""
         if raw.startswith("```"):
             lines = raw.split("\n")
-            # Remove first and last lines (```json and ```)
             lines = [l for l in lines if not l.strip().startswith("```")]
             raw = "\n".join(lines)
 
         try:
-            data = json.loads(raw)
+            return json.loads(raw)
         except json.JSONDecodeError:
-            # Try to find JSON object in the response
             start = raw.find("{")
             end = raw.rfind("}") + 1
             if start >= 0 and end > start:
                 try:
-                    data = json.loads(raw[start:end])
+                    return json.loads(raw[start:end])
                 except json.JSONDecodeError:
-                    return ExtractedFields()
-            else:
-                return ExtractedFields()
+                    pass
+        return {}
+
+    def _parse_single_response(self, raw: str) -> ExtractedFields:
+        """Parse LLM JSON response into ExtractedFields."""
+        data = self._parse_json(raw)
+        if not data:
+            return ExtractedFields()
 
         return ExtractedFields(
             title=str(data.get("title", ""))[:60],

--- a/agents/scribe/record_builder.py
+++ b/agents/scribe/record_builder.py
@@ -294,7 +294,7 @@ class RecordBuilder:
             if raw_event.timestamp:
                 try:
                     ts = float(raw_event.timestamp)
-                    when = datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
+                    when = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
                 except (ValueError, TypeError):
                     when = raw_event.timestamp
 

--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -506,8 +506,9 @@ class MCPServerApp:
                     "certainty": first.why.certainty.value,
                 }
                 if len(records) > 1:
-                    result["phase_count"] = len(records)
+                    result["record_count"] = len(records)
                     result["group_id"] = first.group_id
+                    result["group_type"] = first.group_type or "phase_chain"
                 return result
 
             except Exception as e:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,7 +4,7 @@ set -e
 # Rune Plugin Installation Script
 # This script sets up the Python environment and dependencies for the plugin
 
-VERSION="0.1.0"
+VERSION="0.1.1"
 PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Colors

--- a/scripts/register-plugin.sh
+++ b/scripts/register-plugin.sh
@@ -6,9 +6,9 @@ set -e
 
 PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PLUGIN_NAME="rune"
-MARKETPLACE="local"
+MARKETPLACE="cryptolab-rune"
 PLUGIN_KEY="${PLUGIN_NAME}@${MARKETPLACE}"
-VERSION="0.1.0"
+VERSION="0.1.1"
 
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -87,34 +87,6 @@ with open(path, 'w') as f:
     json.dump(data, f, indent=2)
 "
 print_info "Enabled in settings.json: enabledPlugins['$PLUGIN_KEY'] = true"
-
-# ---- 4. Register local marketplace if not present ----
-MARKETPLACES_FILE="$PLUGINS_DIR/known_marketplaces.json"
-if [ -f "$MARKETPLACES_FILE" ]; then
-    python3 -c "
-import json
-
-path = '$MARKETPLACES_FILE'
-
-with open(path, 'r') as f:
-    data = json.load(f)
-
-if 'local' not in data:
-    data['local'] = {
-        'source': {
-            'source': 'local',
-            'path': '$HOME/.claude/plugins/cache/local'
-        },
-        'installLocation': '$HOME/.claude/plugins/cache/local',
-        'lastUpdated': '$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")'
-    }
-    with open(path, 'w') as f:
-        json.dump(data, f, indent=2)
-    print('  Added local marketplace')
-else:
-    print('  Local marketplace already registered')
-"
-fi
 
 echo ""
 print_info "Rune plugin registered in Claude Code"


### PR DESCRIPTION
This pull request introduces comprehensive support for phase-aware and group-aware decision records throughout the codebase. The changes enable the system to extract, store, retrieve, and present multi-phase reasoning chains and bundled decision facets as logically linked groups, improving organizational memory and reasoning traceability. The update also adds new fields and logic to handle these groupings in both the schema and retrieval pipelines.

The most important changes are:

**Phase/Group Support in Schemas and Records**

* Added new fields to `DecisionRecord` and `SearchResult` (such as `group_id`, `group_type`, `phase_seq`, and `phase_total`) to represent linked records as part of a phase chain or bundle, and added a `generate_group_id` function for consistent group identification. [[1]](diffhunk://#diff-bc0671ff9f8b62063bba47b7211453f0820f88100f69f63d12ca2493e80c5057R191-R196) [[2]](diffhunk://#diff-bc0671ff9f8b62063bba47b7211453f0820f88100f69f63d12ca2493e80c5057R237-R244) [[3]](diffhunk://#diff-6a9508d50f51386d3c97f6e8c6ced00f8128fb0e6cbbb401378cdefa970e8967R25) [[4]](diffhunk://#diff-6a9508d50f51386d3c97f6e8c6ced00f8128fb0e6cbbb401378cdefa970e8967R47) [[5]](diffhunk://#diff-8cc2f23883a4cb81bcd9a5a65adfabd520d4afd98e81288a92903b9679c247f1R32-R47)
* Updated the payload rendering logic to display group/phase information in the output text, making group membership and phase position visible. [[1]](diffhunk://#diff-7273b01bd8cd769da2cd37453a0e58a3822ef2d008068a34d1c3ac5ac48a033bR172-R179) [[2]](diffhunk://#diff-7273b01bd8cd769da2cd37453a0e58a3822ef2d008068a34d1c3ac5ac48a033bR202-R210)

**Phase-Aware Extraction and Grouping**

* Enhanced the LLM extraction process to support automatic splitting of long or detailed inputs into logical phases (for sequential reasoning) or bundles (for detailed facets), including new prompt templates and result data structures (`PhaseExtractedFields`, `ExtractionResult`). [[1]](diffhunk://#diff-171ce843e70221fae79c61c342f7586992302b0a2dbbbdd9c6f490d089d7df71R6-R23) [[2]](diffhunk://#diff-171ce843e70221fae79c61c342f7586992302b0a2dbbbdd9c6f490d089d7df71R37-R67) [[3]](diffhunk://#diff-171ce843e70221fae79c61c342f7586992302b0a2dbbbdd9c6f490d089d7df71R94-R188)

**Retrieval and Synthesis Enhancements**

* Modified the search pipeline to recognize and expand phase chains: when a search result is part of a group, sibling phases are automatically retrieved and results are grouped and ordered accordingly. [[1]](diffhunk://#diff-8cc2f23883a4cb81bcd9a5a65adfabd520d4afd98e81288a92903b9679c247f1L82-R102) [[2]](diffhunk://#diff-8cc2f23883a4cb81bcd9a5a65adfabd520d4afd98e81288a92903b9679c247f1L123-R143) [[3]](diffhunk://#diff-8cc2f23883a4cb81bcd9a5a65adfabd520d4afd98e81288a92903b9679c247f1R267-R272) [[4]](diffhunk://#diff-8cc2f23883a4cb81bcd9a5a65adfabd520d4afd98e81288a92903b9679c247f1R282-R353)
* Improved the synthesis output to format and present grouped records (phase chains and bundles) together in prompts, making reasoning chains and detail bundles clear to downstream consumers or LLMs. [[1]](diffhunk://#diff-77b0bf28a052b0878ca1b9cd632cb7f1fd4e497dc467d0eb3e59b7cba0c4524eL298-R360) [[2]](diffhunk://#diff-77b0bf28a052b0878ca1b9cd632cb7f1fd4e497dc467d0eb3e59b7cba0c4524eR370)

**Versioning**

* Bumped the version number from `0.1.0` to `0.1.1` in all relevant files to reflect these feature additions. [[1]](diffhunk://#diff-5352ee4067f17e7948e1425843f0a454e045bc8edf338f0bcf75c6804ddabd9aL15-R15) [[2]](diffhunk://#diff-037fda53525563fb89230704794a06db1150204ca28ce80697a637121c3ed3f9L4-R4) [[3]](diffhunk://#diff-e120a62e2e20403a2eaaab85d7ce62dc210fb4789776690058b959fc7a09fecbL19-R19)