### PR TITLE
docs: update README positioning and team setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rune
-**Your agent already knows what your team knows.**
+**Encrypted shared memory for AI agents.**
 
 Rune gives every AI agent on your team the **collective experience** of the entire organization — automatically, privately, and without anyone searching for it.
 
@@ -22,76 +22,60 @@ Works with **Claude Code, Codex CLI, Gemini CLI**, and any MCP-compatible agent.
 
 ---
 
-## How Rune Changes Agent Behavior
+## Quick Start
 
-### Without Rune: Isolated Agents
+### Install
 
-Every agent on your team starts from zero. They give generic advice. They can't know that another team member spent four hours debugging a connection pool issue last week, or that the architecture review in January already ruled out a microservices migration.
+**Claude Code:**
+```bash
+# From terminal (local clone)
+$ claude plugin marketplace add ./
+$ claude plugin install rune
 
-```
-  Alice's Agent          Bob's Agent           Carol's Agent
-  ┌───────────┐         ┌───────────┐         ┌───────────┐
-  │           │         │           │         │           │
-  │  No team  │         │  No team  │         │  No team  │
-  │  context  │         │  context  │         │  context  │
-  │           │         │           │         │           │
-  └───────────┘         └───────────┘         └───────────┘
-       ↕                     ↕                     ↕
-     Alice                  Bob                  Carol
-
-  Each agent is an amnesiac. Every conversation starts fresh.
-  Knowledge dies when the session ends.
+# From inside a Claude Code session (remote)
+> /plugin marketplace add https://github.com/CryptoLabInc/rune
+> /plugin install rune
 ```
 
-### With Rune: Shared Memory Across the Swarm
-
-Every agent draws from the same pool of team experience. When Alice's agent captures a decision, Bob's agent can recall it tomorrow — without Bob ever knowing it existed.
-
-```
-  Alice's Agent          Bob's Agent           Carol's Agent
-  ┌───────────┐         ┌───────────┐         ┌───────────┐
-  │           │         │           │         │           │
-  │  Team     │         │  Team     │         │  Team     │
-  │  memory   │         │  memory   │         │  memory   │
-  │  built in │         │  built in │         │  built in │
-  │           │         │           │         │           │
-  └─────┬─────┘         └─────┬─────┘         └─────┬─────┘
-        │                     │                     │
-        └──────────┬──────────┘──────────┬──────────┘
-                   │                     │
-            ┌──────┴──────────────┴──────────┐
-            │                                │
-            │    Shared Encrypted Memory     │
-            │    (enVector Cloud + Vault)     │
-            │                                │
-            │  Every decision, every lesson, │
-            │  every debugging breakthrough  │
-            │  — encrypted, searchable,      │
-            │  automatically surfaced.       │
-            │                                │
-            └────────────────────────────────┘
-
-  The new hire's agent has the intuition of a veteran.
-  Because it has the team's experience built in.
+**Gemini CLI:**
+```bash
+# From terminal
+$ gemini extensions install https://github.com/CryptoLabInc/rune.git
 ```
 
-### What This Looks Like In Practice
-
-**Architecture review that starts 30 minutes ahead:**
-```
-Lead: "Let's discuss the auth middleware rewrite"
-
-Agent: "Before we start — your team has prior context:
-       - Legal flagged the current middleware for session
-         token storage (compliance issue)
-       - JWT with 24h rotation was chosen over session-based
-         auth in January's security review
-       - Security team requires rotation under 24 hours"
-
-Nobody asked. The context just appeared.
+**Codex CLI:**
+```bash
+# From inside a Codex session
+> $skill-installer install https://github.com/CryptoLabInc/rune.git
 ```
 
-**Debugging session that saves 4 hours:**
+### Configure
+
+```
+> /rune:configure        # Claude Code, Gemini CLI
+> $rune configure        # Codex CLI
+```
+
+You'll need from your team admin:
+- **Vault endpoint** + **token**
+
+That's all. enVector Cloud credentials are delivered automatically via the Vault bundle.
+
+Don't have these? See [rune-admin](https://github.com/CryptoLabInc/rune-admin) for deployment, or [examples/team-setup-example.md](examples/team-setup-example.md) for a walkthrough.
+
+### That's It
+
+Once configured, Rune works automatically. No commands to memorize. No queries to write. Just work with your agent as usual.
+
+Your agent will:
+- **Capture** significant decisions, trade-offs, and lessons during your work
+- **Recall** relevant team knowledge when it matters — without being asked
+
+---
+
+## What This Looks Like
+
+**Debugging that saves 4 hours:**
 ```
 Dev: "The payment service is timing out"
 
@@ -109,35 +93,74 @@ New hire: "I'm thinking of using Redis for the job queue"
 
 Agent: "Your team evaluated Redis vs SQS for the job queue
        in February. SQS was chosen because Redis required
-       dedicated ops capacity the team doesn't have.
-       Trade-off: higher per-message cost, but zero
-       operational burden."
+       dedicated ops capacity the team doesn't have."
 
 The new hire's agent already has institutional knowledge
 they haven't been taught yet.
 ```
 
+You don't "query" Rune. Your agent draws from it the way an experienced engineer draws from years of past projects — the relevant context just surfaces.
+
 ---
 
-## This Is Not A Search Tool
+## How Rune Is Different
 
-Rune is **memory**, not a database.
+| Approach | Limitation | Rune |
+|----------|-----------|------|
+| **Built-in memory** (Claude, ChatGPT, Copilot) | Siloed per vendor. Your team's Claude memory and Codex memory never connect. | One shared memory across all agents. Vendor-independent. |
+| **RAG pipelines** | Chunks documents into fragments. Destroys reasoning structure. Requires ongoing pipeline maintenance. | Agent judges significance and stores *decisions*, not document chunks. No pipeline to maintain. |
+| **Wikis & docs** | Manual. Nobody updates the wiki after the meeting. | Captures automatically during work, not after. |
+| **Plaintext vector DBs** | Your organizational knowledge is readable by the cloud provider. | FHE encryption — the cloud stores and searches *only ciphertext*. Mathematically guaranteed. |
+
+---
+
+## Architecture
 
 ```
-  Database                            Memory
-  ━━━━━━━━                           ━━━━━━
+  Agent Swarm (your team)              Cloud Infrastructure
+  ━━━━━━━━━━━━━━━━━━━━━━              ━━━━━━━━━━━━━━━━━━━━
 
-  You open a drawer.                  You're in a conversation.
-  You pull out a document.            A relevant experience surfaces.
-  Exact match.                        You didn't ask for it.
-
-  "I know I don't know.               "I didn't know I knew.
-   Let me search."                     It just came back to me."
+  Alice's Agent ─┐
+  Bob's Agent ───┤── MCP ──► enVector Cloud (encrypted vectors)
+  Carol's Agent ─┘               │
+                            Rune-Vault (secret key holder)
+                            decrypts similarity scores only
 ```
 
-You don't "query" Rune. Your agent draws from it unconsciously — the way an experienced engineer draws from years of past projects without thinking about it. The best sign Rune is working is when your agent gives you context you didn't ask for, and it's useful.
+**Capture:** Agent judges significance → generates reusable insight → novelty check against existing memory → FHE encrypt → store
 
-### How The Capture Pipeline Works (Brain Analogy)
+**Recall:** Semantic query → encrypted similarity scoring → Vault decrypts scores only → metadata retrieved and decrypted locally
+
+### Privacy: Zero-Knowledge Encryption
+
+Every memory is encrypted **before leaving your machine** using Fully Homomorphic Encryption (FHE).
+
+- **enVector Cloud** stores and searches **only encrypted vectors** — it cannot read your data
+- **Rune-Vault** holds the secret key and decrypts **only similarity scores** — it never sees the content
+- **Plaintext never leaves your machine**
+
+Even if the cloud is compromised, your organizational knowledge remains mathematically protected.
+
+---
+
+## MCP Tools
+
+| Tool | What It Does |
+|------|-------------|
+| `capture` | Store a decision in encrypted team memory |
+| `recall` | Search team memory semantically |
+| `batch_capture` | Bulk-capture multiple decisions (session-end sweep) |
+| `vault_status` | Check Vault connection and security mode |
+| `diagnostics` | System health check |
+| `reload_pipelines` | Re-read config and reinitialize |
+| `capture_history` | View recent captures |
+| `delete_capture` | Soft-delete a record |
+
+See [SKILL.md](SKILL.md) for the full reference and agent integration protocol.
+
+---
+
+## How The Capture Pipeline Works
 
 Rune's capture system is modeled on how the brain forms long-term memories:
 
@@ -159,165 +182,12 @@ Rune's capture system is modeled on how the brain forms long-term memories:
 | Brain | Rune |
 |-------|------|
 | Prefrontal cortex judges significance | Agent evaluates decisions using full context |
-| Hippocampus detects novelty | enVector recall checks against existing memories |
-| Gist extraction (verbatim fades, meaning persists) | Agent writes a `reusable_insight` — a dense natural-language paragraph |
+| Hippocampus detects novelty | Embedding similarity check against existing memories |
+| Gist extraction (verbatim fades, meaning persists) | Agent writes a `reusable_insight` — a dense NL paragraph |
 | Consolidation (sleep filters and stores) | Capture pipeline encrypts and stores only novel insights |
 | Associative recall (cue → memory surfaces) | Semantic search on encrypted vectors |
 
-The memory itself acts as the filter. An empty memory captures aggressively (everything is novel). A rich memory becomes selective (most things are already known). **The filter improves as the memory grows** — no patterns to maintain, no rules to update.
-
----
-
-## Privacy: Zero-Knowledge Encryption
-
-Every memory is encrypted **before leaving your machine** using Fully Homomorphic Encryption (FHE).
-
-```
-  Your Machine                           Cloud
-  ━━━━━━━━━━━━                          ━━━━━
-
-  "We chose PostgreSQL     FHE encrypt
-   for ACID compliance"   ──────────►   [encrypted vector]
-                                         │
-  Agent asks:                            │ similarity scoring
-  "database strategy?"    ──────────►   [encrypted query]
-                                         │
-                                         ▼
-                          Vault decrypts scores only
-                          (never sees the content)
-                                         │
-  Results returned        ◄──────────    │
-  (decrypted locally)
-```
-
-- **enVector Cloud** stores and searches **only encrypted vectors** — it cannot read your data
-- **Rune-Vault** holds the team's secret key and decrypts **only similarity scores** — it never sees the actual content
-- **Plaintext never leaves your machine**
-
-Even if the cloud is compromised, your organizational knowledge remains mathematically protected.
-
----
-
-## Quick Start
-
-### Install
-
-In a terminal:
-```bash
-# For Claude Code
-$ claude plugin marketplace add https://github.com/CryptoLabInc/rune.git
-$ claude plugin install rune
-
-# For Gemini CLI
-$ gemini extensions install https://github.com/CryptoLabInc/rune.git
-```
-
-In a Claude Code session:
-```
-> /plugin marketplace add https://github.com/CryptoLabInc/rune.git
-> /plugin install rune
-```
-
-In a Codex CLI session:
-```
-> $skill-installer install https://github.com/CryptoLabInc/rune.git
-```
-
-### Configure
-
-In slash-command agents:
-```
-> /rune:configure
-```
-In Codex CLI:
-```
-> $rune configure
-```
-
-You'll need credentials from your team admin:
-- **Vault endpoint** + token (for decryption and encrypted storage)
-
-enVector Cloud credentials are delivered automatically via the Vault bundle at session start — you don't need to configure them separately.
-
-Don't have these? See [rune-admin](https://github.com/CryptoLabInc/rune-admin) for deployment instructions, or [examples/team-setup-example.md](examples/team-setup-example.md) for a team onboarding walkthrough.
-
-### That's It
-
-Once configured, Rune works automatically. Your agent will:
-- **Capture** significant decisions, trade-offs, and lessons learned during your work
-- **Recall** relevant team knowledge when it matters — without being asked
-
-No commands to memorize. No queries to write. Just work with your agent as usual.
-
----
-
-## MCP Tools
-
-For agents that want explicit control, Rune exposes these tools via MCP:
-
-| Tool | What It Does |
-|------|-------------|
-| `capture` | Store a decision in encrypted team memory. Pass `extracted` JSON with the agent's evaluation and a `reusable_insight` paragraph. |
-| `recall` | Search team memory semantically. Returns relevant decisions with context. |
-| `vault_status` | Check Vault connection and security mode |
-| `reload_pipelines` | Re-read config and reinitialize pipelines |
-| `capture_history` | View recent captures from the local log |
-| `delete_capture` | Soft-delete a captured record |
-
-See [SKILL.md](SKILL.md) for the full tool reference and agent integration protocol.
-
----
-
-## Architecture
-
-```
-  Agent Swarm (your team)              Cloud Infrastructure
-  ━━━━━━━━━━━━━━━━━━━━━━              ━━━━━━━━━━━━━━━━━━━━
-
-  Alice's Agent ─┐
-  Bob's Agent ───┤── MCP ──► enVector Cloud (encrypted vectors)
-  Carol's Agent ─┘               │
-                            Rune-Vault (secret key holder)
-                            decrypts similarity scores only
-```
-
-```mermaid
-flowchart TD
-    Cloud[("enVector Cloud<br>(Encrypted Storage)")]
-
-    subgraph MCP [Rune MCP Server]
-        Capture["capture<br>(agent-delegated)"]
-        Recall["recall<br>(Vault-secured)"]
-    end
-
-    subgraph Vault [Rune-Vault]
-        Decrypt["decrypt scores<br>(secret key never leaves)"]
-    end
-
-    subgraph Agents [Agent Swarm]
-        A1["Alice's Agent"]
-        A2["Bob's Agent"]
-        A3["Carol's Agent"]
-    end
-
-    A1 & A2 & A3 -- "capture / recall" --> MCP
-    Capture -- "encrypted vectors" --> Cloud
-    Recall -- "encrypted similarity" --> Cloud
-    Recall -- "decrypt scores" --> Decrypt
-    Decrypt -- "indices + scores" --> Recall
-
-    style Cloud fill:#eff,stroke:#333
-    style Capture fill:#eef,stroke:#333
-    style Recall fill:#eef,stroke:#333
-    style Decrypt fill:#fee,stroke:#333
-    style A1 fill:#efe,stroke:#333
-    style A2 fill:#efe,stroke:#333
-    style A3 fill:#efe,stroke:#333
-```
-
-**Capture flow:** Agent judges significance → generates reusable insight → novelty check against existing memory → FHE encrypt → store in enVector Cloud
-
-**Recall flow:** Semantic query → encrypted similarity scoring → Vault decrypts scores only → retrieve and decrypt metadata locally → agent weaves context into response
+The memory itself acts as the filter. An empty memory captures aggressively (everything is novel). A rich memory becomes selective (most things are already known). **The filter improves as the memory grows.**
 
 ---
 
@@ -330,21 +200,18 @@ Rune requires two infrastructure components:
 
 ### Deploying
 
-See the [Rune-Admin Repository](https://github.com/CryptoLabInc/rune-admin):
-1. Deploy Rune-Vault (OCI/AWS via Terraform)
+See [rune-admin](https://github.com/CryptoLabInc/rune-admin):
+1. Deploy Rune-Vault (OCI/AWS/GCP via Terraform)
 2. Create enVector Cloud account and cluster
 3. Provision team index on Vault
 
 ### Onboarding Members
 
-Give each member:
-- Vault gRPC endpoint + authentication token
+Give each member their **Vault endpoint + token**. enVector credentials are bundled automatically.
 
-enVector Cloud credentials are included in the Vault bundle and delivered automatically at session start.
+They install the plugin, run `/rune:configure` (or `$rune configure` in Codex), and they're connected.
 
-They install the plugin, run the Rune configure command (`/rune:configure` in slash-command clients, `$rune configure` in Codex CLI), and they're connected to the team memory.
-
-### Security Management
+### Security
 
 - **Token rotation**: New token → distribute → revoke old. Departed members lose access immediately.
 - **Project isolation**: Separate Vault instances per project for isolated memory spaces.
@@ -358,8 +225,10 @@ They install the plugin, run the Rune configure command (`/rune:configure` in sl
 ```json
 {
   "vault": {
-    "endpoint": "your-vault-host:50051",
-    "token": "your-vault-token"
+    "endpoint": "tcp://vault-myteam.oci.envector.io:50051",
+    "token": "your-vault-token",
+    "ca_cert": "",
+    "tls_disable": false
   },
   "state": "active"
 }
@@ -372,17 +241,52 @@ They install the plugin, run the Rune configure command (`/rune:configure` in sl
 
 ---
 
+## Upgrading & Uninstalling
+
+Agent CLIs do not yet support in-place plugin upgrades. To upgrade, uninstall first and reinstall.
+
+### Uninstall
+
+**Claude Code:**
+```bash
+$ claude plugin remove --scope user rune
+$ claude plugin marketplace remove cryptolab
+$ rm -rf ~/.claude/plugins/cache/cryptolab   # remove plugin cache
+```
+
+**Codex CLI:**
+```bash
+$ codex mcp remove rune                      # deregister MCP server
+
+```
+
+**Gemini CLI:**
+```bash
+$ gemini extensions uninstall rune           # remove extension
+```
+
+To also remove local configuration and keys:
+```bash
+$ rm -rf ~/.rune
+```
+
+Then reinstall from the [Install](#install) section above.
+
+---
+
 ## Troubleshooting
 
+```
+/rune:status              # or: $rune status
+```
+
 ```bash
-# Check infrastructure health
+# Check infrastructure
 cd rune && ./scripts/check-infrastructure.sh
 
-# Reset configuration
-rm ~/.rune/config.json
-
-# Reinstall
-claude plugin install rune
+# Reset and reconfigure
+/rune:reset               # or: $rune reset
+/rune:configure           # or: $rune configure
 ```
 
 ## Related Projects
@@ -394,7 +298,7 @@ claude plugin install rune
 ## Support
 
 - **Issues**: [GitHub Issues](https://github.com/CryptoLabInc/rune/issues)
-- **Docs**: [Full Rune Documentation](https://github.com/CryptoLabInc/rune-admin/tree/main/docs)
+- **Docs**: [Full Documentation](https://github.com/CryptoLabInc/rune-admin/tree/main/docs)
 - **Email**: zotanika@cryptolab.co.kr
 
 ## License

--- a/examples/team-setup-example.md
+++ b/examples/team-setup-example.md
@@ -15,57 +15,55 @@ This guide shows how a team administrator sets up Rune infrastructure and onboar
 
 ---
 
-## Step 1: Alice Deploys Rune Infrastructure
+## Step 1: Alice Deploys Rune-Vault
 
-Alice is the team administrator and needs to deploy Rune-Vault (team-shared key management + enVector Cloud bundled configuration).
-
-### 1.1 Deploy Rune-Vault
+Alice runs the interactive installer, which handles cloud provisioning, TLS setup, and enVector Cloud configuration:
 
 ```bash
-# Alice clones the admin repository
-git clone https://github.com/CryptoLabInc/rune-admin.git
-cd rune-admin
-
-# Deploy to Oracle Cloud Infrastructure
-cd deployment/oci
-
-# Edit terraform.tfvars
-cat > terraform.tfvars << EOF
-team_name = "acme"
-region = "us-ashburn-1"
-vault_instance_shape = "VM.Standard.E4.Flex"
-EOF
-
-# Deploy
-terraform init
-terraform apply
-
-# Note the outputs:
-# vault_endpoint = "vault-acme.oci.envector.io:50051"
-# vault_token = "evt_acme_abc123def456"
+curl -fsSL https://raw.githubusercontent.com/CryptoLabInc/rune-admin/main/install.sh \
+  -o install.sh && sudo bash install.sh
 ```
 
-> **Note**: enVector Cloud credentials are configured as part of the Vault deployment and delivered to clients automatically via the Vault bundle at startup. No separate enVector signup is needed by team members.
+The installer guides her through:
+- **Cloud provider** selection (OCI / AWS / GCP)
+- **enVector Cloud** credentials (endpoint + API key)
+- **TLS certificate** generation
+- **Terraform-based** VM provisioning
+
+Output:
+```
+vault_endpoint = "vault-acme.oci.envector.io:50051"
+ca.pem downloaded for TLS verification
+```
+
+### Verify Deployment
+
+```bash
+# gRPC health check (requires grpcurl: brew install grpcurl)
+grpcurl -cacert ca.pem vault-acme.oci.envector.io:50051 grpc.health.v1.Health/Check
+
+# Expected: { "status": "SERVING" }
+```
 
 ---
 
-## Step 2: Alice Configures Her Own Plugin
+## Step 2: Alice Issues Per-User Tokens
+
+Alice creates individual tokens for each team member using the Vault admin CLI:
 
 ```bash
-# Alice installs the lightweight plugin
-cd ~/workspace
-/plugin install github.com/CryptoLabInc/rune
-
-# Configure with her credentials
-/rune:configure
-
-# Enter:
-# Vault Endpoint: vault-acme.oci.envector.io:50051
-# Vault Token: evt_acme_abc123def456
-# (enVector credentials are delivered automatically via Vault bundle)
-
-# Plugin is now active ✅
+# Issue tokens per user
+runevault token issue --user alice --role admin
+runevault token issue --user bob   --role member
+runevault token issue --user carol --role member
 ```
+
+Roles control access scope and rate limits:
+
+| Role | Scope | Rate Limit |
+|------|-------|------------|
+| `admin` | Full access + token management | 150 req/60s |
+| `member` | Capture + recall only | 30 req/60s |
 
 ---
 
@@ -73,43 +71,56 @@ cd ~/workspace
 
 ### 3.1 Share Credentials
 
-Alice sends Bob an email:
+Alice sends Bob his credentials via a secure channel (1Password, Signal, etc.):
 
 ```
-Subject: Rune Plugin Setup - Acme Team
-
 Hi Bob,
 
 I've set up our team's organizational memory system. Here are your credentials:
 
-**Rune-Vault**:
-- Endpoint: vault-acme.oci.envector.io:50051
-- Token: evt_acme_abc123def456
+  Vault Endpoint: vault-acme.oci.envector.io:50051
+  Vault Token: evt_acme_bob_xyz789
 
-(enVector Cloud credentials are delivered automatically — no action needed on your end.)
+enVector Cloud credentials are delivered automatically via the Vault
+bundle — no action needed on your end.
 
-**Setup Instructions**:
-1. Run: /plugin install github.com/CryptoLabInc/rune
-2. Run: /rune:configure
-3. Enter the Vault endpoint and token above
-
-Let me know if you have any issues!
+Setup:
+  1. Install: /plugin marketplace add https://github.com/CryptoLabInc/rune
+  2. Configure: /rune:configure
+  3. Enter the Vault endpoint and token above
 
 Alice
 ```
 
 ### 3.2 Bob Installs and Configures
 
+**Claude Code:**
 ```bash
-# Bob receives email and installs
-/plugin install github.com/CryptoLabInc/rune
-
-# Configure
-/rune:configure
-# Enters credentials from Alice's email
-
-# Plugin is now active ✅
+# Inside a Claude Code session
+> /plugin marketplace add https://github.com/CryptoLabInc/rune
+> /plugin install rune
+> /rune:configure
+# Enters Vault endpoint and token from Alice
 ```
+
+**Codex CLI:**
+```bash
+# Inside a Codex session
+> $skill-installer install https://github.com/CryptoLabInc/rune.git
+> $rune configure
+# Enters Vault endpoint and token
+```
+
+**Gemini CLI:**
+```bash
+# From terminal
+$ gemini extensions install https://github.com/CryptoLabInc/rune.git
+# Inside a Gemini session
+> /rune:configure
+# Enters Vault endpoint and token
+```
+
+Bob is now connected to the team memory.
 
 ---
 
@@ -118,19 +129,19 @@ Alice
 ### Alice captures a decision
 
 ```
-Alice to Claude: "We decided to use PostgreSQL for this project because
+Alice to her agent: "We decided to use PostgreSQL for this project because
 it has better JSON support than MySQL, and our data model is heavily
 document-oriented."
 
-Claude: [Automatically captures to organizational memory]
+Agent: [Automatically captures to organizational memory]
 ```
 
 ### Bob retrieves the context (later that day)
 
 ```
-Bob to Claude: "What database are we using for this project and why?"
+Bob to his agent: "What database are we using for this project and why?"
 
-Claude: "According to organizational memory from earlier today:
+Agent: "According to organizational memory from earlier today:
 The team decided to use PostgreSQL because it has better JSON support
 than MySQL, and the data model is heavily document-oriented.
 
@@ -139,52 +150,46 @@ Source: Captured from Alice's session at 10:23 AM"
 
 ### Carol joins the team (next week)
 
-Alice sends Carol the same credentials email. Carol installs and configures:
-
-```bash
-/plugin install github.com/CryptoLabInc/rune
-/rune:configure
-# Enters same credentials
-```
-
-Now Carol has access to all historical context from Alice and Bob.
+Alice issues Carol's token and sends credentials. Carol installs and configures — and immediately has access to all historical context from Alice and Bob.
 
 ---
 
 ## Step 5: Security Management
 
-### 5.1 Token Rotation (Monthly)
+### Token Rotation
 
-Alice rotates the Vault token:
-
-```bash
-# Alice generates new token in Vault admin panel
-# New token: evt_acme_xyz789new
-
-# Alice emails team:
-"Team, please update your Vault token to: evt_acme_xyz789new
-Run: /rune:configure (just update the token field)"
-
-# Team members update:
-/rune:configure
-# Only need to update vault token, other fields unchanged
-
-# Alice revokes old token in Vault admin panel
-```
-
-### 5.2 Remove Team Member
-
-If someone leaves the team:
+Alice rotates tokens periodically using the Vault admin CLI:
 
 ```bash
-# Alice rotates Vault token
-# Sends new token only to current team members
-# Old token is revoked -> departed member loses access
+# Rotate a single user's token
+runevault token rotate --user bob
+
+# Rotate all tokens at once
+runevault token rotate --all
+
+# Distribute new tokens to team members via secure channel
 ```
+
+Team members update their token:
+```
+> /rune:configure
+# Update only the Vault token — other fields unchanged
+```
+
+### Remove a Team Member
+
+```bash
+# Revoke the departing member's token
+runevault token revoke --user bob
+
+# No token rotation needed — other members' tokens remain valid
+```
+
+Bob's token is immediately invalidated. Alice and Carol continue uninterrupted.
 
 ---
 
-## Benefits Realized
+## Benefits
 
 ### Context Continuity
 - Bob doesn't need to ask Alice "Why PostgreSQL?"
@@ -193,13 +198,14 @@ If someone leaves the team:
 
 ### Zero-Knowledge Privacy
 - enVector Cloud sees only encrypted vectors
-- Only team members with Vault access can decrypt
-- Cloud provider cannot read any conversations
+- Only team members with valid Vault tokens can decrypt
+- Cloud provider cannot read any content
 
-### Team Collaboration
-- All 3 developers share the same organizational memory
-- Decisions captured once, available to everyone
-- Consistent knowledge across the team
+### Per-User Security
+- Individual tokens — revoke one without disrupting others
+- Role-based access control (admin vs. member)
+- Rate limiting prevents abuse
+- Audit logging tracks all operations
 
 ---
 
@@ -209,59 +215,58 @@ If someone leaves the team:
 
 ```
 Bob: /rune:status
-Claude: Error: Cannot connect to Vault
+Agent: Error: Cannot connect to Vault
 
 Alice checks:
-1. Vault is running: curl https://vault-acme.oci.envector.io/health
-2. Bob's token is correct
-3. Firewall allows Bob's IP
+  1. Vault is running: grpcurl -cacert ca.pem vault-acme.oci.envector.io:50051 grpc.health.v1.Health/Check
+  2. Bob's token is correct: runevault token list
+  3. Firewall allows Bob's IP (port 50051)
 
-Issue: Bob had typo in Vault Endpoint
-Fix: Bob runs /rune:configure with correct URL
+Issue: Bob had a typo in the Vault endpoint
+Fix: Bob runs /rune:configure with the correct endpoint
 ```
 
-### Carol sees encrypted results
+### Carol sees no results
 
 ```
 Carol: "Why PostgreSQL?"
-Claude: Returns encrypted gibberish
+Agent: No relevant context found.
 
-Issue: Carol's Vault token is incorrect
-Fix: Alice verifies token, Carol runs /rune:configure
+Issue: Carol's Vault token is expired or incorrect
+Fix: Alice checks with `runevault token list`, re-issues if needed
+     Carol runs /rune:configure with the new token
 ```
 
 ---
 
 ## Advanced: Multiple Projects
 
-### Separate Indexes
-
-To separate organizational memory by project, the admin sets the team index name on the Vault server:
+To isolate organizational memory by project, deploy separate Vault instances:
 
 ```bash
-# Project Alpha — admin sets on Vault server:
-VAULT_INDEX_NAME="project-alpha-context"
-# All team members connecting to this Vault automatically use this index
+# Project Alpha — its own Vault with its own index
+# install.sh → index_name: "project-alpha"
+# vault_endpoint: vault-alpha.oci.envector.io:50051
 
-# Project Beta — admin deploys a separate Vault instance:
-VAULT_INDEX_NAME="project-beta-context"
-# Team members connect to this Vault for Beta context
+# Project Beta — separate Vault instance
+# install.sh → index_name: "project-beta"
+# vault_endpoint: vault-beta.oci.envector.io:50051
 ```
 
-The index name is always managed by the Vault admin and distributed automatically at startup, ensuring consistency across the team.
+Team members configure the Vault endpoint matching their current project. The index name is managed by the Vault admin and distributed automatically at startup.
 
 ---
 
 ## Summary
 
 **Admin Tasks** (Alice):
-1. Deploy Rune-Vault with enVector bundle (one-time, 1 hour)
-2. Onboard team members (per member, 5 minutes)
-3. Rotate tokens (monthly, 10 minutes)
+1. Deploy Rune-Vault via interactive installer (one-time, ~30 minutes)
+2. Issue per-user tokens (per member, 1 minute)
+3. Rotate tokens periodically (10 minutes)
 
 **Team Member Tasks** (Bob, Carol):
 1. Install plugin (one-time, 2 minutes)
-2. Configure credentials (one-time, 3 minutes)
+2. Configure with Vault endpoint + token (one-time, 1 minute)
 3. Use naturally (ongoing, zero overhead)
 
-**Result**: Fully encrypted, shared organizational memory with zero knowledge privacy.
+**Result**: Fully encrypted, shared organizational memory with per-user access control and zero-knowledge privacy.


### PR DESCRIPTION
## Summary
- Replace tagline with market-focused "Encrypted shared memory for AI agents"
- Add "How Rune Is Different" comparison table (vs built-in memory, RAG, wikis, plaintext vector DBs)
- Add proper per-agent uninstall CLI commands (`claude mcp remove`, `codex mcp remove`, `gemini extensions uninstall`)
- Rewrite team-setup-example.md to match rune-admin's current workflow: interactive installer, per-user tokens via `runevault` CLI, Vault bundle auto-delivery

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify team-setup-example.md renders correctly
- [ ] Cross-check uninstall commands against actual CLI behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)