### PR TITLE
fix: add macOS BSD sed compatibility for shebang rewriting in bootstr…

### DIFF
--- a/scripts/bootstrap-mcp.sh
+++ b/scripts/bootstrap-mcp.sh
@@ -81,7 +81,14 @@ else
                        file -b --mime "$_script" 2>/dev/null | grep -q "^text/" || continue
                        _first="$(head -1 "$_script")"
                        case "$_first" in
-                           \#\!*python*) sed -i "1s|^#\!.*|#\!$_VENV_PYTHON|" "$_script" ;;
+                           \#\!*python*)
+                                if sed --version >/dev/null 2>&1; then
+                                    # GNU sed (Linux)
+                                    sed -i "1s|^#\!.*|#\!$_VENV_PYTHON|" "$_script"
+                                else
+                                    # BSD sed (macOS)
+                                    sed -i '' "1s|^#\!.*|#\!$_VENV_PYTHON|" "$_script"
+                                fi ;;
                        esac
                    done
                    echo "[rune] Shebangs fixed." >&2 ;;


### PR DESCRIPTION
## Summary

  - What changed: Split the `sed -i` call in bootstrap-mcp.sh shebang rewriting into GNU/BSD branches
  (macOS)
  - Why: BSD sed on macOS requires an empty string argument ('') after `-i`; the previous code used GNU sed syntax only, causing failures on macOS
  - Scope: Shebang rewriting block in scripts/bootstrap-mcp.sh only

## Validation

- [x] Tests run: Ran bash scripts/bootstrap-mcp.sh install-deps on macOS (BSD sed) — no sed errors, server started normally
- [ ] Docs updated: No behavior change, not needed

## Cross-Agent Invariants

- [x] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [x] No agent-specific script duplicates bootstrap/setup logic
- [x] Agent-specific scripts remain thin adapters (registration/wiring only)
- [x] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [x] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [x] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

  - Risk areas: Branch condition relies on sed --version exit code — GNU sed returns 0, BSD sed returns non-zero, which is reliable
  - Backward compatibility impact: None. The GNU sed (Linux) path is identical to the previous behavior
  - Follow-up work: None

---
## Summary (KR)

  - What changed: bootstrap-mcp.sh의 shebang rewriting에서 `sed -i` 호출을 GNU/BSD 분기로 수정
  - Why: macOS의 BSD sed는 `-i` 뒤에 빈 문자열 인자('')가 필수인데, 기존 코드가 GNU sed 문법만 사용해 macOS에서 실패했음
  - Scope: scripts/bootstrap-mcp.sh 내 shebang rewriting 블록만 변경

## Validation

- [x] Tests run (or explain why not): macOS(BSD sed) 환경에서 bash scripts/bootstrap-mcp.sh install-deps 실행, sed 에러 없이 서버 정상 기동 확인
- [ ] Docs updated (if behavior/setup changed): 동작 변경 없으므로 불필요

## Cross-Agent Invariants
- [x] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [x] No agent-specific script duplicates bootstrap/setup logic
- [x] Agent-specific scripts remain thin adapters (registration/wiring only)
- [x] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [x] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [x] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

  - Risk areas: sed 분기 조건이 sed --version 성공 여부에 의존 — GNU sed는 0을 반환하고 BSD sed는 non-zero를 반환하므로 신뢰할 수 있음
  - Backward compatibility impact: 없음. Linux(GNU sed) 경로는 기존과 동일
  - Follow-up work: 없음