### PR TITLE
fix: split test_ids on whitespace, not space only

### DIFF
--- a/.github/scripts/post_pr_comment.js
+++ b/.github/scripts/post_pr_comment.js
@@ -67,7 +67,7 @@ module.exports = async ({ github, context }) => {
 
   // Tests Added/Modified in This PR — per-test PASS/FAIL and summary
   const hasChanged = process.env.HAS_CHANGED === 'true';
-  const changedIds = (process.env.TEST_IDS || '').trim().split(' ').filter(Boolean);
+  const changedIds = (process.env.TEST_IDS || '').trim().split(/\s+/).filter(Boolean);
 
   // For parameterized tests, ci_changed_tests.py outputs the base function name
   // (e.g. "test_foo") but pytest IDs include params (e.g. "test_foo[param1-param2]").


### PR DESCRIPTION
## Summary

- What changed: `split(' ')` → `split(/\s+/)` when parsing `TEST_IDS` in `post_pr_comment.js`
- Why: `ci_changed_tests.py` writes `test_ids` using GitHub's multiline output syntax (`<<EOF`),
  so `TEST_IDS` arrives as a newline-delimited(`\n`) string. Splitting on `' '` treated the entire value as a single ID, causing all changed tests to appear as `NOT RUN` in the PR comment.
- Scope: `post_pr_comment.js` only

## Validation

- [ ] Tests run (or explain why not): Tests can only be executed after merging into main due to the security that prevents PR from modifying script itself
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [x] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [x] No agent-specific script duplicates bootstrap/setup logic
- [x] Agent-specific scripts remain thin adapters (registration/wiring only)
- [x] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [x] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [x] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
