### PR TITLE
Feat/background downloading embedding

### DIFF
--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -16,7 +16,7 @@ import logging
 from typing import Union, List, Dict, Any, Optional, Annotated
 from datetime import datetime, timezone
 import numpy as np
-import os, sys, signal
+import os, sys, signal, threading
 import json
 
 logger = logging.getLogger("rune.mcp")
@@ -385,6 +385,9 @@ class MCPServerApp:
         self._active_tier2_provider: Optional[str] = None
         # mcp
         self.mcp = FastMCP(name=mcp_server_name)
+        # Background pipeline initialization
+        self._pipelines_ready = threading.Event()
+        self._pipelines_error: Optional[str] = None
 
         # ---------- Confidence Calculation (inlined from Synthesizer) ---------- #
         def _calculate_confidence(results) -> float:
@@ -702,6 +705,10 @@ class MCPServerApp:
         ) -> Dict[str, Any]:
             _maybe_reload_for_auto_provider(ctx)
 
+            wait_err = self._ensure_pipelines()
+            if wait_err:
+                return wait_err
+
             if self._scribe is None:
                 return make_error(PipelineNotReadyError(
                     "Scribe pipeline not initialized.",
@@ -818,6 +825,10 @@ class MCPServerApp:
         ) -> Dict[str, Any]:
             _maybe_reload_for_auto_provider(ctx)
 
+            wait_err = self._ensure_pipelines()
+            if wait_err:
+                return wait_err
+
             if self._scribe is None:
                 return make_error(PipelineNotReadyError("Scribe pipeline not initialized."))
             if not self._vault_index_name:
@@ -905,6 +916,10 @@ class MCPServerApp:
             ctx: Optional[Context] = None,
         ) -> Dict[str, Any]:
             _maybe_reload_for_auto_provider(ctx)
+
+            wait_err = self._ensure_pipelines()
+            if wait_err:
+                return wait_err
 
             if self._retriever is None:
                 return make_error(PipelineNotReadyError(
@@ -1106,6 +1121,10 @@ class MCPServerApp:
         async def tool_delete_capture(
             record_id: Annotated[str, Field(description="The record ID to soft-delete (e.g. dec_20260316_arch_abc)")],
         ) -> Dict[str, Any]:
+            wait_err = self._ensure_pipelines()
+            if wait_err:
+                return wait_err
+
             if self._retriever is None or self._scribe is None:
                 return make_error(PipelineNotReadyError(
                     "Pipelines not initialized.",
@@ -1463,6 +1482,34 @@ class MCPServerApp:
             result["group_type"] = first.group_type or "phase_chain"
         _append_capture_log(first.id, first.title, first.domain.value, "standard")
         return result
+
+    def _init_pipelines_background(self) -> None:
+        """Run _init_pipelines in background, then signal readiness."""
+        try:
+            result = self._init_pipelines()
+            if result["errors"]:
+                self._pipelines_error = "; ".join(
+                    e if isinstance(e, str) else e.get("message", str(e))
+                    for e in result["errors"]
+                )
+        except Exception as e:
+            self._pipelines_error = str(e)
+            logger.error("Background pipeline init failed: %s", e, exc_info=True)
+        finally:
+            self._pipelines_ready.set()
+
+    def _ensure_pipelines(self, timeout: float = 120.0) -> Optional[Dict[str, Any]]:
+        """Wait for background pipeline init. Returns error dict if not ready, None if ok."""
+        if self._pipelines_ready.is_set():
+            return None
+        logger.info("Waiting for pipeline initialization to complete...")
+        ready = self._pipelines_ready.wait(timeout=timeout)
+        if not ready:
+            return make_error(PipelineNotReadyError(
+                "Pipeline initialization still in progress. Please retry shortly.",
+                recovery_hint="The embedding model may still be downloading. Try again in a few seconds.",
+            ))
+        return None
 
     def _init_pipelines(self) -> Dict[str, Any]:
         """
@@ -1907,14 +1954,14 @@ if __name__ == "__main__":
     if ENVECTOR_API_KEY:
         app._envector_api_key = ENVECTOR_API_KEY
 
-    # Initialize pipelines (reads ~/.rune/config.json state)
-    _pipeline_result = app._init_pipelines()
-    if _pipeline_result["scribe"]:
-        logger.info("Scribe pipeline ready (capture tool available)")
-    if _pipeline_result["retriever"]:
-        logger.info("Retriever pipeline ready (recall tool available)")
-    if _pipeline_result["errors"]:
-        logger.warning(f"Pipeline init issues: {_pipeline_result['errors']}")
+    # Initialize pipelines in background — tools are registered immediately,
+    # pipeline-dependent tools wait via _ensure_pipelines().
+    threading.Thread(
+        target=app._init_pipelines_background,
+        name="rune-pipeline-init",
+        daemon=True,
+    ).start()
+    logger.info("Pipeline initialization started in background")
 
     def _handle_shutdown(signum, frame):
         raise SystemExit(0)

--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -1044,6 +1044,8 @@ class MCPServerApp:
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False)
         )
         async def tool_reload_pipelines() -> Dict[str, Any]:
+            self._pipelines_ready.wait()  # wait for background init to finish first
+            self._pipelines_error = None  # clear stale error before reload
             result = self._init_pipelines()
 
             # Pre-warm the enVector connection (blocking) immediately after pipeline init
@@ -1500,14 +1502,18 @@ class MCPServerApp:
 
     def _ensure_pipelines(self, timeout: float = 120.0) -> Optional[Dict[str, Any]]:
         """Wait for background pipeline init. Returns error dict if not ready, None if ok."""
-        if self._pipelines_ready.is_set():
-            return None
-        logger.info("Waiting for pipeline initialization to complete...")
-        ready = self._pipelines_ready.wait(timeout=timeout)
-        if not ready:
+        if not self._pipelines_ready.is_set():
+            logger.info("Waiting for pipeline initialization to complete...")
+            ready = self._pipelines_ready.wait(timeout=timeout)
+            if not ready:
+                return make_error(PipelineNotReadyError(
+                    "Pipeline initialization still in progress. Please retry shortly.",
+                    recovery_hint="The embedding model may still be downloading. Try again in a few seconds.",
+                ))
+        if self._pipelines_error:
             return make_error(PipelineNotReadyError(
-                "Pipeline initialization still in progress. Please retry shortly.",
-                recovery_hint="The embedding model may still be downloading. Try again in a few seconds.",
+                f"Pipeline initialization failed: {self._pipelines_error}",
+                recovery_hint="Run /rune:activate or restart Claude Code.",
             ))
         return None
 

--- a/mcp/tests/test_server.py
+++ b/mcp/tests/test_server.py
@@ -52,6 +52,7 @@ def mcp_server():
 
     app = MCPServerApp(envector_adapter=FakeAdapter(), mcp_server_name="test-mcp")
     app.embedding = FakeEmbeddingService()
+    app._pipelines_ready.set()
     return app.mcp  # FastMCP Instance
 
 
@@ -136,6 +137,7 @@ def mcp_server_with_vault():
         vault_index_name="team-decisions",
     )
     app.embedding = FakeEmbeddingService()
+    app._pipelines_ready.set()
     return app.mcp
 
 
@@ -196,6 +198,7 @@ async def test_vault_status_includes_team_index_name(mcp_server_with_vault):
 def mcp_server_degraded():
     """MCP server with envector_adapter=None, simulating startup when infra is down."""
     app = MCPServerApp(mcp_server_name="test-mcp-degraded")
+    app._pipelines_ready.set()
     return app.mcp
 
 
@@ -260,6 +263,7 @@ async def test_reload_pipelines_warmup_failure():
 
     app = MCPServerApp(envector_adapter=FailingAdapter(), mcp_server_name="test-mcp-warmup-fail")
     app.embedding = FakeEmbeddingService()
+    app._pipelines_ready.set()
     # Force _scribe to be truthy so warmup path is triggered
     app._scribe = {"record_builder": None, "envector_client": None, "embedding_service": None}
 
@@ -379,6 +383,7 @@ def mcp_server_envector_timeout():
 
     app = MCPServerApp(envector_adapter=SlowAdapter(), mcp_server_name="test-mcp-slow")
     app.embedding = FakeEmbeddingService()
+    app._pipelines_ready.set()
     return app.mcp
 
 
@@ -393,6 +398,7 @@ def mcp_server_envector_connection_error():
 
     app = MCPServerApp(envector_adapter=ErrorAdapter(), mcp_server_name="test-mcp-err")
     app.embedding = FakeEmbeddingService()
+    app._pipelines_ready.set()
     return app.mcp
 
 
@@ -407,6 +413,7 @@ def mcp_server_envector_auth_error():
 
     app = MCPServerApp(envector_adapter=AuthErrorAdapter(), mcp_server_name="test-mcp-auth")
     app.embedding = FakeEmbeddingService()
+    app._pipelines_ready.set()
     return app.mcp
 
 
@@ -501,3 +508,31 @@ async def test_recall_returns_structured_error_for_invalid_topk(mcp_server_with_
         assert isinstance(error, dict), f"Expected structured error dict, got: {type(error)}"
         assert error.get("code") in ("PIPELINE_NOT_READY", "INVALID_INPUT")
         assert isinstance(error.get("retryable"), bool)
+
+
+# ----------- Background Pipeline Init Tests ----------- #
+
+@pytest.mark.asyncio
+async def test_ensure_pipelines_returns_none_when_ready():
+    """_ensure_pipelines returns None when pipelines are already initialized."""
+    class FakeAdapter(EnVectorSDKAdapter):
+        def __init__(self):
+            pass
+    app = MCPServerApp(envector_adapter=FakeAdapter(), mcp_server_name="test-mcp")
+    app._pipelines_ready.set()
+    result = app._ensure_pipelines(timeout=0.1)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_pipelines_returns_error_on_timeout():
+    """_ensure_pipelines returns error dict when init times out."""
+    class FakeAdapter(EnVectorSDKAdapter):
+        def __init__(self):
+            pass
+    app = MCPServerApp(envector_adapter=FakeAdapter(), mcp_server_name="test-mcp")
+    # Don't set _pipelines_ready — simulate still initializing
+    result = app._ensure_pipelines(timeout=0.01)
+    assert result is not None
+    assert result["ok"] is False
+    assert "in progress" in result["error"]["message"].lower()


### PR DESCRIPTION
## Summary

Solving https://github.com/CryptoLabInc/rune/issues/72 by integrating a background/lazy intialization mechanism for the pipeline components in the MCP server. Simultaneously we can improve startup responsiveness and reliability as well.
Instead of blocking server startup while pipelines are initialized, the initialization now runs in a background thread, and all pipeline-dependent tools check readiness before proceeding. The tests are also updated to accommodate this new async initialization flow.