### PR TITLE
fix: move setup-python before detect step to fix python not found

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Detect changed test node IDs
         id: detect
         run: |
@@ -33,10 +37,6 @@ jobs:
           else
             python .github/scripts/ci_changed_tests.py "$BASE" "$HEAD" $CHANGED
           fi
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
 
       - name: Cache pip
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

- What changed: Moved `actions/setup-python@v5` step before the "Detect changed test node IDs" step in `pr-tests.yml`
- Why: Self-hosted runner (`rune-ci`) does not have `python` on PATH — only `python3`. The detect step called `python ci_changed_tests.py` before Python was set up, causing exit code 127
- Scope: `.github/workflows/pr-tests.yml` only

## Validation

- [x] Tests run (or explain why not): by running ci
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [x] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [x] No agent-specific script duplicates bootstrap/setup logic
- [x] Agent-specific scripts remain thin adapters (registration/wiring only)
- [x] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [x] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [x] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
