### PR TITLE
Removing stdin buffer lock contention at terminating MCP server

### DIFF
--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -1917,7 +1917,15 @@ if __name__ == "__main__":
         logger.warning(f"Pipeline init issues: {_pipeline_result['errors']}")
 
     def _handle_shutdown(signum, frame):
-        raise SystemExit(0)
+        # Close stdin fd to unblock the anyio worker thread that is stuck on
+        # readline().  Without this, Py_FinalizeEx tries to GC the same
+        # TextIOWrapper whose buffer lock the worker thread still holds,
+        # triggering "could not acquire lock for <BufferedReader>" → abort().
+        try:
+            os.close(0)
+        except OSError:
+            pass
+        os._exit(0)
     for sig in (signal.SIGINT, getattr(signal, "SIGTERM", None)):
         if sig is not None:
             signal.signal(sig, _handle_shutdown)


### PR DESCRIPTION
Solving https://github.com/CryptoLabInc/rune/issues/37 by removing stdin buffer lock contention.
    
The anyio worker thread blocks on stdin.readline() holding the BufferedReader lock.  When SystemExit triggered Py_FinalizeEx, the interpreter tried to GC the same TextIOWrapper, hit the locked buffer, and called abort().
    
Close fd 0 to unblock the worker thread and use os._exit(0) to skip finalization entirely.