### PR TITLE
fix: timezone consistency, type annotations, and safe env var parsing

### DIFF
--- a/agents/common/config.py
+++ b/agents/common/config.py
@@ -232,11 +232,20 @@ def load_config() -> RuneConfig:
         config.embedding.model = os.getenv("EMBEDDING_MODEL")
 
     if os.getenv("SCRIBE_PORT"):
-        config.scribe.slack_webhook_port = int(os.getenv("SCRIBE_PORT"))
+        try:
+            config.scribe.slack_webhook_port = int(os.getenv("SCRIBE_PORT"))
+        except ValueError:
+            print(f"[Config] Warning: invalid SCRIBE_PORT value: {os.getenv('SCRIBE_PORT')}")
     if os.getenv("SCRIBE_THRESHOLD"):
-        config.scribe.similarity_threshold = float(os.getenv("SCRIBE_THRESHOLD"))
+        try:
+            config.scribe.similarity_threshold = float(os.getenv("SCRIBE_THRESHOLD"))
+        except ValueError:
+            print(f"[Config] Warning: invalid SCRIBE_THRESHOLD value: {os.getenv('SCRIBE_THRESHOLD')}")
     if os.getenv("SCRIBE_AUTO_THRESHOLD"):
-        config.scribe.auto_capture_threshold = float(os.getenv("SCRIBE_AUTO_THRESHOLD"))
+        try:
+            config.scribe.auto_capture_threshold = float(os.getenv("SCRIBE_AUTO_THRESHOLD"))
+        except ValueError:
+            print(f"[Config] Warning: invalid SCRIBE_AUTO_THRESHOLD value: {os.getenv('SCRIBE_AUTO_THRESHOLD')}")
     if os.getenv("SLACK_SIGNING_SECRET"):
         config.scribe.slack_signing_secret = os.getenv("SLACK_SIGNING_SECRET")
     if os.getenv("NOTION_SIGNING_SECRET"):

--- a/agents/scribe/record_builder.py
+++ b/agents/scribe/record_builder.py
@@ -399,7 +399,7 @@ class RecordBuilder:
         if raw_event.timestamp:
             try:
                 ts = float(raw_event.timestamp)
-                when = datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
+                when = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
             except (ValueError, TypeError):
                 when = raw_event.timestamp
 

--- a/mcp/adapter/document_preprocess.py
+++ b/mcp/adapter/document_preprocess.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from dataclasses import dataclass
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 
 from langchain_text_splitters import RecursiveCharacterTextSplitter, Language
 from pypdf import PdfReader
@@ -34,7 +34,7 @@ class DocumentPreprocessingAdapter:
     def preprocess_document_from_text(
         self,
         texts: List[str],
-    ) -> None:
+    ) -> List[Dict[str, Any]]:
         """
         Preprocess documents from the given text inputs
         """
@@ -51,8 +51,8 @@ class DocumentPreprocessingAdapter:
     def preprocess_documents_from_path(
         self,
         path: str,
-        language: str = None,
-    ) -> None:
+        language: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
         """
         Preprocess documents from the given path
         """
@@ -66,7 +66,7 @@ class DocumentPreprocessingAdapter:
         chunks = self._chunk_documents(documents, splitter)
         return chunks
 
-    def _check_language_supported(self, language: str) -> bool:
+    def _check_language_supported(self, language: Optional[str] = None) -> str:
         if language is None:
             language = "DOCUMENT"
         language = language.upper()
@@ -82,7 +82,7 @@ class DocumentPreprocessingAdapter:
         logger.info(f"{len(doc_files)} text document loaded")
         return doc_files
 
-    def _load_documents_from_path(self, path: str, language: str = None) -> List[DocumentFile]:
+    def _load_documents_from_path(self, path: str, language: Optional[str] = None) -> List[DocumentFile]:
         root = Path(path)
         doc_files: List[DocumentFile] = []
 


### PR DESCRIPTION
## Summary

  - What changed: Three minor fixes across agents and MCP adapter code:
    1. `record_builder.py`: Added `tz=timezone.utc` to
  `_extract_decision_detail` timestamp parsing to match `build_phases` and
  codebase convention
    2. `document_preprocess.py`: Corrected return type annotations (`-> None` to
   actual return types) and parameter types (`str` to `Optional[str]`)
    3. `config.py`: Wrapped `int()`/`float()` env var conversions in try/except
  to prevent server crash on malformed input
  - Why: Timezone inconsistency could shift dates by a day depending on server
  locale. Incorrect type hints mislead callers and type checkers. Uncaught
  ValueError in config loading crashes the MCP server on startup.
  - Scope: Minimal — no logic changes beyond error handling in config.py.
  Type-only changes in document_preprocess.py. Single-line fix in
  record_builder.py.

  ## Validation

  - [x] Tests run (or explain why not): 279 passed, 2 skipped. 4 pre-existing
  failures in test_retriever and test_tier2_filter (unrelated to this PR).
  - [ ] Docs updated (if behavior/setup changed): N/A — no behavior or setup
  changes.

  ## Cross-Agent Invariants

  - [x] `scripts/bootstrap-mcp.sh` remains the single source of truth for
  runtime prep (venv/deps/self-heal)
  - [x] No agent-specific script duplicates bootstrap/setup logic
  - [x] Agent-specific scripts remain thin adapters (registration/wiring only)
  - [x] Codex-only commands (`codex mcp ...`) are clearly separated from
  cross-agent/common instructions
  - [x] Claude/Gemini/OpenAI instructions do not include Codex-only commands
  - [x] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay
  consistent on boundaries

  ## Notes for Reviewers

  - Risk areas: None. All changes are additive safety improvements with no logic
   changes.
  - Backward compatibility impact: None. Type hints are not enforced at runtime.
   Config fallback preserves existing default values.
  - Follow-up work (if any):
    - `handlers/base.py:39` has the same timezone-naive `fromtimestamp` bug
    - `_get_splitter` parameter `language: str = None` could be tightened
    - 4 pre-existing test failures in test_tier2_filter and test_retriever
  should be updated