### PR TITLE
fix(ci): use PAT for PR comment to support fork PRs

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -8,14 +8,19 @@ on:
 permissions:
   contents: read
   actions: read
-  issues: write
+  pull-requests: write
 
 jobs:
   post-comment:
-    name: Post test results comment
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout trusted default branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: false
 
       - name: Download test results
         uses: actions/download-artifact@v4
@@ -23,6 +28,17 @@ jobs:
           name: test-results
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Validate PR metadata
+        run: |
+          python3 - <<'EOF'
+          import json, re
+          with open("pr_info.json", "r", encoding="utf-8") as f:
+            info = json.load(f)
+
+          assert re.fullmatch(r"[1-9][0-9]*", str(info.get("PR_NUMBER", "")))
+          assert re.fullmatch(r"[0-9a-fA-F]{40}", str(info.get("HEAD_SHA", "")))
+          EOF
 
       - name: Post PR comment
         uses: actions/github-script@v7
@@ -33,10 +49,11 @@ jobs:
           script: |
             const fs = require('fs');
             const info = JSON.parse(fs.readFileSync('pr_info.json', 'utf8'));
-            process.env.EXIT_CODE = info.EXIT_CODE;
-            process.env.HAS_CHANGED = info.HAS_CHANGED;
-            process.env.TEST_IDS = info.TEST_IDS;
-            process.env.HEAD_SHA = info.HEAD_SHA;
-            process.env.PR_NUMBER = info.PR_NUMBER;
+            process.env.EXIT_CODE = String(info.EXIT_CODE ?? '');
+            process.env.HAS_CHANGED = String(info.HAS_CHANGED ?? 'false');
+            process.env.TEST_IDS = String(info.TEST_IDS ?? '');
+            process.env.HEAD_SHA = String(info.HEAD_SHA ?? '');
+            process.env.PR_NUMBER = String(info.PR_NUMBER ?? '');
+
             const fn = require('./.github/scripts/post_pr_comment.js');
             await fn({ github, context });

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           CI_RUN_ID: ${{ github.event.workflow_run.id }}
         with:
+          github-token: ${{ secrets.CI_BOT_TOKEN }}
           script: |
             const fs = require('fs');
             const info = JSON.parse(fs.readFileSync('pr_info.json', 'utf8'));

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
   actions: read
   pull-requests: write
+  issues: write
 
 jobs:
   post-comment:


### PR DESCRIPTION
## Summary

- What changed:
  - Replaced default `GITHUB_TOKEN` to `CI_BOT_TOKEN` within `pr-comment.yml`
  - Check out the trusted `main` branch (not the fork's HEAD) to prevent untrusted-code execution in a privileged context                                          
  - Validate `PR_NUMBER` and `HEAD_SHA` from `pr_info.json` before use (regex assertions) to guard against artifact injection                                           
  - Coerce all `process.env` assignments to `String(...)` to prevent silent `undefined` propagation
- Why: When workflow_run is triggered by a fork PR, `GITHUB_TOKEN` is permanently read-only (write access to comments is denied). A PAT bypasses this restriction
- Scope: `pr-comment.yml` only.

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [x] `scripts/bootstrap-mcp.sh` remains the single source of truth영 for runtime prep (venv/deps/self-heal)
- [x] No agent-specific script duplicates bootstrap/setup logic
- [x] Agent-specific scripts remain thin adapters (registration/wiring only)
- [x] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [x] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [x] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
