### PR TITLE
fix(mcp): add fallback on insertion failure

### DIFF
--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -1382,7 +1382,11 @@ class MCPServerApp:
         )
 
         if not insert_result.get("ok"):
-            return {"ok": False, "error": f"Insert failed: {insert_result.get('error')}"}
+            error_msg = insert_result.get("error", "Unknown error")
+            if any(term in error_msg for term in ["RpcError", "Connection", "UNAVAILABLE", "OSError"]):
+                logger.error(f"Insert failed (network): {error_msg}")
+                _set_dormant_with_reason("envector_unreachable")
+            return {"ok": False, "error": f"Insert failed: {error_msg}"}
 
         first = records[0]
         result = {
@@ -1467,7 +1471,11 @@ class MCPServerApp:
         )
 
         if not insert_result.get("ok"):
-            return {"ok": False, "error": f"Insert failed: {insert_result.get('error')}"}
+            error_msg = insert_result.get("error", "Unknown error")
+            if any(term in error_msg for term in ["RpcError", "Connection", "UNAVAILABLE", "OSError"]):
+                logger.error(f"Insert failed (network): {error_msg}")
+                _set_dormant_with_reason("envector_unreachable")
+            return {"ok": False, "error": f"Insert failed: {error_msg}"}
 
         first = records[0]
         result = {


### PR DESCRIPTION
## Summary

- What changed: Update status to `dormant` if insertion fail with network/connection errors
- Why: It remains `active` even if Rune is unavailable to connect with enVector
- Scope: `mcp/server/server.py`

## Validation

- [x] Tests run (or explain why not):
- [x] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [x] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [x] No agent-specific script duplicates bootstrap/setup logic
- [x] Agent-specific scripts remain thin adapters (registration/wiring only)
- [x] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [x] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [x] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
