### PR TITLE
feat(status): surface active server path for multi-checkout drift detection

### DIFF
--- a/commands/claude/status.md
+++ b/commands/claude/status.md
@@ -26,6 +26,7 @@ Dormant Since:  <timestamp>  (only when dormant with a timestamp)
 
 Configuration:
   [check] Config file: ~/.rune/config.json
+  [check] MCP server: <diagnostics.environment.executable>
   [check] Vault Endpoint: <url or "not set">
   [check] enVector: <endpoint or "not set">
 
@@ -43,6 +44,12 @@ Recommendations:
 ```
 
 Use checkmarks for healthy items, X marks for issues.
+
+**MCP server**: Render `environment.executable` from the `diagnostics` MCP
+tool response as-is (it is a Python interpreter path like
+`<plugin_root>/.venv/bin/python3`). This shows which Rune checkout is actually
+serving requests — useful when multiple checkouts coexist on the machine
+(Claude Code marketplace cache, Codex skill install, local dev checkout, etc.).
 
 **Dormant Reason Display**: When `dormant_reason` is present in config or diagnostics, translate reason code into a user-friendly message:
 - `vault_unreachable`: "Vault server could not be reached. Check if it's running and the endpoint is correct."

--- a/commands/rune/status.toml
+++ b/commands/rune/status.toml
@@ -30,6 +30,7 @@ State: Active / Dormant
 
 Configuration:
   Config file   : ~/.rune/config.json
+  MCP server    : <diagnostics.environment.executable>
   Vault Endpoint: <url or "not set">
   Vault Token   : <masked or "not set">
   enVector      : <endpoint or "not set">
@@ -59,6 +60,8 @@ MCP Tools:
    - enVector not provisioned: "No enVector Cloud endpoint is configured on Rune-Vault. Contact your Vault administrator."
 
 Use checkmarks for healthy items, X marks for issues.
+
+MCP server: Render `environment.executable` from the `diagnostics` MCP tool response as-is (it is a Python interpreter path like `<plugin_root>/.venv/bin/python3`). This shows which Rune checkout is actually serving requests — useful when multiple checkouts coexist on the machine (Claude Code marketplace cache, Codex skill install, local dev checkout, etc.).
 
 User input: {{input}}
 """

--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -555,6 +555,7 @@ class MCPServerApp:
                     "os": sys.platform,
                     "python_version": sys.version.split(" ")[0],
                     "cwd": os.getcwd(),
+                    "executable": sys.executable,
                 }
             except Exception as e:
                 report["environment"] = {"error": str(e)}

--- a/mcp/tests/test_server.py
+++ b/mcp/tests/test_server.py
@@ -319,6 +319,24 @@ async def test_diagnostics_with_vault(mcp_server_with_vault):
 
 
 @pytest.mark.asyncio
+async def test_diagnostics_environment_includes_executable(mcp_server_with_vault):
+    """diagnostics.environment must expose sys.executable so clients can
+    derive the active plugin checkout path from it. This is the basis for
+    multi-checkout drift detection in /rune:status — stripping /.venv/bin/
+    python3 from the value yields the plugin root of the responding server."""
+    async with Client(mcp_server_with_vault) as client:
+        result = await client.call_tool("diagnostics", {})
+        data = getattr(result, "data", None) or getattr(result, "structured", None) \
+               or getattr(result, "structured_content", None)
+
+        assert data is not None
+        env = data.get("environment", {})
+        assert "executable" in env, "environment must include 'executable' field"
+        assert isinstance(env["executable"], str)
+        assert env["executable"] == sys.executable
+
+
+@pytest.mark.asyncio
 async def test_diagnostics_without_vault(mcp_server):
     async with Client(mcp_server) as client:
         result = await client.call_tool("diagnostics", {})


### PR DESCRIPTION
**One line**: rune:activate 했을 때 실제 실행중인 mcp 서버의 위치를 잡아주는 PR입니다.

## Summary

- **What changed**:
  - Added `executable` field to `diagnostics.environment` exposing `sys.executable` (the MCP server's own Python interpreter path).
  - Added `MCP server` row to `/rune:status` Configuration section, rendering that executable path as-is.
  - Synced across `commands/claude/status.md` and `commands/rune/status.toml`.
  - Added `test_diagnostics_environment_includes_executable`.

- **Why**: In multi-checkout environments (Claude Code + Codex + Gemini + local dev, all coexisting), there was no way to tell which checkout's MCP server was actually responding. Existing `environment` fields don't identify the checkout — `cwd` inherits from the host process, not the plugin path. Since `bootstrap-mcp.sh` always creates the venv inside `$PLUGIN_DIR/.venv`, `sys.executable` is a fully-qualified signal (`<plugin_root>/.venv/bin/python3`).

## Validation

- [x] Tests run: `pytest mcp/tests/test_server.py -v -k diagnostics` — all 8 pass including the new test.
- [x] Manual verification: restarted Claude Code, ran `/rune:status`, confirmed `MCP server:
/Users/od/rune/.venv/bin/python3` renders correctly.
- [x] Docs updated: N/A — no user-facing docs reference `/rune:status` field names.

## Cross-Agent Invariants

- [x] `scripts/bootstrap-mcp.sh` remains the single source of truth — no script changes; this PR relies on
bootstrap-mcp.sh's venv placement as the invariant that makes `sys.executable` meaningful.
- [x] No agent-specific script duplicates bootstrap/setup logic — no script changes.
- [x] Agent-specific scripts remain thin adapters — no script changes.
- [x] Codex-only commands clearly separated — no new Codex-only commands introduced.
- [x] Claude/Gemini/OpenAI instructions don't include Codex-only commands — MD template stays Claude-specific.
- [x] `SKILL.md`, `commands/rune/*.toml`, `AGENT_INTEGRATION.md` consistent on boundaries — MD and TOML
updated symmetrically in one commit.

## Notes for Reviewers

- **Risk**: Minimal. Single additive field in diagnostics response, single new display row.
- **Backward compatibility**: Fully additive. Older clients ignore the new field; no schema changes.
- **Why no drift detection**: Issue #82's original scope included comparing this value against `config.metadata.installedFrom` to detect drift. Dropped because `installedFrom` detection in `/rune:configure` hardcodes `find ~/.claude/plugins/cache` lookup, producing false positives in any dev setup.  A separate issue should improve `installedFrom` detection before drift comparison can be added meaningfully.
- **PR dependency**: Stacked on top of #83. Merge #83 first; this PR auto-rebases afterward.