### PR TITLE
refactor(mcp-go): implement pure domain / policy logic without I/O side effects

### DIFF
--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -4,6 +4,8 @@ package domain
 // Spec: docs/v04/spec/components/rune-mcp.md §에러 처리.
 // Python: mcp/server/errors.py (118 LoC).
 
+import "errors"
+
 // Code enum — 8 codes.
 const (
 	CodeInternal             = "INTERNAL_ERROR"
@@ -43,9 +45,28 @@ var (
 )
 
 // MakeError — Python make_error equivalent. Wraps an error as MCP response.
-// TODO: implement type-assertion chain (*RuneError → use its fields;
-//	otherwise fall back to INTERNAL_ERROR).
 func MakeError(err error) map[string]any {
-	// TODO: bit-identical to Python make_error (errors.py:L93-118)
-	return nil
+	var runeErr *RuneError
+	if errors.As(err, &runeErr) {
+		errMap := map[string]any{
+			"code":      runeErr.Code,
+			"message":   runeErr.Message,
+			"retryable": runeErr.Retryable,
+		}
+		if runeErr.RecoveryHint != "" {
+			errMap["recovery_hint"] = runeErr.RecoveryHint
+		}
+		return map[string]any{
+			"ok":    false,
+			"error": errMap,
+		}
+	}
+	return map[string]any{
+		"ok": false,
+		"error": map[string]any{
+			"code":      CodeInternal,
+			"message":   err.Error(),
+			"retryable": false,
+		},
+	}
 }

--- a/internal/domain/schema.go
+++ b/internal/domain/schema.go
@@ -41,9 +41,41 @@ const (
 )
 
 // ParseDomain — unknown → DomainGeneral (agent-delegated 관대함).
-// TODO: implement full 19-value map + customer_escalation alias (record_builder.py:L646).
+var domainList = []struct {
+	Key string
+	Val Domain
+}{
+	{"architecture", DomainArchitecture},
+	{"security", DomainSecurity},
+	{"product", DomainProduct},
+	{"exec", DomainExec},
+	{"ops", DomainOps},
+	{"design", DomainDesign},
+	{"data", DomainData},
+	{"hr", DomainHR},
+	{"marketing", DomainMarketing},
+	{"incident", DomainIncident},
+	{"debugging", DomainDebugging},
+	{"qa", DomainQA},
+	{"legal", DomainLegal},
+	{"finance", DomainFinance},
+	{"sales", DomainSales},
+	{"customer_success", DomainCustomerSuccess},
+	{"research", DomainResearch},
+	{"risk", DomainRisk},
+	{"general", DomainGeneral},
+}
+
 func ParseDomain(s string) Domain {
-	// TODO: bit-identical to _parse_domain in record_builder.py:L621-655
+	if s == "" {
+		return DomainGeneral
+	}
+	sLower := strings.ToLower(s)
+	for _, entry := range domainList {
+		if strings.Contains(sLower, entry.Key) {
+			return entry.Val
+		}
+	}
 	return DomainGeneral
 }
 

--- a/internal/policy/novelty.go
+++ b/internal/policy/novelty.go
@@ -3,7 +3,11 @@
 // No I/O, no external deps. Each file has a Python canonical reference.
 package policy
 
-import "github.com/envector/rune-go/internal/domain"
+import (
+	"math"
+
+	"github.com/envector/rune-go/internal/domain"
+)
 
 // NoveltyThresholds — runtime defaults per D11 (Python server.py:L102-104).
 // Module constants in embedding.py (0.4/0.7/0.93) are dead defaults — server.py
@@ -31,8 +35,16 @@ var DefaultNoveltyThresholds = NoveltyThresholds{
 //   - 0.7 ≤ sim <  0.95  → related
 //   - sim ≥ 0.95         → near_duplicate (capture blocked)
 func ClassifyNovelty(maxSimilarity float64, th NoveltyThresholds) (domain.NoveltyClass, float64) {
-	// TODO: implement per embedding.py:L49-56 + round(1.0-max, 4)
-	_ = maxSimilarity
-	_ = th
-	return domain.NoveltyClassNovel, 1.0
+	noveltyScore := 1.0 - maxSimilarity
+	score := math.Round(noveltyScore*10000) / 10000
+
+	if maxSimilarity >= th.NearDup {
+		return domain.NoveltyClassNearDuplicate, score
+	} else if maxSimilarity >= th.Related {
+		return domain.NoveltyClassRelated, score
+	} else if maxSimilarity >= th.Novel {
+		return domain.NoveltyClassEvolution, score
+	}
+
+	return domain.NoveltyClassNovel, score
 }

--- a/internal/policy/query.go
+++ b/internal/policy/query.go
@@ -1,60 +1,274 @@
 package policy
 
-import "github.com/envector/rune-go/internal/domain"
+import (
+	"regexp"
+	"strings"
+
+	"github.com/envector/rune-go/internal/domain"
+)
 
 // Query parsing — Python: agents/retriever/query_processor.py (437 LoC).
 // Flow: docs/v04/spec/flows/recall.md Phase 2.
-//
-// Constants to port (line-by-line):
-//   - INTENT_PATTERNS: 31 regex across 7 intents + GENERAL fallback (L70-116)
-//   - TIME_PATTERNS: 16 regex across 4 scopes (L119-124)
-//   - STOP_WORDS: 81 words (L127-137)
-//   - tech patterns: 4 groups (L345-350)
-//
-// Multilingual path (_parse_multilingual L237-281) — NOT ported (D21).
 
-// IntentRule — ordered list (insertion order matters; Go map is unordered).
 type IntentRule struct {
 	Intent   domain.QueryIntent
-	Patterns []string // raw regex; compiled once at package init
+	Patterns []string
 }
 
-// IntentRules — ordered. TODO: port 31 patterns from query_processor.py:L70-116.
 var IntentRules = []IntentRule{
-	// TODO: {IntentDecisionRationale, []string{...6 patterns...}},
-	// TODO: {IntentFeatureHistory, []string{...5 patterns...}},
-	// ... 7 intents, 31 patterns total
+	{domain.QueryIntentDecisionRationale, []string{
+		`why did we (choose|decide|go with|select|pick)`,
+		`what was the (reasoning|rationale|logic|thinking)`,
+		`why .+ over .+`,
+		`what were the (reasons|factors)`,
+		`why (not|didn't we)`,
+		`reasoning behind`,
+	}},
+	{domain.QueryIntentFeatureHistory, []string{
+		`(have|did) (customers?|users?) (asked|requested|wanted)`,
+		`feature request`,
+		`why did we (reject|say no|decline)`,
+		`(how many|which) customers`,
+		`customer feedback (on|about)`,
+	}},
+	{domain.QueryIntentPatternLookup, []string{
+		`how do we (handle|deal with|approach|manage)`,
+		`what'?s our (approach|process|standard|convention)`,
+		`is there (an?|existing) (pattern|standard|convention)`,
+		`what'?s the (best practice|recommended way)`,
+		`how should (we|I)`,
+	}},
+	{domain.QueryIntentTechnicalContext, []string{
+		`what'?s our (architecture|design|system) for`,
+		`how (does|is) .+ (implemented|built|designed)`,
+		`(explain|describe) (the|our) .+ (system|architecture|design)`,
+		`technical (details|overview) (of|for)`,
+	}},
+	{domain.QueryIntentSecurityCompliance, []string{
+		`(security|compliance) (requirements?|considerations?)`,
+		`what (security|privacy) (measures|controls)`,
+		`(gdpr|hipaa|sox|pci) (requirements?|compliance)`,
+		`audit (requirements?|trail)`,
+	}},
+	{domain.QueryIntentHistoricalContext, []string{
+		`when did we (decide|choose|implement|launch)`,
+		`(history|timeline) of`,
+		`(have|did) we (ever|previously)`,
+		`how long (have|has) .+ been`,
+	}},
+	{domain.QueryIntentAttribution, []string{
+		`who (decided|chose|approved|owns)`,
+		`which (team|person|group) (is responsible|decided|owns)`,
+		`(owner|maintainer) of`,
+	}},
 }
 
-// TimeRules — ordered. TODO: port 16 patterns from query_processor.py:L119-124.
-var TimeRules = []IntentRule{}
+type TimeRule struct {
+	Scope    domain.TimeScope
+	Patterns []string
+}
 
-// StopWords — 81 words. TODO: port from query_processor.py:L127-137.
+var TimeRules = []TimeRule{
+	{domain.TimeScopeLastWeek, []string{`last week`, `this week`, `past week`, `7 days`}},
+	{domain.TimeScopeLastMonth, []string{`last month`, `this month`, `past month`, `30 days`}},
+	{domain.TimeScopeLastQuarter, []string{`last quarter`, `this quarter`, `Q[1-4]`, `past 3 months`}},
+	{domain.TimeScopeLastYear, []string{`last year`, `this year`, `20\d{2}`, `past year`}},
+}
+
 var StopWords = map[string]struct{}{
-	// TODO: 81 entries (the, a, an, is, are, ... and, or, but, if, ...)
+	"the": {}, "a": {}, "an": {}, "is": {}, "are": {}, "was": {}, "were": {}, "be": {}, "been": {}, "being": {},
+	"have": {}, "has": {}, "had": {}, "do": {}, "does": {}, "did": {}, "will": {}, "would": {}, "could": {},
+	"should": {}, "may": {}, "might": {}, "must": {}, "shall": {}, "can": {}, "need": {}, "dare": {},
+	"ought": {}, "used": {}, "to": {}, "of": {}, "in": {}, "for": {}, "on": {}, "with": {}, "at": {}, "by": {},
+	"from": {}, "up": {}, "about": {}, "into": {}, "over": {}, "after": {}, "we": {}, "our": {}, "us": {},
+	"i": {}, "me": {}, "my": {}, "you": {}, "your": {}, "it": {}, "its": {}, "they": {}, "them": {}, "their": {},
+	"this": {}, "that": {}, "these": {}, "those": {}, "what": {}, "which": {}, "who": {}, "whom": {},
+	"when": {}, "where": {}, "why": {}, "how": {}, "and": {}, "or": {}, "but": {}, "if": {}, "because": {},
+	"as": {}, "until": {}, "while": {}, "although": {}, "though": {}, "even": {}, "just": {}, "also": {},
 }
 
-// TechPatterns — 4 regex groups. TODO: port from query_processor.py:L345-350.
 var TechPatterns = []string{
-	// TODO: PostgreSQL|MySQL|..., React|Vue|..., AWS|GCP|..., REST|GraphQL|...
+	`\b(PostgreSQL|MySQL|MongoDB|Redis|Elasticsearch|Kafka)\b`,
+	`\b(React|Vue|Angular|Next\.js|Node\.js|Python|Java|Go)\b`,
+	`\b(AWS|GCP|Azure|Kubernetes|Docker|Terraform)\b`,
+	`\b(REST|GraphQL|gRPC|WebSocket|HTTP|HTTPS)\b`,
 }
 
-// Parse — Python: query_processor.py _parse_english path only (D21).
-//
-// 6-stage pipeline (spec/flows/recall.md Phase 2):
-//  1. cleanQuery: lowercase + whitespace collapse + trailing punct strip (? preserved)
-//  2. detectIntent: ordered match against IntentRules → first hit (or GENERAL)
-//  3. detectTimeScope: ordered match against TimeRules
-//  4. extractEntities: 4-stage (quoted, capitalized i>0, tech patterns, dedup [:10])
-//  5. extractKeywords: \w+ + stopword filter + len>2 + dedup [:15]
-//  6. generateExpansions: intent variants + entity[:3]×2 + lowercase-key dedup [:5]
-//
-// TODO: implement each stage.
+// Pre-compiled regexes
+var (
+	wsRe         = regexp.MustCompile(`\s+`)
+	punctRe      = regexp.MustCompile(`[.!,;:]+$`)
+	quotesRe     = regexp.MustCompile(`"([^"]+)"|'([^']+)'`)
+	wordRe       = regexp.MustCompile(`\b\w+\b`)
+	intentRegexs [][]*regexp.Regexp
+	timeRegexs   [][]*regexp.Regexp
+	techRegexs   []*regexp.Regexp
+)
+
+func init() {
+	for _, rule := range IntentRules {
+		var rx []*regexp.Regexp
+		for _, p := range rule.Patterns {
+			rx = append(rx, regexp.MustCompile("(?i)"+p))
+		}
+		intentRegexs = append(intentRegexs, rx)
+	}
+	for _, rule := range TimeRules {
+		var rx []*regexp.Regexp
+		for _, p := range rule.Patterns {
+			rx = append(rx, regexp.MustCompile("(?i)"+p))
+		}
+		timeRegexs = append(timeRegexs, rx)
+	}
+	for _, p := range TechPatterns {
+		techRegexs = append(techRegexs, regexp.MustCompile("(?i)"+p))
+	}
+}
+
+func cleanQuery(q string) string {
+	c := strings.TrimSpace(strings.ToLower(q))
+	c = wsRe.ReplaceAllString(c, " ")
+	c = punctRe.ReplaceAllString(c, "")
+	return c
+}
+
+func detectIntent(qLower string) domain.QueryIntent {
+	for i, rule := range IntentRules {
+		for _, rx := range intentRegexs[i] {
+			if rx.MatchString(qLower) {
+				return rule.Intent
+			}
+		}
+	}
+	return domain.QueryIntentGeneral
+}
+
+func detectTimeScope(qLower string) domain.TimeScope {
+	for i, rule := range TimeRules {
+		for _, rx := range timeRegexs[i] {
+			if rx.MatchString(qLower) {
+				return rule.Scope
+			}
+		}
+	}
+	return domain.TimeScopeAllTime
+}
+
+func extractEntities(q string) []string {
+	var entities []string
+	addUnique := func(e string) {
+		if len(e) <= 1 {
+			return
+		}
+		for _, ex := range entities {
+			if ex == e {
+				return
+			}
+		}
+		entities = append(entities, e)
+	}
+
+	matches := quotesRe.FindAllStringSubmatch(q, -1)
+	for _, m := range matches {
+		if m[1] != "" {
+			addUnique(m[1])
+		} else if m[2] != "" {
+			addUnique(m[2])
+		}
+	}
+
+	words := strings.Fields(q)
+	for i := 1; i < len(words); i++ {
+		if words[i] != "" && words[i][0] >= 'A' && words[i][0] <= 'Z' && len(words[i]) > 1 {
+			phrase := []string{words[i]}
+			j := i + 1
+			for j < len(words) && len(words[j]) > 0 && words[j][0] >= 'A' && words[j][0] <= 'Z' {
+				phrase = append(phrase, words[j])
+				j++
+			}
+			addUnique(strings.Join(phrase, " "))
+		}
+	}
+
+	for _, rx := range techRegexs {
+		for _, m := range rx.FindAllString(q, -1) {
+			addUnique(m)
+		}
+	}
+
+	if len(entities) > 10 {
+		entities = entities[:10]
+	}
+	return entities
+}
+
+func extractKeywords(qLower string) []string {
+	words := wordRe.FindAllString(qLower, -1)
+	var keywords []string
+	seen := make(map[string]bool)
+	for _, w := range words {
+		if _, isStop := StopWords[w]; !isStop && len(w) > 2 {
+			if !seen[w] {
+				seen[w] = true
+				keywords = append(keywords, w)
+			}
+		}
+	}
+	if len(keywords) > 15 {
+		keywords = keywords[:15]
+	}
+	return keywords
+}
+
+func generateExpansions(qLower string, intent domain.QueryIntent, entities []string) []string {
+	var exp []string
+	exp = append(exp, qLower)
+
+	switch intent {
+	case domain.QueryIntentDecisionRationale:
+		exp = append(exp, "decision "+qLower, "rationale "+qLower, "trade-off "+qLower)
+	case domain.QueryIntentFeatureHistory:
+		exp = append(exp, "customer request "+qLower, "feature rejected "+qLower)
+	case domain.QueryIntentPatternLookup:
+		exp = append(exp, "standard approach "+qLower, "best practice "+qLower)
+	case domain.QueryIntentTechnicalContext:
+		exp = append(exp, "architecture "+qLower, "implementation "+qLower)
+	}
+
+	for i := 0; i < len(entities) && i < 3; i++ {
+		exp = append(exp, entities[i]+" decision", "why "+entities[i])
+	}
+
+	var unique []string
+	seen := make(map[string]bool)
+	for _, e := range exp {
+		lower := strings.ToLower(e)
+		if !seen[lower] {
+			seen[lower] = true
+			unique = append(unique, e)
+		}
+	}
+	if len(unique) > 5 {
+		unique = unique[:5]
+	}
+	return unique
+}
+
 func Parse(q string) domain.ParsedQuery {
-	// TODO: bit-identical to _parse_english (query_processor.py)
+	cleaned := cleanQuery(q)
+	intent := detectIntent(cleaned)
+	timeScope := detectTimeScope(cleaned)
+	entities := extractEntities(q)
+	keywords := extractKeywords(cleaned)
+	expanded := generateExpansions(cleaned, intent, entities)
+
 	return domain.ParsedQuery{
-		Original:  q,
-		Intent:    domain.QueryIntentGeneral,
-		TimeScope: domain.TimeScopeAllTime,
+		Original:        q,
+		Cleaned:         cleaned,
+		Intent:          intent,
+		TimeScope:       timeScope,
+		Entities:        entities,
+		Keywords:        keywords,
+		ExpandedQueries: expanded,
 	}
 }

--- a/internal/policy/rerank.go
+++ b/internal/policy/rerank.go
@@ -1,6 +1,8 @@
 package policy
 
 import (
+	"math"
+	"sort"
 	"time"
 
 	"github.com/envector/rune-go/internal/domain"
@@ -40,15 +42,66 @@ var TimeRanges = map[domain.TimeScope]time.Duration{
 // BIT-IDENTICAL REQUIREMENT: Python timedelta.days is integer floor.
 // Go Hours()/24 is float — must math.Floor to match.
 //
-// TODO: implement full loop + sort.
 func ApplyRecencyWeighting(hits []domain.SearchHit, now time.Time) []domain.SearchHit {
-	// TODO: bit-identical to searcher.py:L273-300
+	for i := range hits {
+		r := &hits[i]
+		ageDays := 0.0
+		if tsStr, ok := r.Metadata["timestamp"].(string); ok {
+			if ts, err := time.Parse(time.RFC3339, tsStr); err == nil {
+				ageDays = math.Max(0, math.Floor(now.Sub(ts).Hours()/24))
+			}
+		} else if tsFloat, ok := r.Metadata["timestamp"].(float64); ok {
+			ts := time.Unix(int64(tsFloat), 0).UTC()
+			ageDays = math.Max(0, math.Floor(now.Sub(ts).Hours()/24))
+		}
+
+		decay := 1.0
+		if HalfLifeDays > 0 {
+			decay = math.Pow(0.5, ageDays/HalfLifeDays)
+		}
+		statusMult := 1.0
+		if mult, ok := StatusMultiplier[r.Status]; ok {
+			statusMult = mult
+		}
+		r.AdjustedScore = (SimilarityWeight*r.Score + RecencyWeight*decay) * statusMult
+	}
+
+	sort.SliceStable(hits, func(i, j int) bool {
+		return hits[i].AdjustedScore > hits[j].AdjustedScore
+	})
 	return hits
 }
 
 // FilterByTime — Python: searcher.py:L523-559 _filter_by_time.
-// TODO: implement. Records with no timestamp are kept (Python: if no ts, keep).
+// Records with no timestamp are kept (Python: if no ts, keep).
 func FilterByTime(hits []domain.SearchHit, scope domain.TimeScope, now time.Time) []domain.SearchHit {
-	// TODO: bit-identical to searcher.py:L523-559
-	return hits
+	timeRange, ok := TimeRanges[scope]
+	if !ok || scope == domain.TimeScopeAllTime {
+		return hits
+	}
+
+	cutoff := now.Add(-timeRange)
+	var filtered []domain.SearchHit
+
+	for i := range hits {
+		r := hits[i]
+		keep := true
+		if tsStr, ok := r.Metadata["timestamp"].(string); ok {
+			if ts, err := time.Parse(time.RFC3339, tsStr); err == nil {
+				if ts.Before(cutoff) {
+					keep = false
+				}
+			}
+		} else if tsFloat, ok := r.Metadata["timestamp"].(float64); ok {
+			ts := time.Unix(int64(tsFloat), 0).UTC()
+			if ts.Before(cutoff) {
+				keep = false
+			}
+		}
+
+		if keep {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
 }


### PR DESCRIPTION
## Summary

- What changed: pure domain / policy logic of mcp in Go
- Why: refactoring step
- Scope: `internal/domain`, `internal/policy`

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [ ] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [ ] No agent-specific script duplicates bootstrap/setup logic
- [ ] Agent-specific scripts remain thin adapters (registration/wiring only)
- [ ] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [ ] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [ ] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
