### PR TITLE
yg/phase a6 policy query tests

### DIFF
--- a/internal/domain/query_test.go
+++ b/internal/domain/query_test.go
@@ -1,8 +1,8 @@
+package domain_test
+
 // Tests for query/recall domain helpers — port of Python's SearchResult
 // is_reliable / is_phase predicates plus the v0.4-simplified payload
 // extraction. Python: agents/retriever/searcher.py.
-
-package domain_test
 
 import (
 	"testing"
@@ -10,9 +10,14 @@ import (
 	"github.com/envector/rune-go/internal/domain"
 )
 
-// SearchHit.IsReliable — supported / partially_supported map to true,
-// everything else (including empty string) is unreliable.
-// Python: searcher.py:SearchResult.is_reliable.
+// SearchHit.IsReliable — Python: searcher.py:SearchResult.is_reliable
+// (returns true iff certainty is "supported" or "partially_supported").
+//
+// Canonical Certainty values per Python schema (agents/common/schemas.py
+// Certainty enum): supported, partially_supported, unsupported, unknown.
+// Test covers all 4 + empty-string + an unrelated value to lock the
+// predicate against accidental broadening (e.g., "high" being added later
+// without owner intent).
 func TestSearchHit_IsReliable(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -21,10 +26,10 @@ func TestSearchHit_IsReliable(t *testing.T) {
 	}{
 		{"supported", "supported", true},
 		{"partially_supported", "partially_supported", true},
-		{"unknown", "unknown", false},
 		{"unsupported", "unsupported", false},
+		{"unknown", "unknown", false},
 		{"empty", "", false},
-		{"unrelated_string", "high", false},
+		{"unrelated_value_high", "high", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -36,38 +41,48 @@ func TestSearchHit_IsReliable(t *testing.T) {
 	}
 }
 
-// SearchHit.IsPhase — GroupID non-nil ⇔ true.
-// Python: searcher.py:SearchResult.is_phase.
+// SearchHit.IsPhase — Python: searcher.py:SearchResult.is_phase
+// (returns true iff group_id is not None). Go uses pointer presence.
 func TestSearchHit_IsPhase(t *testing.T) {
-	t.Run("group_id_nil_is_not_phase", func(t *testing.T) {
-		h := &domain.SearchHit{}
-		if h.IsPhase() {
-			t.Error("IsPhase with nil GroupID should be false")
-		}
-	})
+	gid := "grp_2026-01-01_arch_strategy"
+	empty := ""
 
-	t.Run("group_id_set_is_phase", func(t *testing.T) {
-		gid := "grp_2026-01-01_arch_strategy"
-		h := &domain.SearchHit{GroupID: &gid}
-		if !h.IsPhase() {
-			t.Error("IsPhase with non-nil GroupID should be true")
-		}
-	})
+	cases := []struct {
+		name    string
+		groupID *string
+		want    bool
+		// note documents intent for surprising cases.
+		note string
+	}{
+		{name: "group_id_nil", groupID: nil, want: false},
+		{name: "group_id_set", groupID: &gid, want: true},
+		// TODO(yg): confirm with team — should pointer-to-empty-string be
+		// treated as "no phase"? Current Go and Python both say "phase"
+		// (Python: `group_id = ""` is `not None` → True). Locking in current
+		// behavior; flip if the predicate is ever tightened.
+		{
+			name:    "group_id_pointer_to_empty_string",
+			groupID: &empty,
+			want:    true,
+			note:    "pointer presence drives the predicate; empty string still counts (matches Python `is not None`).",
+		},
+	}
 
-	t.Run("group_id_pointer_to_empty_string_is_phase", func(t *testing.T) {
-		// Documenting current behavior: pointer presence drives the predicate,
-		// not string contents. If empty string should also be "no phase",
-		// the predicate must change.
-		empty := ""
-		h := &domain.SearchHit{GroupID: &empty}
-		if !h.IsPhase() {
-			t.Error("IsPhase with pointer to empty string is currently true (predicate uses pointer presence)")
-		}
-	})
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &domain.SearchHit{GroupID: tc.groupID}
+			if got := h.IsPhase(); got != tc.want {
+				t.Errorf("IsPhase() = %v, want %v (%s)", got, tc.want, tc.note)
+			}
+		})
+	}
 }
 
-// ExtractPayloadText — strict v2.1 (D32). No v1/v2.0 fallback.
-// Python: searcher.py:L487-496 (v0.4 simplified to payload.text only).
+// ExtractPayloadText — strict v2.1 (D32). No v1/v2.0 fallback path.
+// This is an INTENTIONAL simplification of Python's _extract_payload_text
+// (searcher.py:L487-496), which has 3 fallback paths
+// (metadata.text → raw.text → decision.what). Go drops them; only
+// payload.text is read. See domain/query.go:121 for the design comment.
 func TestExtractPayloadText(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/domain/query_test.go
+++ b/internal/domain/query_test.go
@@ -1,0 +1,126 @@
+// Tests for query/recall domain helpers — port of Python's SearchResult
+// is_reliable / is_phase predicates plus the v0.4-simplified payload
+// extraction. Python: agents/retriever/searcher.py.
+
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/envector/rune-go/internal/domain"
+)
+
+// SearchHit.IsReliable — supported / partially_supported map to true,
+// everything else (including empty string) is unreliable.
+// Python: searcher.py:SearchResult.is_reliable.
+func TestSearchHit_IsReliable(t *testing.T) {
+	cases := []struct {
+		name      string
+		certainty string
+		want      bool
+	}{
+		{"supported", "supported", true},
+		{"partially_supported", "partially_supported", true},
+		{"unknown", "unknown", false},
+		{"unsupported", "unsupported", false},
+		{"empty", "", false},
+		{"unrelated_string", "high", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &domain.SearchHit{Certainty: tc.certainty}
+			if got := h.IsReliable(); got != tc.want {
+				t.Errorf("IsReliable(%q) = %v, want %v", tc.certainty, got, tc.want)
+			}
+		})
+	}
+}
+
+// SearchHit.IsPhase — GroupID non-nil ⇔ true.
+// Python: searcher.py:SearchResult.is_phase.
+func TestSearchHit_IsPhase(t *testing.T) {
+	t.Run("group_id_nil_is_not_phase", func(t *testing.T) {
+		h := &domain.SearchHit{}
+		if h.IsPhase() {
+			t.Error("IsPhase with nil GroupID should be false")
+		}
+	})
+
+	t.Run("group_id_set_is_phase", func(t *testing.T) {
+		gid := "grp_2026-01-01_arch_strategy"
+		h := &domain.SearchHit{GroupID: &gid}
+		if !h.IsPhase() {
+			t.Error("IsPhase with non-nil GroupID should be true")
+		}
+	})
+
+	t.Run("group_id_pointer_to_empty_string_is_phase", func(t *testing.T) {
+		// Documenting current behavior: pointer presence drives the predicate,
+		// not string contents. If empty string should also be "no phase",
+		// the predicate must change.
+		empty := ""
+		h := &domain.SearchHit{GroupID: &empty}
+		if !h.IsPhase() {
+			t.Error("IsPhase with pointer to empty string is currently true (predicate uses pointer presence)")
+		}
+	})
+}
+
+// ExtractPayloadText — strict v2.1 (D32). No v1/v2.0 fallback.
+// Python: searcher.py:L487-496 (v0.4 simplified to payload.text only).
+func TestExtractPayloadText(t *testing.T) {
+	cases := []struct {
+		name string
+		meta map[string]any
+		want string
+	}{
+		{
+			name: "standard_payload_text",
+			meta: map[string]any{"payload": map[string]any{"text": "hello"}},
+			want: "hello",
+		},
+		{
+			name: "empty_text_field",
+			meta: map[string]any{"payload": map[string]any{"text": ""}},
+			want: "",
+		},
+		{
+			name: "payload_missing",
+			meta: map[string]any{},
+			want: "",
+		},
+		{
+			name: "payload_not_a_map",
+			meta: map[string]any{"payload": "raw string"},
+			want: "",
+		},
+		{
+			name: "text_field_not_a_string",
+			meta: map[string]any{"payload": map[string]any{"text": 42}},
+			want: "",
+		},
+		{
+			name: "text_field_missing",
+			meta: map[string]any{"payload": map[string]any{"format": "markdown"}},
+			want: "",
+		},
+		{
+			name: "nil_metadata",
+			meta: nil,
+			want: "",
+		},
+		{
+			name: "payload_is_nil",
+			meta: map[string]any{"payload": nil},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := domain.ExtractPayloadText(tc.meta)
+			if got != tc.want {
+				t.Errorf("ExtractPayloadText(%v) = %q, want %q", tc.meta, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/policy/query_test.go
+++ b/internal/policy/query_test.go
@@ -1,19 +1,21 @@
-// Tests for policy.Parse — port of Python's TestQueryProcessor
-// (agents/tests/test_retriever.py) plus thoroughness-extending cases for
-// every QueryIntent and TimeScope, clean/cap invariants, and stop-word filter.
-//
-// Multilingual tests intentionally omitted: Go port has no Language field
-// (D21 — agent pre-translates before invocation), so the regex/LLM split in
-// the Python QueryProcessor does not exist here.
-//
-// Black-box style (package policy_test) — exercises only the public Parse
-// entry point. Internals (cleanQuery, detectIntent, detectTimeScope,
-// extractEntities, extractKeywords, generateExpansions) are gated through
-// the resulting ParsedQuery fields.
-
 package policy_test
 
+// Tests for policy.Parse — port of Python's TestQueryProcessor
+// (agents/tests/test_retriever.py:11-92) plus thoroughness-extending cases for
+// every QueryIntent and TimeScope, regex precedence (rule iteration order),
+// clean/cap invariants exact-match, and stop-word filter.
+//
+// Multilingual tests intentionally omitted: Go ParsedQuery has no Language
+// field (D21 — agent pre-translates before invocation), so the regex/LLM
+// split that exists in Python QueryProcessor does not exist here.
+//
+// Black-box style — exercises only the public Parse entry point. Internals
+// (cleanQuery, detectIntent, detectTimeScope, extractEntities,
+// extractKeywords, generateExpansions) are gated through the resulting
+// ParsedQuery fields.
+
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -21,14 +23,14 @@ import (
 	"github.com/envector/rune-go/internal/policy"
 )
 
-// ─────────────────────────────────────────────────────────────────────────────
 // Intent classification — covers all 7 explicit intents + GENERAL fallback.
-// Python parity tests: test_parse_decision_rationale_query / feature_history /
-// pattern_lookup / technical_context / general_query. The remaining 3 intents
-// (security_compliance, historical_context, attribution) extend beyond the
-// Python suite — same regex tables on both sides, so we gate them here too.
-// ─────────────────────────────────────────────────────────────────────────────
-
+// Python parity (test_retriever.py:19-53):
+//
+//	test_parse_decision_rationale_query / feature_history / pattern_lookup /
+//	technical_context / general_query.
+//
+// Beyond Python: SECURITY_COMPLIANCE / HISTORICAL_CONTEXT / ATTRIBUTION
+// share the regex tables on both sides, so we gate them too.
 func TestParse_IntentClassification(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -56,12 +58,24 @@ func TestParse_IntentClassification(t *testing.T) {
 	}
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Time scope detection — all 4 explicit scopes + ALL_TIME default.
-// Python parity: test_time_scope_detection. Beyond Python: month/year and
-// numeric Q[1-4] / 20\d{2} matchers.
-// ─────────────────────────────────────────────────────────────────────────────
+// Intent rule precedence — when a query hits multiple rules, the earliest
+// rule in IntentRules iteration order wins. Order is: DecisionRationale (0),
+// FeatureHistory (1), PatternLookup (2), TechnicalContext (3),
+// SecurityCompliance (4), HistoricalContext (5), Attribution (6).
+// Silent reordering would be undetected by TestParse_IntentClassification
+// alone — this test gates the iteration contract.
+func TestParse_IntentRulePrecedence(t *testing.T) {
+	// Hits both DecisionRationale (`why did we decide`) AND
+	// SecurityCompliance (`gdpr compliance`). DecisionRationale (rule 0)
+	// must win.
+	got := policy.Parse("Why did we decide on GDPR compliance?").Intent
+	if got != domain.QueryIntentDecisionRationale {
+		t.Errorf("rule precedence: DecisionRationale should win over SecurityCompliance, got %q", got)
+	}
+}
 
+// Time scope detection — all 4 explicit scopes + ALL_TIME default + numeric
+// boundaries. Python parity (test_retriever.py:55-62): test_time_scope_detection.
 func TestParse_TimeScope(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -69,10 +83,17 @@ func TestParse_TimeScope(t *testing.T) {
 		scope domain.TimeScope
 	}{
 		{"last_week_phrase", "What decisions did we make last week?", domain.TimeScopeLastWeek},
-		{"last_quarter_q3", "What happened in Q3?", domain.TimeScopeLastQuarter},
+		{"this_week_phrase", "Any progress this week?", domain.TimeScopeLastWeek},
 		{"last_month_phrase", "What did we decide last month?", domain.TimeScopeLastMonth},
+		{"this_quarter_phrase", "What is the priority this quarter?", domain.TimeScopeLastQuarter},
+		{"last_quarter_q3", "What happened in Q3?", domain.TimeScopeLastQuarter},
+		{"past_3_months_phrase", "Decisions from past 3 months?", domain.TimeScopeLastQuarter},
 		{"last_year_phrase", "What was decided last year?", domain.TimeScopeLastYear},
+		// Numeric boundary: regex is `20\d{2}`, matches 2000-2099 only.
 		{"last_year_numeric_2025", "Did we decide in 2025?", domain.TimeScopeLastYear},
+		{"past_year_phrase", "Trends in the past year?", domain.TimeScopeLastYear},
+		// Negative boundary: 1999 must NOT match `20\d{2}`.
+		{"all_time_1999_does_not_match", "What was decided in 1999?", domain.TimeScopeAllTime},
 		{"all_time_default", "Why PostgreSQL?", domain.TimeScopeAllTime},
 	}
 
@@ -86,64 +107,109 @@ func TestParse_TimeScope(t *testing.T) {
 	}
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Entity extraction — quoted strings, capitalized words, tech name patterns.
-// Python parity: test_entity_extraction_quoted / _capitalized.
-// ─────────────────────────────────────────────────────────────────────────────
+// Time rule precedence — when a query hits multiple time patterns, the
+// earliest rule in TimeRules iteration order wins. Order: LastWeek (0),
+// LastMonth (1), LastQuarter (2), LastYear (3).
+func TestParse_TimeRulePrecedence(t *testing.T) {
+	// Hits LastWeek (`last week`) AND LastYear (`last year`).
+	// LastWeek (rule 0) must win.
+	got := policy.Parse("Compare last week to last year").TimeScope
+	if got != domain.TimeScopeLastWeek {
+		t.Errorf("rule precedence: LastWeek should win over LastYear, got %q", got)
+	}
+}
 
+// Entity extraction — quoted strings preserved verbatim (incl. case & space).
+// Python parity (test_retriever.py:64-67): test_entity_extraction_quoted.
 func TestParse_EntitiesQuoted(t *testing.T) {
 	parsed := policy.Parse(`Why did we choose "React Native"?`)
 
-	if !contains(parsed.Entities, "React Native") {
-		t.Errorf("entities should contain 'React Native', got %v", parsed.Entities)
+	if !slices.Contains(parsed.Entities, "React Native") {
+		t.Errorf("entities should contain 'React Native' verbatim, got %v", parsed.Entities)
 	}
 }
 
+// Entity extraction — capitalized scan + tech regex must each surface their
+// targets. Tightened from the looser Python assertion (which used OR): both
+// PostgreSQL AND MySQL must appear (case-insensitive after stripping
+// trailing punctuation that strings.Fields keeps attached, e.g. "MySQL?").
+// Python parity (test_retriever.py:69-74): test_entity_extraction_capitalized.
 func TestParse_EntitiesCapitalizedAndTechPatterns(t *testing.T) {
 	parsed := policy.Parse("Why did we use PostgreSQL instead of MySQL?")
 
-	// Either capitalized scan or tech-pattern matcher should surface both.
-	// Strip trailing punctuation that strings.Fields keeps attached.
-	entitiesLower := make(map[string]bool)
+	want := map[string]bool{"postgresql": false, "mysql": false}
 	for _, e := range parsed.Entities {
-		entitiesLower[strings.ToLower(strings.TrimRight(e, "?.,!;:"))] = true
+		key := strings.ToLower(strings.TrimRight(e, "?.,!;:"))
+		if _, ok := want[key]; ok {
+			want[key] = true
+		}
 	}
-	if !entitiesLower["postgresql"] && !entitiesLower["mysql"] {
-		t.Errorf("entities should contain PostgreSQL or MySQL, got %v", parsed.Entities)
+	for k, ok := range want {
+		if !ok {
+			t.Errorf("entities should contain %q, got %v", k, parsed.Entities)
+		}
 	}
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Keyword extraction — stop words filtered, words ≤ 2 chars filtered, dedup'd.
-// Python parity: test_keyword_extraction.
-// ─────────────────────────────────────────────────────────────────────────────
+// Decision-rationale query surfaces the entity in entities OR the lowercased
+// token in cleaned. Mirrors the disjunction Python asserts in
+// test_retriever.py:25 — preserved here as a single test rather than split
+// across files.
+func TestParse_EntityOrCleanedSurfacesToken(t *testing.T) {
+	parsed := policy.Parse("Why did we choose PostgreSQL over MySQL?")
 
+	inEntities := false
+	for _, e := range parsed.Entities {
+		if e == "PostgreSQL" {
+			inEntities = true
+			break
+		}
+	}
+	inCleaned := strings.Contains(parsed.Cleaned, "postgresql")
+	if !inEntities && !inCleaned {
+		t.Errorf("token must surface in entities (verbatim) or cleaned (lowercased); entities=%v cleaned=%q",
+			parsed.Entities, parsed.Cleaned)
+	}
+}
+
+// Keyword extraction — content terms retained, stop words and short words
+// filtered, dedup'd post-lowercase. Python parity (test_retriever.py:76-79):
+// test_keyword_extraction. Tightened from Python's OR to AND — both content
+// terms must surface.
 func TestParse_KeywordsRetainsContentTerms(t *testing.T) {
 	parsed := policy.Parse("Why did we choose PostgreSQL for the database?")
 
-	if !contains(parsed.Keywords, "postgresql") && !contains(parsed.Keywords, "database") {
-		t.Errorf("keywords should contain 'postgresql' or 'database', got %v", parsed.Keywords)
+	for _, w := range []string{"postgresql", "database", "choose"} {
+		if !slices.Contains(parsed.Keywords, w) {
+			t.Errorf("keywords should contain %q, got %v", w, parsed.Keywords)
+		}
 	}
 }
 
 func TestParse_KeywordsFiltersStopWords(t *testing.T) {
 	parsed := policy.Parse("Why did we choose PostgreSQL for the database?")
 
-	// Words that must be filtered: 3+ char stop words present in StopWords map.
+	// 3+ char stop words present in StopWords map.
 	for _, w := range []string{"the", "did", "for", "why"} {
-		if contains(parsed.Keywords, w) {
+		if slices.Contains(parsed.Keywords, w) {
 			t.Errorf("keywords should not contain stop word %q, got %v", w, parsed.Keywords)
 		}
 	}
-	// Words that must be filtered by length (≤ 2 chars).
+	// ≤ 2 chars are filtered by length regardless of stop-word membership.
 	for _, w := range []string{"we", "is", "of"} {
-		if contains(parsed.Keywords, w) {
+		if slices.Contains(parsed.Keywords, w) {
 			t.Errorf("keywords should not contain short word %q, got %v", w, parsed.Keywords)
 		}
 	}
 }
 
-func TestParse_KeywordsDeduplicated(t *testing.T) {
+// Cleaning happens before keyword extraction, so by the time dedup runs the
+// strings are already lowercase. This test gates that property: even when
+// the input has multiple casings, the output keyword list contains
+// "postgresql" exactly once. Renamed from the earlier "Deduplicated" name —
+// it does not test case-insensitive dedup at the extractor level (that
+// happens upstream in cleanQuery), only post-lowercase dedup.
+func TestParse_KeywordsDedupAfterLowercase(t *testing.T) {
 	parsed := policy.Parse("PostgreSQL postgresql PostgreSQL database database")
 
 	count := 0
@@ -152,22 +218,26 @@ func TestParse_KeywordsDeduplicated(t *testing.T) {
 			count++
 		}
 	}
-	if count > 1 {
-		t.Errorf("keyword 'postgresql' should appear once, got %d times: %v", count, parsed.Keywords)
+	if count != 1 {
+		t.Errorf("keyword 'postgresql' should appear exactly once, got %d times: %v",
+			count, parsed.Keywords)
 	}
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Query expansion — original included, intent-based variants present,
-// entity-based variants present, capped at 5.
-// Python parity: test_query_expansion.
-// ─────────────────────────────────────────────────────────────────────────────
-
+// Query expansion — the cleaned query, intent variants, and entity-derived
+// strings all appear. Python parity (test_retriever.py:81-86): test_query_expansion.
+// Tightened: also asserts at least one DecisionRationale-prefix variant
+// appears (would catch a regression that deletes the intent switch).
+//
+// Note on query choice: "Why did we choose PostgreSQL?" must match
+// DecisionRationale (`why did we (choose|...)`) — a shorter query like
+// "Why PostgreSQL?" falls through to GENERAL (no intent prefix matches),
+// which exercises a different branch of generateExpansions.
 func TestParse_ExpansionContainsCleanedAndIntentVariants(t *testing.T) {
-	parsed := policy.Parse("Why PostgreSQL?")
+	parsed := policy.Parse("Why did we choose PostgreSQL?")
 
 	if len(parsed.ExpandedQueries) <= 1 {
-		t.Errorf("expanded_queries should have > 1 entry, got %d (%v)",
+		t.Fatalf("expanded_queries should have > 1 entry, got %d (%v)",
 			len(parsed.ExpandedQueries), parsed.ExpandedQueries)
 	}
 
@@ -181,25 +251,69 @@ func TestParse_ExpansionContainsCleanedAndIntentVariants(t *testing.T) {
 	if !foundPostgres {
 		t.Errorf("expanded_queries should reference 'postgresql', got %v", parsed.ExpandedQueries)
 	}
+
+	// DecisionRationale prefixes are: "decision ", "rationale ", "trade-off ".
+	// An empty switch (regression) would leave only [cleaned, entity-variants].
+	gotIntentVariant := false
+	for _, q := range parsed.ExpandedQueries {
+		ql := strings.ToLower(q)
+		if strings.HasPrefix(ql, "decision ") ||
+			strings.HasPrefix(ql, "rationale ") ||
+			strings.HasPrefix(ql, "trade-off ") {
+			gotIntentVariant = true
+			break
+		}
+	}
+	if !gotIntentVariant {
+		t.Errorf("expanded_queries should include a DecisionRationale-prefixed variant, got %v",
+			parsed.ExpandedQueries)
+	}
 }
 
-func TestParse_ExpansionCappedAtFive(t *testing.T) {
-	// Long input with multiple entities + decision_rationale intent should
-	// produce > 5 raw expansions; output must clamp.
+// GENERAL intent gets no intent-prefix variants — only [cleaned, entity-derived].
+// "Why PostgreSQL?" fails every IntentRule and falls through to GENERAL.
+// Documents the fall-through contract so a future change that adds GENERAL
+// expansions has to update this test deliberately.
+func TestParse_ExpansionGeneralIntentNoPrefixes(t *testing.T) {
+	parsed := policy.Parse("Why PostgreSQL?")
+
+	if got := parsed.Intent; got != domain.QueryIntentGeneral {
+		t.Fatalf("precondition: query should classify as GENERAL, got %q", got)
+	}
+	for _, q := range parsed.ExpandedQueries {
+		ql := strings.ToLower(q)
+		if strings.HasPrefix(ql, "decision ") ||
+			strings.HasPrefix(ql, "rationale ") ||
+			strings.HasPrefix(ql, "trade-off ") ||
+			strings.HasPrefix(ql, "customer request ") ||
+			strings.HasPrefix(ql, "feature rejected ") ||
+			strings.HasPrefix(ql, "standard approach ") ||
+			strings.HasPrefix(ql, "best practice ") ||
+			strings.HasPrefix(ql, "architecture ") ||
+			strings.HasPrefix(ql, "implementation ") {
+			t.Errorf("GENERAL intent should produce no intent-prefix variants, found %q in %v",
+				q, parsed.ExpandedQueries)
+		}
+	}
+}
+
+// Expansion cap is exactly 5 when the input would naturally overflow. A
+// regression to a smaller cap (e.g., 3) would be missed by checking only
+// "≤ 5"; this test gates "= 5".
+func TestParse_ExpansionCappedAtExactlyFive(t *testing.T) {
+	// DecisionRationale intent yields 1 (cleaned) + 3 (intent variants) +
+	// 2*N (entity-derived) candidates, easily > 5 with 4 quoted entities.
 	parsed := policy.Parse(`Why did we choose "PostgreSQL" over "MySQL" and "MongoDB" and "Redis"?`)
 
-	if len(parsed.ExpandedQueries) > 5 {
-		t.Errorf("expanded_queries should be capped at 5, got %d (%v)",
+	if len(parsed.ExpandedQueries) != 5 {
+		t.Errorf("expanded_queries should be exactly 5 when input overflows, got %d (%v)",
 			len(parsed.ExpandedQueries), parsed.ExpandedQueries)
 	}
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Cleaning — lowercase, whitespace collapse, leading/trailing trim,
-// trailing-punctuation strip (but keep ?).
-// Beyond Python: explicit table for each transformation.
-// ─────────────────────────────────────────────────────────────────────────────
-
+// Cleaning transformations: lowercase, whitespace collapse (incl. tabs and
+// newlines), leading/trailing trim, trailing-punctuation strip (? preserved,
+// .!,;: stripped including consecutive runs).
 func TestParse_Cleaned(t *testing.T) {
 	cases := []struct {
 		name string
@@ -207,7 +321,9 @@ func TestParse_Cleaned(t *testing.T) {
 		want string
 	}{
 		{"lowercase", "Why PostgreSQL?", "why postgresql?"},
-		{"whitespace_collapse", "Why  PostgreSQL?", "why postgresql?"},
+		{"whitespace_space_collapse", "Why  PostgreSQL?", "why postgresql?"},
+		{"whitespace_tab_collapse", "Why\tPostgreSQL?", "why postgresql?"},
+		{"whitespace_newline_collapse", "Why\nPostgreSQL?", "why postgresql?"},
 		{"trim_leading_trailing", "  Why PostgreSQL?  ", "why postgresql?"},
 		{"strip_trailing_period", "Why PostgreSQL.", "why postgresql"},
 		{"strip_trailing_exclaim", "Why PostgreSQL!", "why postgresql"},
@@ -227,7 +343,7 @@ func TestParse_Cleaned(t *testing.T) {
 	}
 }
 
-// Original is preserved verbatim (case + punctuation + whitespace).
+// Original is preserved verbatim — case, punctuation, whitespace.
 func TestParse_OriginalPreserved(t *testing.T) {
 	in := "Why did we choose PostgreSQL over MySQL?"
 	got := policy.Parse(in).Original
@@ -236,34 +352,29 @@ func TestParse_OriginalPreserved(t *testing.T) {
 	}
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Output caps — entities ≤ 10, keywords ≤ 15, expansions ≤ 5.
-// Spec: docs/v04/spec/types.md §5.2 ParsedQuery (matches Python defaults).
-// ─────────────────────────────────────────────────────────────────────────────
-
+// Output caps must clamp to exactly the documented bounds when input
+// overflows. Spec: docs/v04/spec/types.md §5.2 ParsedQuery
+// (entities ≤ 10, keywords ≤ 15, expansions ≤ 5).
 func TestParse_FieldCaps(t *testing.T) {
-	// Tech-heavy query that would naturally produce > caps without clamping.
-	long := `Why did we choose "Alpha" "Beta" "Gamma" "Delta" "Epsilon" "Zeta" "Eta" "Theta" "Iota" "Kappa" "Lambda" "Mu" PostgreSQL MySQL MongoDB Redis Elasticsearch Kafka React Vue Angular Node Python Java AWS GCP Azure Kubernetes Docker Terraform REST GraphQL gRPC HTTP HTTPS over alternatives?`
+	// Entity-flood input: 12 quoted strings (overflows cap by 2) plus
+	// tech tokens that would also surface, plus enough content words to
+	// overflow the keyword cap.
+	long := buildOverflowQuery()
 	parsed := policy.Parse(long)
 
-	if len(parsed.Entities) > 10 {
-		t.Errorf("Entities cap: got %d, want <= 10", len(parsed.Entities))
+	if got := len(parsed.Entities); got != 10 {
+		t.Errorf("Entities cap: got %d, want exactly 10 when overflowing", got)
 	}
-	if len(parsed.Keywords) > 15 {
-		t.Errorf("Keywords cap: got %d, want <= 15", len(parsed.Keywords))
+	if got := len(parsed.Keywords); got != 15 {
+		t.Errorf("Keywords cap: got %d, want exactly 15 when overflowing", got)
 	}
-	if len(parsed.ExpandedQueries) > 5 {
-		t.Errorf("ExpandedQueries cap: got %d, want <= 5", len(parsed.ExpandedQueries))
+	if got := len(parsed.ExpandedQueries); got != 5 {
+		t.Errorf("ExpandedQueries cap: got %d, want exactly 5 when overflowing", got)
 	}
 }
 
-// helpers
-
-func contains(xs []string, target string) bool {
-	for _, x := range xs {
-		if x == target {
-			return true
-		}
-	}
-	return false
+func buildOverflowQuery() string {
+	// 12 quoted entities (overflows entity cap by 2) plus tech tokens that
+	// add more entity candidates, plus content words to overflow keyword cap.
+	return `Why did we choose "Alpha" "Beta" "Gamma" "Delta" "Epsilon" "Zeta" "Eta" "Theta" "Iota" "Kappa" "Lambda" "Mu" PostgreSQL MySQL MongoDB Redis Elasticsearch Kafka React Vue Angular Node Python Java AWS GCP Azure Kubernetes Docker Terraform REST GraphQL gRPC HTTP HTTPS over alternatives?`
 }

--- a/internal/policy/query_test.go
+++ b/internal/policy/query_test.go
@@ -1,0 +1,269 @@
+// Tests for policy.Parse — port of Python's TestQueryProcessor
+// (agents/tests/test_retriever.py) plus thoroughness-extending cases for
+// every QueryIntent and TimeScope, clean/cap invariants, and stop-word filter.
+//
+// Multilingual tests intentionally omitted: Go port has no Language field
+// (D21 — agent pre-translates before invocation), so the regex/LLM split in
+// the Python QueryProcessor does not exist here.
+//
+// Black-box style (package policy_test) — exercises only the public Parse
+// entry point. Internals (cleanQuery, detectIntent, detectTimeScope,
+// extractEntities, extractKeywords, generateExpansions) are gated through
+// the resulting ParsedQuery fields.
+
+package policy_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/envector/rune-go/internal/domain"
+	"github.com/envector/rune-go/internal/policy"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Intent classification — covers all 7 explicit intents + GENERAL fallback.
+// Python parity tests: test_parse_decision_rationale_query / feature_history /
+// pattern_lookup / technical_context / general_query. The remaining 3 intents
+// (security_compliance, historical_context, attribution) extend beyond the
+// Python suite — same regex tables on both sides, so we gate them here too.
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestParse_IntentClassification(t *testing.T) {
+	cases := []struct {
+		name   string
+		query  string
+		intent domain.QueryIntent
+	}{
+		{"decision_rationale_choose", "Why did we choose PostgreSQL over MySQL?", domain.QueryIntentDecisionRationale},
+		{"decision_rationale_reasoning", "What was the reasoning behind the migration?", domain.QueryIntentDecisionRationale},
+		{"feature_history_customers", "Have customers asked for dark mode?", domain.QueryIntentFeatureHistory},
+		{"pattern_lookup_handle", "How do we handle authentication?", domain.QueryIntentPatternLookup},
+		{"technical_context_arch", "What's our architecture for the payment system?", domain.QueryIntentTechnicalContext},
+		{"security_compliance_gdpr", "What are the GDPR compliance requirements?", domain.QueryIntentSecurityCompliance},
+		{"historical_context_when", "When did we decide to migrate?", domain.QueryIntentHistoricalContext},
+		{"attribution_who", "Who decided to use Redis?", domain.QueryIntentAttribution},
+		{"general_fallback", "Tell me about our database", domain.QueryIntentGeneral},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := policy.Parse(tc.query).Intent
+			if got != tc.intent {
+				t.Errorf("Parse(%q).Intent = %q, want %q", tc.query, got, tc.intent)
+			}
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Time scope detection — all 4 explicit scopes + ALL_TIME default.
+// Python parity: test_time_scope_detection. Beyond Python: month/year and
+// numeric Q[1-4] / 20\d{2} matchers.
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestParse_TimeScope(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+		scope domain.TimeScope
+	}{
+		{"last_week_phrase", "What decisions did we make last week?", domain.TimeScopeLastWeek},
+		{"last_quarter_q3", "What happened in Q3?", domain.TimeScopeLastQuarter},
+		{"last_month_phrase", "What did we decide last month?", domain.TimeScopeLastMonth},
+		{"last_year_phrase", "What was decided last year?", domain.TimeScopeLastYear},
+		{"last_year_numeric_2025", "Did we decide in 2025?", domain.TimeScopeLastYear},
+		{"all_time_default", "Why PostgreSQL?", domain.TimeScopeAllTime},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := policy.Parse(tc.query).TimeScope
+			if got != tc.scope {
+				t.Errorf("Parse(%q).TimeScope = %q, want %q", tc.query, got, tc.scope)
+			}
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Entity extraction — quoted strings, capitalized words, tech name patterns.
+// Python parity: test_entity_extraction_quoted / _capitalized.
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestParse_EntitiesQuoted(t *testing.T) {
+	parsed := policy.Parse(`Why did we choose "React Native"?`)
+
+	if !contains(parsed.Entities, "React Native") {
+		t.Errorf("entities should contain 'React Native', got %v", parsed.Entities)
+	}
+}
+
+func TestParse_EntitiesCapitalizedAndTechPatterns(t *testing.T) {
+	parsed := policy.Parse("Why did we use PostgreSQL instead of MySQL?")
+
+	// Either capitalized scan or tech-pattern matcher should surface both.
+	// Strip trailing punctuation that strings.Fields keeps attached.
+	entitiesLower := make(map[string]bool)
+	for _, e := range parsed.Entities {
+		entitiesLower[strings.ToLower(strings.TrimRight(e, "?.,!;:"))] = true
+	}
+	if !entitiesLower["postgresql"] && !entitiesLower["mysql"] {
+		t.Errorf("entities should contain PostgreSQL or MySQL, got %v", parsed.Entities)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Keyword extraction — stop words filtered, words ≤ 2 chars filtered, dedup'd.
+// Python parity: test_keyword_extraction.
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestParse_KeywordsRetainsContentTerms(t *testing.T) {
+	parsed := policy.Parse("Why did we choose PostgreSQL for the database?")
+
+	if !contains(parsed.Keywords, "postgresql") && !contains(parsed.Keywords, "database") {
+		t.Errorf("keywords should contain 'postgresql' or 'database', got %v", parsed.Keywords)
+	}
+}
+
+func TestParse_KeywordsFiltersStopWords(t *testing.T) {
+	parsed := policy.Parse("Why did we choose PostgreSQL for the database?")
+
+	// Words that must be filtered: 3+ char stop words present in StopWords map.
+	for _, w := range []string{"the", "did", "for", "why"} {
+		if contains(parsed.Keywords, w) {
+			t.Errorf("keywords should not contain stop word %q, got %v", w, parsed.Keywords)
+		}
+	}
+	// Words that must be filtered by length (≤ 2 chars).
+	for _, w := range []string{"we", "is", "of"} {
+		if contains(parsed.Keywords, w) {
+			t.Errorf("keywords should not contain short word %q, got %v", w, parsed.Keywords)
+		}
+	}
+}
+
+func TestParse_KeywordsDeduplicated(t *testing.T) {
+	parsed := policy.Parse("PostgreSQL postgresql PostgreSQL database database")
+
+	count := 0
+	for _, k := range parsed.Keywords {
+		if k == "postgresql" {
+			count++
+		}
+	}
+	if count > 1 {
+		t.Errorf("keyword 'postgresql' should appear once, got %d times: %v", count, parsed.Keywords)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Query expansion — original included, intent-based variants present,
+// entity-based variants present, capped at 5.
+// Python parity: test_query_expansion.
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestParse_ExpansionContainsCleanedAndIntentVariants(t *testing.T) {
+	parsed := policy.Parse("Why PostgreSQL?")
+
+	if len(parsed.ExpandedQueries) <= 1 {
+		t.Errorf("expanded_queries should have > 1 entry, got %d (%v)",
+			len(parsed.ExpandedQueries), parsed.ExpandedQueries)
+	}
+
+	foundPostgres := false
+	for _, q := range parsed.ExpandedQueries {
+		if strings.Contains(strings.ToLower(q), "postgresql") {
+			foundPostgres = true
+			break
+		}
+	}
+	if !foundPostgres {
+		t.Errorf("expanded_queries should reference 'postgresql', got %v", parsed.ExpandedQueries)
+	}
+}
+
+func TestParse_ExpansionCappedAtFive(t *testing.T) {
+	// Long input with multiple entities + decision_rationale intent should
+	// produce > 5 raw expansions; output must clamp.
+	parsed := policy.Parse(`Why did we choose "PostgreSQL" over "MySQL" and "MongoDB" and "Redis"?`)
+
+	if len(parsed.ExpandedQueries) > 5 {
+		t.Errorf("expanded_queries should be capped at 5, got %d (%v)",
+			len(parsed.ExpandedQueries), parsed.ExpandedQueries)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cleaning — lowercase, whitespace collapse, leading/trailing trim,
+// trailing-punctuation strip (but keep ?).
+// Beyond Python: explicit table for each transformation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestParse_Cleaned(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"lowercase", "Why PostgreSQL?", "why postgresql?"},
+		{"whitespace_collapse", "Why  PostgreSQL?", "why postgresql?"},
+		{"trim_leading_trailing", "  Why PostgreSQL?  ", "why postgresql?"},
+		{"strip_trailing_period", "Why PostgreSQL.", "why postgresql"},
+		{"strip_trailing_exclaim", "Why PostgreSQL!", "why postgresql"},
+		{"strip_trailing_comma", "Why PostgreSQL,", "why postgresql"},
+		{"strip_trailing_colon", "Why PostgreSQL:", "why postgresql"},
+		{"strip_trailing_semicolon", "Why PostgreSQL;", "why postgresql"},
+		{"keep_question_mark", "Why PostgreSQL?", "why postgresql?"},
+		{"strip_multiple_trailing", "Why PostgreSQL...", "why postgresql"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := policy.Parse(tc.in).Cleaned
+			if got != tc.want {
+				t.Errorf("Cleaned: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Original is preserved verbatim (case + punctuation + whitespace).
+func TestParse_OriginalPreserved(t *testing.T) {
+	in := "Why did we choose PostgreSQL over MySQL?"
+	got := policy.Parse(in).Original
+	if got != in {
+		t.Errorf("Original: got %q, want %q", got, in)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Output caps — entities ≤ 10, keywords ≤ 15, expansions ≤ 5.
+// Spec: docs/v04/spec/types.md §5.2 ParsedQuery (matches Python defaults).
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestParse_FieldCaps(t *testing.T) {
+	// Tech-heavy query that would naturally produce > caps without clamping.
+	long := `Why did we choose "Alpha" "Beta" "Gamma" "Delta" "Epsilon" "Zeta" "Eta" "Theta" "Iota" "Kappa" "Lambda" "Mu" PostgreSQL MySQL MongoDB Redis Elasticsearch Kafka React Vue Angular Node Python Java AWS GCP Azure Kubernetes Docker Terraform REST GraphQL gRPC HTTP HTTPS over alternatives?`
+	parsed := policy.Parse(long)
+
+	if len(parsed.Entities) > 10 {
+		t.Errorf("Entities cap: got %d, want <= 10", len(parsed.Entities))
+	}
+	if len(parsed.Keywords) > 15 {
+		t.Errorf("Keywords cap: got %d, want <= 15", len(parsed.Keywords))
+	}
+	if len(parsed.ExpandedQueries) > 5 {
+		t.Errorf("ExpandedQueries cap: got %d, want <= 5", len(parsed.ExpandedQueries))
+	}
+}
+
+// helpers
+
+func contains(xs []string, target string) bool {
+	for _, x := range xs {
+		if x == target {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Warning: This PR is created by Claude.

## Summary

- **What:** `internal/policy/query_test.go` + `internal/domain/query_test.go` 신규. 테스트 only, production 코드 변경 없음.
- **Why:** `policy/query.go` (Python `query_processor.py` bit-identical 포팅) 와 `domain/query.go` 의 helpers (`IsReliable`/`IsPhase`/`ExtractPayloadText`) 에 테스트 0건. silent drift 시 recall accuracy 가 무성으로 떨어짐.
- **Scope:** `agents/tests/test_retriever.py::TestQueryProcessor` 의 **11개 중 10개 포팅** + Python 이 안 가드한 invariant 추가. 나머지 클래스는 Go 등가 코드 없음/D21/D28 로 모두 N/A.

### Python 대비 매핑

| Python 클래스 | 처리 | 사유 |
|---|---|---|
| TestQueryProcessor (11) | **10 포팅** | `test_format_for_search` 만 N/A — Go 에 `format_for_search` 미존재 |
| TestQueryProcessorMultilingual (8) | N/A | **D21** — agent pre-translates, Go `ParsedQuery` 에 `Language` 필드 없음 |
| TestSearcher / TestExpandPhaseChains | N/A | searcher Go 등가물 = `service/recall.go` (Phase 5, TODO 다수) |
| TestSynthesizer* (3 클래스) | N/A | **D28** — agent-delegated, Go 에 synthesis 자체 없음 |
| TestDisplayTextLocalization / FormatAnswer | N/A | display/synthesis 영역, recall 외부 |

### 강화 포인트 (Python 미가드)

- 모든 `QueryIntent` 8개 / `TimeScope` 5개 망라 (Python 은 4 of 8, 2 of 5)
- 규칙 iteration 순서 precedence (intent + time)
- Cap 정확값 (`len == 5/10/15`, `≤` 아님)
- AND assertion (Python 의 OR 보다 strict)
- GENERAL intent fall-through contract
- Stop word + length filter + dedup count exact-1
- 1999 negative boundary (`20\d{2}` 패턴 강제)

## Validation

- [x] `go test -count=1 -race ./internal/policy/ ./internal/domain/` → ok (~1.4s, 27 함수 / 68 subtest)
- [x] `gofmt -l` / `go vet` → clean
- [x] **사전 리뷰 적용**: 3 서브에이전트 (adversarial / Python parity / Go style) 가 잡은 HIGH 발견 모두 반영 (OR→AND, exact-cap, 규칙 precedence, `slices.Contains`, package doc 충돌 회피, table-driven `IsPhase`)

## Cross-Agent Invariants

테스트 파일 2개만 추가. **scripts/bootstrap-mcp.sh, agent 스크립트, Codex/Claude/Gemini/OpenAI 지시서, SKILL.md, commands/rune/*.toml, AGENT_INTEGRATION.md 모두 미수정** → 모든 invariant trivially 만족.

## Notes for Reviewers

- **Risk:** `TestSearchHit_IsPhase/group_id_pointer_to_empty_string` 가 현재 동작 (pointer 존재만 보고 `IsPhase=true`) 을 lock-in. 팀이 빈 문자열을 "phase 아님" 으로 결정하면 production `IsPhase` 와 같이 수정 필요. 코드에 `TODO(yg)` 표시.
- **BC:** 없음 (test-only).
- **Follow-up:** `policy/{rerank,novelty,record_builder,payload_text,pii}.go`, `domain/schema.go` (Python golden 비교 추천), `lifecycle/shutdown.go::ZeroizeDEK` (dead-store 최적화 가드 필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
