### PR TITLE
fix(status): remove false-negative MCP server logs check

### DIFF
--- a/commands/claude/status.md
+++ b/commands/claude/status.md
@@ -38,10 +38,6 @@ System Health:
   [check] LLM Provider  : <provider or "none">
   [check] enVector Cloud: reachable (<latency>ms) / unreachable
 
-Infrastructure:
-  [check] Python venv: <installedFrom>/.venv
-  [check] MCP server logs: <recent or "stale/missing">
-
 Recommendations:
   - <actionable suggestions based on what's missing>
 ```


### PR DESCRIPTION
## Summary

- **What changed**: Removed the `Infrastructure` block (4 lines including trailing blank) from `commands/claude/status.md`. The block contained two checks — `MCP server logs` and `Python venv` — that rendered immediately after the `System Health` section.

- **Why**: The `MCP server logs` check referenced `~/.rune/logs`, a directory that is *only* ever created by `scripts/start-mcp-servers.sh` (standalone daemon mode). In plugin mode — where the MCP server runs as a stdio child spawned by `bootstrap-mcp.sh` — the directory is never created. The Python server uses `logging.getLogger("rune.mcp")` with no `FileHandler` (stderr only), and `bootstrap-mcp.sh` does not create the path either. Verified with `rg 'FileHandler|rune/logs' mcp/` → 0 matches. The result was `[✗] MCP server logs: ~/.rune/logs missing` on every `/rune:status` invocation in an otherwise-healthy report, causing users to think the server was broken.

The `Python venv: found` line is removed in the same block because it is implied by the `System Health` section above — diagnostics can only respond if the venv is already alive, so a separate venv check carried no new information. The useful part of that line (the actual checkout path) will be re-surfaced in a more meaningful form via the follow-up issue linked below.

- **Scope**: Single file, 4 lines removed, 0 added. No code, config, test, or MCP server changes. No cross-agent template changes — `commands/rune/status.toml` already avoids this anti-pattern and uses a `MCP Tools: capture/recall/diagnostics availability` block instead, which is the reference design this PR implicitly moves the MD template toward.

## Validation

- [x] **Tests run**: N/A — this is a Markdown command-template change, not code. No unit test covers `/rune:status` template rendering. Verified manually by running `/rune:status` in Claude Code after applying the change and confirming the false-negative line is gone; remaining output unchanged.
- [x] **Docs updated**: N/A — `README.md`, `CONTRIBUTING.md`, `docs/*`, and other command templates do not reference the removed lines. Verified with `rg 'MCP server logs|~/\.rune/logs|stale/missing' commands/` → only match is the removed line itself.

## Cross-Agent Invariants

- [x] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal) — no script changes
- [x] No agent-specific script duplicates bootstrap/setup logic — no script changes
- [x] Agent-specific scripts remain thin adapters (registration/wiring only) — no script changes
- [x] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions — no command-body changes
- [x] Claude/Gemini/OpenAI instructions do not include Codex-only commands — this PR *removes* content from a Claude-only file, does not add
- [x] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries — this PR actually *improves* consistency: `commands/rune/status.toml` already uses a `MCP Tools` availability block instead of the broken `Infrastructure` block, and this PR brings the Claude MD template closer to that reference design (reduces MD↔TOML drift rather than introducing it)

## Notes for Reviewers

- **Risk areas**: Very low.
- The removed section was always producing a false-negative in plugin mode, so removing it only removes noise; no user workflow depended on it being present.
- `Python venv: found` was purely cosmetic (implied by System Health).
- No code or schema changes — purely template text.

- **Backward compatibility impact**: None.
- The template is consumed by the LLM running `/rune:status`; removing a section just means that section disappears from future status reports.
- No data schema, MCP tool response shape, or CLI interface changes.
- Older Rune installs running this updated command will simply see a slightly shorter, more accurate status report.