### PR TITLE
ci: migrate workflows to self-hosted runner

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   post-comment:
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, rune-ci]
 
     steps:
       - name: Checkout trusted default branch

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   run-tests:
     name: Run all tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, rune-ci]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- What changed: Migrated runs-on from ubuntu-latest to self-hosted
- Why: Move CI execution to a self-hosted runner with for cost control
- Scope: CI only - no changes to application code, scripts, or agent behavior

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [x] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [x] No agent-specific script duplicates bootstrap/setup logic
- [x] Agent-specific scripts remain thin adapters (registration/wiring only)
- [x] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [x] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [x] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
