### PR TITLE
version updated to 0.2.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "rune",
       "description": "FHE-encrypted organizational memory for teams. Capture and retrieve institutional knowledge with zero-knowledge privacy.",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "source": "./",
       "author": {
         "name": "Sunchul Jung",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rune",
   "description": "FHE-encrypted organizational memory for teams. Capture and retrieve institutional knowledge with zero-knowledge privacy.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "Sunchul Jung",
     "email": "zotanika@cryptolab.co.kr"

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -16,4 +16,4 @@ Usage:
     from agents.retriever import Searcher, Synthesizer
 """
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "rune",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "FHE-encrypted organizational memory for teams. Capture and retrieve institutional knowledge with zero-knowledge privacy.",
   "contextFileName": "GEMINI.md",
   "mcpServers": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cryptolab/rune",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "FHE-encrypted organizational memory for teams",
   "private": true,
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- What changed: revised to version 0.2.2
- Why: to differenciate new TLS feature
- Scope: N/A

## Validation

- [x] Tests run (or explain why not):
- [x] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [x] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [x] No agent-specific script duplicates bootstrap/setup logic
- [x] Agent-specific scripts remain thin adapters (registration/wiring only)
- [x] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [x] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [x] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
