### PR TITLE
fix(skill): add missing parameters

### DIFF
--- a/commands/claude/activate.md
+++ b/commands/claude/activate.md
@@ -73,7 +73,7 @@ Validate infrastructure end-to-end and switch to active state.
          key_id='test',
          key_path='/tmp',
          eval_mode='rmp',
-         query_encryption=True,
+         query_encryption=False,
          access_token='<envector_api_key>',
          auto_key_setup=False,
      )


### PR DESCRIPTION
## Summary

- What changed: Added missing parameters `eval_mode` and `query_encryption` in the activate skill
- Why: Error occurred on `/rune:activate`
- Scope: `commands/claude/activate.md`

## Validation

- [x] Tests run (or explain why not):
- [x] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [x] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [x] No agent-specific script duplicates bootstrap/setup logic
- [x] Agent-specific scripts remain thin adapters (registration/wiring only)
- [x] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [x] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [x] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
