### PR TITLE
fix: split PR comment posting to support fork PRs

### DIFF
--- a/.github/scripts/post_pr_comment.js
+++ b/.github/scripts/post_pr_comment.js
@@ -121,7 +121,7 @@ module.exports = async ({ github, context }) => {
   // Warn if corrected total still doesn't match summary after reconciliation
   const stillMismatched = pytestSummary && correctedTotal !== authoritativeTotal;
 
-  const runUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+  const runUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.CI_RUN_ID || process.env.GITHUB_RUN_ID}`;
 
   let tableSection = '';
   if (testResults.length > 0) {
@@ -184,7 +184,7 @@ module.exports = async ({ github, context }) => {
   const { data: comments } = await github.rest.issues.listComments({
     owner: context.repo.owner,
     repo: context.repo.repo,
-    issue_number: context.issue.number,
+    issue_number: parseInt(process.env.PR_NUMBER) || context.issue.number,
   });
 
   const existing = comments.find(c => c.body && c.body.includes(marker));
@@ -200,7 +200,7 @@ module.exports = async ({ github, context }) => {
     await github.rest.issues.createComment({
       owner: context.repo.owner,
       repo: context.repo.repo,
-      issue_number: context.issue.number,
+      issue_number: parseInt(process.env.PR_NUMBER) || context.issue.number,
       body,
     });
   }

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,41 @@
+name: Post PR Comment
+
+on:
+  workflow_run:
+    workflows: ["PR Tests"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+jobs:
+  post-comment:
+    name: Post test results comment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download test results
+        uses: actions/download-artifact@v4
+        with:
+          name: test-results
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Post PR comment
+        uses: actions/github-script@v7
+        env:
+          CI_RUN_ID: ${{ github.event.workflow_run.id }}
+        with:
+          script: |
+            const fs = require('fs');
+            const info = JSON.parse(fs.readFileSync('pr_info.json', 'utf8'));
+            process.env.EXIT_CODE = info.EXIT_CODE;
+            process.env.HAS_CHANGED = info.HAS_CHANGED;
+            process.env.TEST_IDS = info.TEST_IDS;
+            process.env.HEAD_SHA = info.HEAD_SHA;
+            process.env.PR_NUMBER = info.PR_NUMBER;
+            const fn = require('./.github/scripts/post_pr_comment.js');
+            await fn({ github, context });

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   run-tests:
@@ -62,18 +61,36 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
         continue-on-error: true
 
-      - name: Post PR comment
+      - name: Save PR info
         if: always()
-        uses: actions/github-script@v7
+        run: |
+          python3 - <<'EOF'
+          import json, os
+          info = {
+            'PR_NUMBER': os.environ['PR_NUMBER'],
+            'EXIT_CODE': os.environ['EXIT_CODE'],
+            'HAS_CHANGED': os.environ['HAS_CHANGED'],
+            'TEST_IDS': os.environ['TEST_IDS'],
+            'HEAD_SHA': os.environ['HEAD_SHA'],
+          }
+          with open('pr_info.json', 'w') as f:
+            json.dump(info, f)
+          EOF
         env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           EXIT_CODE: ${{ steps.pytest.outputs.exit_code }}
           HAS_CHANGED: ${{ steps.detect.outputs.has_changed }}
           TEST_IDS: ${{ steps.detect.outputs.test_ids }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const fn = require('./.github/scripts/post_pr_comment.js')
-            await fn({ github, context })
+          name: test-results
+          path: |
+            pytest_output.txt
+            pr_info.json
 
       - name: Fail if tests failed
         if: always() && steps.pytest.outputs.exit_code != '0'


### PR DESCRIPTION
## Summary

- What changed:
  - Split PR comment posting innto a separate `pr-comment.yml`
  - The test results and PR metadata are now saved as artifact(pr_info.json) in `pr-tests.yml`
  - and downloaded by PR comment workflow in `pr-comment.yml`
- Why: Github restricts write permissions for untrusted fork code
- Scope: CI only.

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [x] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [x] No agent-specific script duplicates bootstrap/setup logic
- [x] Agent-specific scripts remain thin adapters (registration/wiring only)
- [x] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [x] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [x] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas: If the pr-comment.yml workflow is not yet merged to main, it will not run for PRs. It must be merged to main first to take effect.
- Backward compatibility impact:
- Follow-up work (if any):
