### PR TITLE
ci: suppress PR comment when all tests pass (skips OK)

### DIFF
--- a/.github/scripts/post_pr_comment.js
+++ b/.github/scripts/post_pr_comment.js
@@ -7,6 +7,28 @@ module.exports = async ({ github, context }) => {
   const passed = exitCode === '0';
   const status = passed ? '✅ All tests passed' : '❌ Some tests failed';
 
+  const marker = '<!-- pr-tests-bot -->';
+
+  // Early exit on a clean run. pytest exits 0 iff no FAILED/ERROR (skips OK),
+  // so we suppress the success comment entirely and clean up any prior failure
+  // comment so the PR doesn't keep showing a stale red banner.
+  if (passed) {
+    const { data: comments } = await github.rest.issues.listComments({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: parseInt(process.env.PR_NUMBER) || context.issue.number,
+    });
+    const existing = comments.find(c => c.body && c.body.includes(marker));
+    if (existing) {
+      await github.rest.issues.deleteComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        comment_id: existing.id,
+      });
+    }
+    return;
+  }
+
   // Parse pytest final summary line for authoritative counts
   // e.g. "4 failed, 261 passed, 2 skipped in 4.06s"
   function parsePytestSummary(output) {
@@ -159,7 +181,6 @@ module.exports = async ({ github, context }) => {
   const shortSha = headSha.slice(0, 7);
   const commitUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/commit/${headSha}`;
 
-  const marker = '<!-- pr-tests-bot -->';
   const bodyParts = [
     marker,
     '## ' + status,


### PR DESCRIPTION
Go migration 중에 python CI 가 자꾸 댓글을 다는데 go migration과 관련이 없기도 하고, pass/skip 된 테스트는 알림을 줄 필요가 없어서 수정합니다.

## Summary

- **What changed:** `.github/scripts/post_pr_comment.js` 에 early-exit 추가 — pytest 가 exit 0 (PASS + SKIP 만, FAILED/ERROR 0개) 이면 새 댓글 작성 안 하고, 이전 실패 run 에서 남은 댓글이 있으면 삭제 후 return. 실패/에러 시는 기존 동작 그대로 (post or update).

- **Why:** 매 PR 마다 "✅ All tests passed" 댓글이 알림 노이즈. 통과 여부는 GitHub status check 로 이미 보이고, PR conversation 은 review 토론용. 실패 시에만 댓글로 디테일 (어떤 테스트가 깨졌는지) 제공하는 게 SNR 높음.

- **Scope:**
  - ✅ 통과 시 (FAILED/ERROR 0개, skip OK) 댓글 안 달기
  - ✅ 통과 시 + 이전 실패 댓글 잔존 → 삭제 (stale red banner 방지)
  - ✅ 실패 시 기존 로직 그대로
  - ❌ `pr-tests.yml` 워크플로우 자체는 변경 없음 — 결과 artifact / fail-on-failure step 그대로
  - ❌ Go 테스트 추가는 별도 PR 예정