### PR TITLE
fix(mcp): wrap raw JSON errors

### DIFF
--- a/mcp/adapter/vault_client.py
+++ b/mcp/adapter/vault_client.py
@@ -207,7 +207,10 @@ class VaultClient:
             )
             if response.error:
                 raise VaultError(f"GetPublicKey failed: {response.error}")
-            return json.loads(response.key_bundle_json)
+            try:
+                return json.loads(response.key_bundle_json)
+            except (json.JSONDecodeError, ValueError) as e:
+                raise VaultError("GetPublicKey returned invalid JSON") from e
         except grpc.aio.AioRpcError as e:
             raise VaultError(f"gRPC GetPublicKey failed: {e.code()} {e.details()}")
 
@@ -286,7 +289,10 @@ class VaultClient:
                 raise VaultError(f"DecryptMetadata failed: {response.error}")
 
             # Parse each JSON string back to Python object
-            return [json.loads(s) for s in response.decrypted_metadata]
+            try:
+                return [json.loads(s) for s in response.decrypted_metadata]
+            except (json.JSONDecodeError, ValueError) as e:
+                raise VaultError("DecryptMetadata returned invalid JSON in metadata entry") from e
         except grpc.aio.AioRpcError as e:
             raise VaultError(
                 f"gRPC DecryptMetadata failed: {e.code()} {e.details()}"


### PR DESCRIPTION
## Summary

- What changed: Wrap missing raw JSON errors with Rune errors
- Why: Tests failed
- Scope:

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [ ] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [ ] No agent-specific script duplicates bootstrap/setup logic
- [ ] Agent-specific scripts remain thin adapters (registration/wiring only)
- [ ] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [ ] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [ ] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
