### PR TITLE
fix: remove credential env overrides

### DIFF
--- a/agents/common/config.py
+++ b/agents/common/config.py
@@ -218,19 +218,6 @@ def load_config() -> RuneConfig:
             print(f"[Config] Warning: Failed to load config file: {e}")
 
     # Environment variable overrides
-    if os.getenv("RUNEVAULT_ENDPOINT"):
-        config.vault.endpoint = os.getenv("RUNEVAULT_ENDPOINT")
-    if os.getenv("RUNEVAULT_TOKEN"):
-        config.vault.token = os.getenv("RUNEVAULT_TOKEN")
-    if os.getenv("VAULT_CA_CERT"):
-        config.vault.ca_cert = os.getenv("VAULT_CA_CERT")
-    if os.getenv("VAULT_TLS_DISABLE", "").lower() == "true":
-        config.vault.tls_disable = True
-
-    if os.getenv("ENVECTOR_ENDPOINT"):
-        config.envector.endpoint = os.getenv("ENVECTOR_ENDPOINT")
-    if os.getenv("ENVECTOR_API_KEY"):
-        config.envector.api_key = os.getenv("ENVECTOR_API_KEY")
     if os.getenv("EMBEDDING_MODE"):
         config.embedding.mode = os.getenv("EMBEDDING_MODE")
     if os.getenv("EMBEDDING_MODEL"):

--- a/agents/common/config.py
+++ b/agents/common/config.py
@@ -194,6 +194,10 @@ def load_config() -> RuneConfig:
     """
     Load configuration from file and environment variables.
 
+    Credentials managed by /rune:configure (vault, envector) are loaded
+    exclusively from ~/.rune/config.json. Other settings (embedding, scribe,
+    LLM keys) can be overridden via environment variables.
+
     Priority (highest to lowest):
     1. Environment variables
     2. Config file (~/.rune/config.json)

--- a/agents/tests/test_config.py
+++ b/agents/tests/test_config.py
@@ -6,7 +6,7 @@ import pytest
 from unittest.mock import patch
 
 
-class TestCredentialEnvVarOverrideRemoved:
+class TestCredentialOverrideConfig:
     """Regression tests for the reconfigure-then-reload_pipelines bug.
 
     Previously, env vars (RUNEVAULT_TOKEN, ENVECTOR_API_KEY, etc.) silently

--- a/agents/tests/test_config.py
+++ b/agents/tests/test_config.py
@@ -6,6 +6,66 @@ import pytest
 from unittest.mock import patch
 
 
+class TestCredentialEnvVarOverrideRemoved:
+    """Regression tests for the reconfigure-then-reload_pipelines bug.
+
+    Previously, env vars (RUNEVAULT_TOKEN, ENVECTOR_API_KEY, etc.) silently
+    overrode config.json values on every load_config() call. This meant that
+    after /rune:configure wrote a new token to disk, reload_pipelines still
+    used the old token from the process environment — producing a misleading
+    "Vault key fetch failed" error instead of picking up the new credential.
+    """
+
+    @pytest.mark.parametrize("env_var,field_path,env_val,config_val", [
+        ("RUNEVAULT_TOKEN",   ("vault", "token"),             "old-token",    "new-token"),
+        ("RUNEVAULT_ENDPOINT",("vault", "endpoint"),          "tcp://old:50051", "tcp://new:50051"),
+        ("VAULT_CA_CERT",     ("vault", "ca_cert"),           "/old/ca.pem",  "/new/ca.pem"),
+        ("VAULT_TLS_DISABLE", ("vault", "tls_disable"),       "true",         False),
+        ("ENVECTOR_API_KEY",  ("envector", "api_key"),        "old-key",      "new-key"),
+        ("ENVECTOR_ENDPOINT", ("envector", "endpoint"),       "old.envector.io", "new.envector.io"),
+    ])
+    def test_credential_not_overridden_by_env(self, tmp_path, env_var, field_path, env_val, config_val):
+        """configure-managed credentials must come from config.json, not env vars."""
+        from agents.common.config import load_config
+
+        section, field = field_path
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({section: {field: config_val}}))
+
+        with patch("agents.common.config.CONFIG_PATH", config_file), \
+             patch.dict(os.environ, {env_var: env_val}, clear=False):
+            cfg = load_config()
+
+        actual = getattr(getattr(cfg, section), field)
+        assert actual == config_val
+
+    @pytest.mark.parametrize("section,field,old_val,new_val", [
+        ("vault",    "token",    "old-token",       "new-token"),
+        ("vault",    "endpoint", "tcp://old:50051", "tcp://new:50051"),
+        ("vault",    "ca_cert",  "/old/ca.pem",     "/new/ca.pem"),
+        ("vault",    "tls_disable", False,           True),
+        ("envector", "api_key",  "old-key",         "new-key"),
+        ("envector", "endpoint", "old.envector.io", "new.envector.io"),
+    ])
+    def test_reload_picks_up_reconfigured_credential(self, tmp_path, section, field, old_val, new_val):
+        """Simulates reload_pipelines after reconfigure: second load_config() must reflect updated credential."""
+        from agents.common.config import load_config
+
+        config_file = tmp_path / "config.json"
+
+        config_file.write_text(json.dumps({section: {field: old_val}, "state": "active"}))
+        with patch("agents.common.config.CONFIG_PATH", config_file):
+            cfg1 = load_config()
+            assert getattr(getattr(cfg1, section), field) == old_val
+
+            # Simulate /rune:configure writing new credential
+            config_file.write_text(json.dumps({section: {field: new_val}, "state": "active"}))
+
+            # reload_pipelines calls load_config() again
+            cfg2 = load_config()
+            assert getattr(getattr(cfg2, section), field) == new_val
+
+
 class TestLLMConfig:
     def test_llm_config_defaults(self):
         from agents.common.config import LLMConfig


### PR DESCRIPTION
## Summary

- What changed:
  - Removed the six env var overrides that correspond to credentials managed by `/rune:configure`. `reload_pipelines` now correctly picks up updated credentials from `config.json` without requiring a session restart.                                                                  
  - Updated `load_config()` docstring to reflect that vault/envector credentials are loaded exclusively from `config.json`.
- Why:
  - Context
    - `/rune:configure` collects Vault and enVector credentials and writes them to                                
  `~/.rune/config.json`.
     - The MCP server exposes a `reload_pipelines` tool that re-reads `config.json` at runtime, allowing credential updates to take effect without restarting the session.                                                                             
                                                                                                              
  - Problem
    - `load_config()` applied environment variable overrides for `RUNEVAULT_ENDPOINT`,                            
  `RUNEVAULT_TOKEN`, `VAULT_CA_CERT`, `VAULT_TLS_DISABLE`, `ENVECTOR_ENDPOINT`, and `ENVECTOR_API_KEY` after reading the config file.
    - they would override the newly written config values on every `reload_pipelines` call, causing reconfiguration to have no effect and producing a misleading "Vault key fetch failed" error that suggested a permissions problem.
- Scope:
  - `agents/common/config.py`
  - `agents/tests/test_config.py`

## Validation

- [x] Tests run (or explain why not):
  - agents/tests/test_config.py — Added `TestCredentialOverrideConfig` class
    Added 12 parametrized test cases covering all 6 removed env vars
    - `test_credential_not_overridden_by_env` — env var present but config.json value wins
    - `test_reload_picks_up_reconfigured_credential` — second `load_config()` call (simulating                  
  `reload_pipelines`) reflects updated file value
<img width="1807" height="486" alt="image" src="https://github.com/user-attachments/assets/10f053c9-27c2-49a6-b278-ed2b096fa144" />


## Cross-Agent Invariants

- [x] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [x] No agent-specific script duplicates bootstrap/setup logic
- [x] Agent-specific scripts remain thin adapters (registration/wiring only)
- [x] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [x] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [x] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):