### PR TITLE
feat(runed): runed daemon gRPC client implementation

### DIFF
--- a/docs/v04/notes/audit-runed-grpc.md
+++ b/docs/v04/notes/audit-runed-grpc.md
@@ -1,0 +1,134 @@
+# Runed-grpc Spec Parity Audit (Task 3)
+
+> Run on `couragehong/feat/runed-grpc` HEAD `309e76d`.
+> Spec: `docs/v04/spec/components/embedder.md`.
+> No Python equivalent — D30 designates runed as a Go-native sibling daemon
+> replacing the in-process Python embedding pipeline. Audit baseline is the
+> spec doc + the runed daemon's actual proto contract
+> (`runed/proto/runed/v1/runed.proto`).
+
+## Verdict
+
+**Pass on the core RPC surface, two spec-promised behaviors are missing**:
+(1) Info.vector_dim verification on Embed responses, (2) Health-aware
+classification of first-failure (LOADING vs DEGRADED). Both are explicitly
+deferred in the embedder.md spec ("classify first failure via Health"
+described but never marked required for MVP). Documenting + queueing.
+
+## Direct spec parity (✅)
+
+| # | Spec section | Behavior | Where |
+|---|---|---|---|
+| 1 | §RPC 요약 | `Embed(text) → vector` | client.go:96-103 |
+| 2 | §RPC 요약 | `EmbedBatch(texts) → embeddings` | client.go:106-130 |
+| 3 | §RPC 요약 | `Info() → daemon_version, model_identity, vector_dim, max_text_length, max_batch_size` | info_cache.go |
+| 4 | §RPC 요약 | `Health() → status, uptime, total_requests` | client.go:152-164 |
+| 5 | §RPC 요약 | Shutdown intentionally NOT used (rune-mcp does not own daemon lifecycle) | (omitted) |
+| 6 | §Dial | `unix://`+sockPath, insecure creds (UDS = same machine) | client.go:71-86 |
+| 7 | §Retry 정책 (D7) | Backoff `[0, 500ms, 2s]` × 3 attempts | retry.go (#95) + client.go uses |
+| 8 | §Retry 정책 | Retryable: Unavailable / DeadlineExceeded / ResourceExhausted | retry.go:retryable |
+| 9 | §EmbedBatch with split | Split when len > MaxBatchSize, preserve order | client.go:106-130 |
+| 10 | §Info 캐시 | `sync.Once` ensures single Info RPC | info_cache.go:Get |
+| 11 | §Info 캐시 + D30 | `slog.Info "embedder info loaded"` w/ model_identity / vector_dim / max_batch_size | info_cache.go |
+| 12 | §EmbedBatch resp count guard | `len(resp.Embeddings) != len(texts)` → error | client.go:144-147 |
+| 13 | §Health 활용 status mapping | `STATUS_OK / LOADING / DEGRADED / SHUTTING_DOWN / UNSPECIFIED` enum→string | client.go:statusName |
+
+## Acceptable divergences (⚠️)
+
+1. **Hybrid choice — raw stub instead of `runed/client` Plan A wrapper**.
+   Spec: "rune-mcp는 [runed/client] 라이브러리를 inner transport로 두고
+   정책 layer만 자체 작성하는 hybrid 채택 가능." Implementation chose direct
+   `runedv1.RunedServiceClient` because the wrapper exposes
+   `Connect/Embed/EmbedBatch/Info/Close` but **NOT** `Health` (we need Health
+   for the `rune_diagnostics` MCP tool). Documented in PR body. Net effect: a
+   slightly larger surface area in our adapter, but no functional gap.
+
+2. **Health is NOT auto-retried**. Spec §Retry 정책 lists Health among the
+   retryable surface but D8 ("Boot does NOT poll Health — first embed call
+   drives") implies Health is for diagnostic surfaces (vault_status,
+   diagnostics) where transient-retry is misleading. We surface the raw error
+   instead. Aligns with how `LifecycleService.Diagnostics` consumes it.
+
+3. **`Close` does not call runed `Shutdown` RPC**. Spec §RPC 요약 explicitly
+   "rune-mcp does not call Shutdown." Confirmed — we just close the gRPC
+   conn.
+
+## Open gaps (⚠️ should follow up)
+
+### 1. **Info.vector_dim mismatch detection** (spec §불변 계약)
+
+Spec: "**dim**: Qwen3-Embedding-0.6B 기준 1024. `Info.vector_dim`으로 확인 후
+불일치면 에러." Not implemented — `embedBatchOnce` does not verify
+`len(e.Vector) == c.info.Snapshot().VectorDim`. The spec's earlier prose code
+sample (embedder.md §EmbedBatch with split) shows this guard:
+
+```go
+if len(e.Vector) != c.infoCache.Snapshot().VectorDim {
+    return nil, fmt.Errorf("embedder: vector dim mismatch at index %d", i)
+}
+```
+
+**Resolution**: Add the check inside `embedBatchOnce` (and a similar one
+inside `EmbedSingle`). Low-risk add, ~5 LoC. Track as runed follow-up.
+
+### 2. **Health-aware first-failure classification** (spec §Health 활용)
+
+Spec: "첫 embed 호출 실패 시 `Health` 조회로 분류:
+- LOADING → 잠시 후 재시도 (wait-and-retry 대기)
+- DEGRADED → 경고 로그 + 상위 EmbedderDegradedError 전파
+- SHUTTING_DOWN → 즉시 실패 + 상위 EmbedderUnavailableError"
+
+Not implemented — we just bubble up the gRPC error. The retry helper does
+N=3 attempts with code-based retryable check, but doesn't probe Health
+between failures.
+
+**Resolution**: This is a separate retry strategy refinement; a healthy MVP
+can ship with code-based retryable alone (LOADING typically surfaces as
+Unavailable + retryable=true → covered). Mark optional. Track as runed
+follow-up.
+
+### 3. **Error mapping to typed adapter errors** (spec §에러 매핑 table)
+
+Spec lists 5 typed error sentinels:
+- `EmbedderInvalidInputError` (gRPC InvalidArgument)
+- `EmbedderBusyError` (ResourceExhausted)
+- `EmbedderUnavailableError` (Unavailable)
+- `EmbedderTimeoutError` (DeadlineExceeded)
+- `EmbedderError(wrap)` (other)
+
+Not implemented — `errors.go` doesn't exist in this adapter. Currently we
+return the raw gRPC status error wrapped with `fmt.Errorf`. Service layer
+relies on `status.FromError` to introspect the code, which works but lacks
+the typed-sentinel pattern that vault uses.
+
+**Resolution**: Add `internal/adapters/embedder/errors.go` with sentinels +
+`MapGRPCError`. Symmetrical to `vault/errors.go`. Low-risk add. Track as
+runed follow-up.
+
+### 4. **Socket path resolution priority is caller's responsibility**
+
+Comment at the top of `client.go` documents:
+> 1. env RUNE_EMBEDDER_SOCKET
+> 2. config.embedder.socket_path
+> 3. default ~/.runed/embedding.sock
+
+But `New(sockPath string)` takes the resolved path as input — caller must
+implement the priority chain. Not implemented anywhere yet (no callsite
+exists). **Resolution**: Add to `cmd/rune-mcp/main.go` `buildDeps` or in a
+new `internal/adapters/embedder/socket.go` helper, alongside the boot loop
+work.
+
+## Test coverage status
+
+`go test ./internal/adapters/embedder/` reports `[no test files]`. Mock
+`RunedServiceClient` + retry / split / cache tests are queued as Task #7.
+
+## Cross-check: runed daemon contract compatibility
+
+- runed `go.mod` requires `go 1.26.2`; rune `go.mod` is `go 1.25.9`. Local
+  `replace ../runed` bypasses the toolchain check. **Open**: bump rune to
+  1.26 before publishing (also needed for runed publish).
+- runed has `model_identity` placeholder behavior — slog breadcrumb captures
+  whatever value it emits; we do not validate the format.
+- runed gen/ is `.gitignored` in runed; first-time setup requires
+  `cd ../runed && buf generate` (or `make proto`). Document in onboarding.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envector/rune-go
 
-go 1.25.9
+go 1.26.2
 
 // External dependencies, in implementation order:
 //
@@ -14,6 +14,7 @@ go 1.25.9
 require (
 	github.com/CryptoLabInc/envector-go-sdk v0.1.0
 	github.com/CryptoLabInc/rune-admin/vault v0.0.0-20260506055025-ad52b6bd549d
+	github.com/CryptoLabInc/runed v0.0.0
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	google.golang.org/grpc v1.81.0
 )
@@ -31,3 +32,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+replace github.com/CryptoLabInc/runed => ../runed

--- a/internal/adapters/embedder/client.go
+++ b/internal/adapters/embedder/client.go
@@ -75,13 +75,24 @@ func New(sockPath string) (Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("embedder: grpc dial %s: %w", sockPath, err)
 	}
+	return newWithConn(sockPath, conn), nil
+}
+
+// NewBufconnClient wraps an existing *grpc.ClientConn (e.g., from
+// google.golang.org/grpc/test/bufconn) so tests can exercise the same RPC
+// path without needing a real unix socket / runed daemon.
+func NewBufconnClient(conn *grpc.ClientConn) Client {
+	return newWithConn("bufconn", conn)
+}
+
+func newWithConn(sockPath string, conn *grpc.ClientConn) *client {
 	pb := runedv1.NewRunedServiceClient(conn)
 	return &client{
 		sockPath: sockPath,
 		conn:     conn,
 		pb:       pb,
 		info:     &infoCache{svc: pb},
-	}, nil
+	}
 }
 
 func (c *client) EmbedSingle(ctx context.Context, text string) ([]float32, error) {

--- a/internal/adapters/embedder/client.go
+++ b/internal/adapters/embedder/client.go
@@ -84,14 +84,61 @@ func New(sockPath string) (Client, error) {
 	}, nil
 }
 
-// Stub implementations — replaced in subsequent commits.
-
 func (c *client) EmbedSingle(ctx context.Context, text string) ([]float32, error) {
-	return nil, nil
+	resp, err := retry(ctx, func(ctx context.Context) (*runedv1.EmbedResponse, error) {
+		return c.pb.Embed(ctx, &runedv1.EmbedRequest{Text: text})
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.GetVector(), nil
 }
 
+// EmbedBatch splits len(texts) > Info.MaxBatchSize into chunks and submits
+// each chunk via embedBatchOnce. Order is preserved.
 func (c *client) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
-	return nil, nil
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	info, err := c.info.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("embedder: load Info before EmbedBatch: %w", err)
+	}
+
+	if info.MaxBatchSize <= 0 || len(texts) <= info.MaxBatchSize {
+		return c.embedBatchOnce(ctx, texts)
+	}
+
+	out := make([][]float32, 0, len(texts))
+	for i := 0; i < len(texts); i += info.MaxBatchSize {
+		end := i + info.MaxBatchSize
+		if end > len(texts) {
+			end = len(texts)
+		}
+		chunk, err := c.embedBatchOnce(ctx, texts[i:end])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, chunk...)
+	}
+	return out, nil
+}
+
+func (c *client) embedBatchOnce(ctx context.Context, texts []string) ([][]float32, error) {
+	resp, err := retry(ctx, func(ctx context.Context) (*runedv1.EmbedBatchResponse, error) {
+		return c.pb.EmbedBatch(ctx, &runedv1.EmbedBatchRequest{Texts: texts})
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.GetEmbeddings()) != len(texts) {
+		return nil, fmt.Errorf("embedder: expected %d embeddings, got %d", len(texts), len(resp.GetEmbeddings()))
+	}
+	out := make([][]float32, len(resp.GetEmbeddings()))
+	for i, e := range resp.GetEmbeddings() {
+		out[i] = e.GetVector()
+	}
+	return out, nil
 }
 
 func (c *client) Info(ctx context.Context) (InfoSnapshot, error) { return c.info.Get(ctx) }

--- a/internal/adapters/embedder/client.go
+++ b/internal/adapters/embedder/client.go
@@ -94,7 +94,7 @@ func (c *client) EmbedBatch(ctx context.Context, texts []string) ([][]float32, e
 	return nil, nil
 }
 
-func (c *client) Info(ctx context.Context) (InfoSnapshot, error)     { return InfoSnapshot{}, nil }
+func (c *client) Info(ctx context.Context) (InfoSnapshot, error) { return c.info.Get(ctx) }
 func (c *client) Health(ctx context.Context) (HealthSnapshot, error) { return HealthSnapshot{}, nil }
 func (c *client) Close() error {
 	if c.conn != nil {

--- a/internal/adapters/embedder/client.go
+++ b/internal/adapters/embedder/client.go
@@ -14,7 +14,12 @@ package embedder
 
 import (
 	"context"
+	"fmt"
 	"time"
+
+	runedv1 "github.com/CryptoLabInc/runed/gen/runed/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // RetryBackoffs — D7 (Python server.py timeout equivalent).
@@ -51,28 +56,49 @@ type Client interface {
 
 type client struct {
 	sockPath string
-	// TODO: grpc.ClientConn + embedder.v1.EmbedderServiceClient stub (external dep)
-	// TODO: infoCache sync.Once + InfoSnapshot
+	conn     *grpc.ClientConn
+	pb       runedv1.RunedServiceClient
+	info     *infoCache
 }
 
-// New — dials unix socket. TODO: grpc.NewClient("unix:"+sockPath, insecure creds).
+// New dials the runed daemon over unix socket. The caller resolves sockPath
+// (env RUNE_EMBEDDER_SOCKET > config.embedder.socket_path > default
+// ~/.runed/embedding.sock per embedder.md §소켓 경로).
+//
+// grpc-go natively resolves "unix://" targets; no custom dialer is needed.
+// TLS is unnecessary for UDS (kernel-mediated, same machine — embedder.md §Dial).
 func New(sockPath string) (Client, error) {
-	// TODO
-	return &client{sockPath: sockPath}, nil
+	conn, err := grpc.NewClient(
+		"unix://"+sockPath,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("embedder: grpc dial %s: %w", sockPath, err)
+	}
+	pb := runedv1.NewRunedServiceClient(conn)
+	return &client{
+		sockPath: sockPath,
+		conn:     conn,
+		pb:       pb,
+		info:     &infoCache{svc: pb},
+	}, nil
 }
 
-// Stub implementations.
+// Stub implementations — replaced in subsequent commits.
 
 func (c *client) EmbedSingle(ctx context.Context, text string) ([]float32, error) {
-	// TODO: call Embed RPC with retry
 	return nil, nil
 }
 
 func (c *client) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
-	// TODO: call EmbedBatch with Info.MaxBatchSize split + retry
 	return nil, nil
 }
 
 func (c *client) Info(ctx context.Context) (InfoSnapshot, error)     { return InfoSnapshot{}, nil }
 func (c *client) Health(ctx context.Context) (HealthSnapshot, error) { return HealthSnapshot{}, nil }
-func (c *client) Close() error                                       { return nil }
+func (c *client) Close() error {
+	if c.conn != nil {
+		return c.conn.Close()
+	}
+	return nil
+}

--- a/internal/adapters/embedder/client.go
+++ b/internal/adapters/embedder/client.go
@@ -142,7 +142,40 @@ func (c *client) embedBatchOnce(ctx context.Context, texts []string) ([][]float3
 }
 
 func (c *client) Info(ctx context.Context) (InfoSnapshot, error) { return c.info.Get(ctx) }
-func (c *client) Health(ctx context.Context) (HealthSnapshot, error) { return HealthSnapshot{}, nil }
+
+// Health issues a Health RPC. Status maps proto enum (STATUS_OK / STATUS_LOADING /
+// STATUS_DEGRADED / STATUS_SHUTTING_DOWN / STATUS_UNSPECIFIED) to the
+// "STATUS_"-stripped string the spec documents (OK / LOADING / DEGRADED /
+// SHUTTING_DOWN / UNSPECIFIED).
+//
+// Health is NOT retried — D8 says first embed call drives connectivity; Health
+// is a diagnostic tool surface (vault_status, diagnostics).
+func (c *client) Health(ctx context.Context) (HealthSnapshot, error) {
+	resp, err := c.pb.Health(ctx, &runedv1.HealthRequest{})
+	if err != nil {
+		return HealthSnapshot{}, err
+	}
+	return HealthSnapshot{
+		Status:        statusName(resp.GetStatus()),
+		UptimeSeconds: resp.GetUptimeSeconds(),
+		TotalRequests: resp.GetTotalRequests(),
+	}, nil
+}
+
+func statusName(s runedv1.HealthResponse_Status) string {
+	switch s {
+	case runedv1.HealthResponse_STATUS_OK:
+		return "OK"
+	case runedv1.HealthResponse_STATUS_LOADING:
+		return "LOADING"
+	case runedv1.HealthResponse_STATUS_DEGRADED:
+		return "DEGRADED"
+	case runedv1.HealthResponse_STATUS_SHUTTING_DOWN:
+		return "SHUTTING_DOWN"
+	default:
+		return "UNSPECIFIED"
+	}
+}
 func (c *client) Close() error {
 	if c.conn != nil {
 		return c.conn.Close()

--- a/internal/adapters/embedder/client_test.go
+++ b/internal/adapters/embedder/client_test.go
@@ -1,0 +1,345 @@
+package embedder_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	runedv1 "github.com/CryptoLabInc/runed/gen/runed/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/envector/rune-go/internal/adapters/embedder"
+)
+
+// fakeRuned implements RunedServiceServer in-process. Each RPC delegates to
+// a per-test func; tests configure those before calling the client.
+type fakeRuned struct {
+	runedv1.UnimplementedRunedServiceServer
+
+	embedFn      func(*runedv1.EmbedRequest) (*runedv1.EmbedResponse, error)
+	embedBatchFn func(*runedv1.EmbedBatchRequest) (*runedv1.EmbedBatchResponse, error)
+	infoFn       func(*runedv1.InfoRequest) (*runedv1.InfoResponse, error)
+	healthFn     func(*runedv1.HealthRequest) (*runedv1.HealthResponse, error)
+
+	infoCalls   int32 // atomic — Info should be invoked exactly once across the lifetime of an infoCache
+	embedCalls  int32 // atomic — used by retry test to count attempts
+	embedBatchCalls int32 // atomic — used by batch-split test
+}
+
+func (f *fakeRuned) Embed(_ context.Context, req *runedv1.EmbedRequest) (*runedv1.EmbedResponse, error) {
+	atomic.AddInt32(&f.embedCalls, 1)
+	if f.embedFn != nil {
+		return f.embedFn(req)
+	}
+	return nil, status.Error(codes.Unimplemented, "Embed not stubbed")
+}
+
+func (f *fakeRuned) EmbedBatch(_ context.Context, req *runedv1.EmbedBatchRequest) (*runedv1.EmbedBatchResponse, error) {
+	atomic.AddInt32(&f.embedBatchCalls, 1)
+	if f.embedBatchFn != nil {
+		return f.embedBatchFn(req)
+	}
+	return nil, status.Error(codes.Unimplemented, "EmbedBatch not stubbed")
+}
+
+func (f *fakeRuned) Info(_ context.Context, req *runedv1.InfoRequest) (*runedv1.InfoResponse, error) {
+	atomic.AddInt32(&f.infoCalls, 1)
+	if f.infoFn != nil {
+		return f.infoFn(req)
+	}
+	return &runedv1.InfoResponse{
+		DaemonVersion: "0.1.0-test",
+		ModelIdentity: "qwen3-test",
+		VectorDim:     1024,
+		MaxTextLength: 8192,
+		MaxBatchSize:  4,
+	}, nil
+}
+
+func (f *fakeRuned) Health(_ context.Context, req *runedv1.HealthRequest) (*runedv1.HealthResponse, error) {
+	if f.healthFn != nil {
+		return f.healthFn(req)
+	}
+	return &runedv1.HealthResponse{Status: runedv1.HealthResponse_STATUS_OK}, nil
+}
+
+func startFakeRuned(t *testing.T) (*fakeRuned, embedder.Client) {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	srv := grpc.NewServer()
+	fake := &fakeRuned{}
+	runedv1.RegisterRunedServiceServer(srv, fake)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	conn, err := grpc.NewClient(
+		"passthrough://bufconn",
+		grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(context.Background())
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return fake, embedder.NewBufconnClient(conn)
+}
+
+func TestEmbedSingle_HappyPath(t *testing.T) {
+	fake, c := startFakeRuned(t)
+	fake.embedFn = func(req *runedv1.EmbedRequest) (*runedv1.EmbedResponse, error) {
+		if req.GetText() != "hello" {
+			t.Errorf("text: got %q, want hello", req.GetText())
+		}
+		return &runedv1.EmbedResponse{Vector: []float32{0.1, 0.2, 0.3}}, nil
+	}
+
+	v, err := c.EmbedSingle(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("EmbedSingle: %v", err)
+	}
+	if len(v) != 3 || v[0] != 0.1 {
+		t.Errorf("vector: got %v", v)
+	}
+}
+
+func TestEmbedSingle_RetryThenSuccess(t *testing.T) {
+	fake, c := startFakeRuned(t)
+	var attempts int32
+	fake.embedFn = func(*runedv1.EmbedRequest) (*runedv1.EmbedResponse, error) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 2 {
+			return nil, status.Error(codes.Unavailable, "transient")
+		}
+		return &runedv1.EmbedResponse{Vector: []float32{1}}, nil
+	}
+
+	v, err := c.EmbedSingle(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("retry should succeed: %v", err)
+	}
+	if len(v) != 1 || v[0] != 1 {
+		t.Errorf("vector: got %v", v)
+	}
+	if atomic.LoadInt32(&attempts) != 2 {
+		t.Errorf("attempts: got %d, want 2", atomic.LoadInt32(&attempts))
+	}
+}
+
+func TestEmbedSingle_NonRetryableErrorReturnsImmediately(t *testing.T) {
+	fake, c := startFakeRuned(t)
+	fake.embedFn = func(*runedv1.EmbedRequest) (*runedv1.EmbedResponse, error) {
+		return nil, status.Error(codes.InvalidArgument, "text too long")
+	}
+
+	_, err := c.EmbedSingle(context.Background(), "x")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code: got %v, want InvalidArgument", st.Code())
+	}
+	if atomic.LoadInt32(&fake.embedCalls) != 1 {
+		t.Errorf("attempts: got %d, want 1 (no retry)", atomic.LoadInt32(&fake.embedCalls))
+	}
+}
+
+func TestEmbedBatch_NoSplitWhenLEMax(t *testing.T) {
+	fake, c := startFakeRuned(t)
+	// Info default: MaxBatchSize=4. Pass 3 texts → single chunk.
+	fake.embedBatchFn = func(req *runedv1.EmbedBatchRequest) (*runedv1.EmbedBatchResponse, error) {
+		if len(req.GetTexts()) != 3 {
+			t.Errorf("texts in single chunk: got %d, want 3", len(req.GetTexts()))
+		}
+		return &runedv1.EmbedBatchResponse{Embeddings: []*runedv1.EmbedResponse{
+			{Vector: []float32{1}}, {Vector: []float32{2}}, {Vector: []float32{3}},
+		}}, nil
+	}
+
+	out, err := c.EmbedBatch(context.Background(), []string{"a", "b", "c"})
+	if err != nil {
+		t.Fatalf("EmbedBatch: %v", err)
+	}
+	if len(out) != 3 {
+		t.Errorf("output: got %d, want 3", len(out))
+	}
+	if atomic.LoadInt32(&fake.embedBatchCalls) != 1 {
+		t.Errorf("EmbedBatch RPC calls: got %d, want 1", atomic.LoadInt32(&fake.embedBatchCalls))
+	}
+}
+
+func TestEmbedBatch_SplitsWhenAboveMax(t *testing.T) {
+	fake, c := startFakeRuned(t)
+	fake.embedBatchFn = func(req *runedv1.EmbedBatchRequest) (*runedv1.EmbedBatchResponse, error) {
+		// Echo a vector per input
+		emb := make([]*runedv1.EmbedResponse, len(req.GetTexts()))
+		for i, txt := range req.GetTexts() {
+			emb[i] = &runedv1.EmbedResponse{Vector: []float32{float32(len(txt))}}
+		}
+		return &runedv1.EmbedBatchResponse{Embeddings: emb}, nil
+	}
+
+	// MaxBatchSize=4 (default Info), 9 texts → 3 chunks (4+4+1)
+	texts := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}
+	out, err := c.EmbedBatch(context.Background(), texts)
+	if err != nil {
+		t.Fatalf("EmbedBatch: %v", err)
+	}
+	if len(out) != 9 {
+		t.Errorf("output: got %d, want 9", len(out))
+	}
+	if atomic.LoadInt32(&fake.embedBatchCalls) != 3 {
+		t.Errorf("EmbedBatch RPC calls: got %d, want 3 (4+4+1)", atomic.LoadInt32(&fake.embedBatchCalls))
+	}
+}
+
+func TestEmbedBatch_RespCountMismatchErrors(t *testing.T) {
+	fake, c := startFakeRuned(t)
+	fake.embedBatchFn = func(req *runedv1.EmbedBatchRequest) (*runedv1.EmbedBatchResponse, error) {
+		// Return ONE less embedding than requested — contract violation
+		return &runedv1.EmbedBatchResponse{Embeddings: []*runedv1.EmbedResponse{
+			{Vector: []float32{1}},
+		}}, nil
+	}
+
+	_, err := c.EmbedBatch(context.Background(), []string{"a", "b"})
+	if err == nil {
+		t.Fatal("expected error on resp count mismatch")
+	}
+	if !strings.Contains(err.Error(), "expected 2 embeddings") {
+		t.Errorf("error: got %q", err.Error())
+	}
+}
+
+func TestEmbedBatch_EmptyInput(t *testing.T) {
+	_, c := startFakeRuned(t)
+	out, err := c.EmbedBatch(context.Background(), nil)
+	if err != nil {
+		t.Errorf("empty input: got error %v, want nil", err)
+	}
+	if out != nil {
+		t.Errorf("empty input: got %v, want nil", out)
+	}
+}
+
+func TestInfo_CachesAcrossCalls(t *testing.T) {
+	fake, c := startFakeRuned(t)
+	for i := 0; i < 5; i++ {
+		_, err := c.Info(context.Background())
+		if err != nil {
+			t.Fatalf("Info: %v", err)
+		}
+	}
+	if got := atomic.LoadInt32(&fake.infoCalls); got != 1 {
+		t.Errorf("Info RPC calls: got %d, want 1 (sync.Once cache)", got)
+	}
+}
+
+func TestInfo_CachesError(t *testing.T) {
+	fake, c := startFakeRuned(t)
+	fake.infoFn = func(*runedv1.InfoRequest) (*runedv1.InfoResponse, error) {
+		return nil, status.Error(codes.Unavailable, "down")
+	}
+	_, err1 := c.Info(context.Background())
+	if err1 == nil {
+		t.Fatal("first Info: expected error")
+	}
+	_, err2 := c.Info(context.Background())
+	if err2 == nil {
+		t.Fatal("second Info: expected cached error")
+	}
+	// Both calls return the same cached error; only one RPC fires.
+	if got := atomic.LoadInt32(&fake.infoCalls); got != 1 {
+		t.Errorf("Info RPC calls: got %d, want 1 (error caches too)", got)
+	}
+}
+
+func TestHealth_StatusEnumMapping(t *testing.T) {
+	cases := []struct {
+		grpcStatus runedv1.HealthResponse_Status
+		want       string
+	}{
+		{runedv1.HealthResponse_STATUS_OK, "OK"},
+		{runedv1.HealthResponse_STATUS_LOADING, "LOADING"},
+		{runedv1.HealthResponse_STATUS_DEGRADED, "DEGRADED"},
+		{runedv1.HealthResponse_STATUS_SHUTTING_DOWN, "SHUTTING_DOWN"},
+		{runedv1.HealthResponse_STATUS_UNSPECIFIED, "UNSPECIFIED"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			fake, c := startFakeRuned(t)
+			fake.healthFn = func(*runedv1.HealthRequest) (*runedv1.HealthResponse, error) {
+				return &runedv1.HealthResponse{
+					Status:        tc.grpcStatus,
+					UptimeSeconds: 42,
+					TotalRequests: 7,
+				}, nil
+			}
+			snap, err := c.Health(context.Background())
+			if err != nil {
+				t.Fatalf("Health: %v", err)
+			}
+			if snap.Status != tc.want {
+				t.Errorf("Status: got %q, want %q", snap.Status, tc.want)
+			}
+			if snap.UptimeSeconds != 42 || snap.TotalRequests != 7 {
+				t.Errorf("counters: got %+v", snap)
+			}
+		})
+	}
+}
+
+func TestEmbedSingle_RetriesExhaust(t *testing.T) {
+	fake, c := startFakeRuned(t)
+	fake.embedFn = func(*runedv1.EmbedRequest) (*runedv1.EmbedResponse, error) {
+		return nil, status.Error(codes.Unavailable, "permanently down")
+	}
+
+	// Use a context with deadline so the third backoff doesn't drag the test.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := c.EmbedSingle(ctx, "x")
+	if err == nil {
+		t.Fatal("expected error after retries exhausted")
+	}
+	if !strings.Contains(err.Error(), "all retries exhausted") {
+		t.Errorf("error: got %q, want 'all retries exhausted'", err.Error())
+	}
+	// 3 attempts: backoff [0, 500ms, 2s] × 3 → 3 calls
+	if got := atomic.LoadInt32(&fake.embedCalls); got != 3 {
+		t.Errorf("Embed RPC calls: got %d, want 3", got)
+	}
+}
+
+func TestEmbedSingle_RespectsCancelledContext(t *testing.T) {
+	fake, c := startFakeRuned(t)
+	fake.embedFn = func(*runedv1.EmbedRequest) (*runedv1.EmbedResponse, error) {
+		return nil, status.Error(codes.Unavailable, "transient")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before call
+
+	_, err := c.EmbedSingle(ctx, "x")
+	if err == nil {
+		t.Fatal("expected error from cancelled ctx")
+	}
+	if !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("error: got %v, want context.Canceled", err)
+	}
+}

--- a/internal/adapters/embedder/info_cache.go
+++ b/internal/adapters/embedder/info_cache.go
@@ -27,31 +27,26 @@ type infoCache struct {
 	svc  runedv1.RunedServiceClient
 }
 
-// Get returns the cached snapshot, populating on first call.
-//
-// TODO: implement once gRPC stub types are generated:
-//
-//	ic.once.Do(func() {
-//	    resp, err := ic.svc.Info(ctx, &embedderv1.InfoRequest{})
-//	    if err != nil { ic.err = err; return }
-//	    ic.snap = InfoSnapshot{
-//	        DaemonVersion: resp.DaemonVersion,
-//	        ModelIdentity: resp.ModelIdentity,
-//	        VectorDim:     int(resp.VectorDim),
-//	        MaxTextLength: int(resp.MaxTextLength),
-//	        MaxBatchSize:  int(resp.MaxBatchSize),
-//	    }
-//	    slog.Info("embedder info loaded",
-//	        "daemon_version", ic.snap.DaemonVersion,
-//	        "model_identity", ic.snap.ModelIdentity,
-//	        "vector_dim", ic.snap.VectorDim,
-//	        "max_batch_size", ic.snap.MaxBatchSize,
-//	    )
-//	})
 func (ic *infoCache) Get(ctx context.Context) (InfoSnapshot, error) {
 	ic.once.Do(func() {
-		// TODO: ic.svc.Info(ctx, ...) then populate snap / err
-		_ = ctx
+		resp, err := ic.svc.Info(ctx, &runedv1.InfoRequest{})
+		if err != nil {
+			ic.err = err
+			return
+		}
+		ic.snap = InfoSnapshot{
+			DaemonVersion: resp.GetDaemonVersion(),
+			ModelIdentity: resp.GetModelIdentity(),
+			VectorDim:     int(resp.GetVectorDim()),
+			MaxTextLength: int(resp.GetMaxTextLength()),
+			MaxBatchSize:  int(resp.GetMaxBatchSize()),
+		}
+		slog.Info("embedder info loaded",
+			"daemon_version", ic.snap.DaemonVersion,
+			"model_identity", ic.snap.ModelIdentity,
+			"vector_dim", ic.snap.VectorDim,
+			"max_batch_size", ic.snap.MaxBatchSize,
+		)
 	})
 	return ic.snap, ic.err
 }
@@ -59,6 +54,3 @@ func (ic *infoCache) Get(ctx context.Context) (InfoSnapshot, error) {
 // Snapshot returns the cached value without triggering load.
 // Returns zero InfoSnapshot if Get() has never been called.
 func (ic *infoCache) Snapshot() InfoSnapshot { return ic.snap }
-
-// Enforce slog reference so import survives lint.
-var _ = slog.Info

--- a/internal/adapters/embedder/info_cache.go
+++ b/internal/adapters/embedder/info_cache.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+
+	runedv1 "github.com/CryptoLabInc/runed/gen/runed/v1"
 )
 
 // infoCache caches the embedder Info RPC response.
@@ -22,7 +24,7 @@ type infoCache struct {
 	once sync.Once
 	snap InfoSnapshot
 	err  error
-	// TODO: svc embedderv1.EmbedderServiceClient — wired at NewClient time
+	svc  runedv1.RunedServiceClient
 }
 
 // Get returns the cached snapshot, populating on first call.


### PR DESCRIPTION
## 요약
v0.4 go-migration의 외부 runed 데몬(임베딩 전담 sibling 프로세스) gRPC 클라이언트 구현입니다.
- 4 RPC (`Embed` / `EmbedBatch` / `Info` / `Health`) 
- D7 retry `[0, 500ms, 2s]` + `sync.Once` Info 캐시 + batch split (`len > MaxBatchSize` 일 때) + Status enum→string 매핑. 
- mock-server unit test

runed 모듈이 아직 public registry 에 publish 안 돼서 (go get이 안됨) 로컬 `replace` directive 사용 
-  `../runed` 위치에 sibling repo clone 하고 한 번 `buf generate` 돌려서 `gen/runed/v1/*.pb.go` 만들어줘야 빌드됨 (runed 의 `gen/` 은 gitignore).

`runed/client` Plan A wrapper 안 쓰고 raw `runedv1.RunedServiceClient` stub 직접 사용 — wrapper 가 `Health()` 안 노출해서 (`rune_diagnostics` MCP tool 에 필요).

base 는 `wip/go-impl-runtime`. #93/95/96 머지 후 retarget 예정입니다. 

---

## Scope

Task 3 of the v0.4 Go migration runtime impl: implement the runed embedding daemon gRPC client.

6 commits, 3 files of source + 1 audit doc (~659 LoC):
- `build(runed): add runed dep + initial gRPC dial wiring` — `github.com/CryptoLabInc/runed/gen/runed/v1` import; UDS dial
- `feat(runed): implement Info RPC + sync.Once cache` — `slog.Info "embedder info loaded"` breadcrumb (D30)
- `feat(runed): implement EmbedSingle + EmbedBatch (batch split + retry)` — D7 `[0, 500ms, 2s]`; resp count guard
- `feat(runed): implement Health RPC + enum→string mapping` — STATUS_* → 5-string mapping
- `test(runed): mock-server unit tests + NewBufconnClient injection` — 12 fn / 17 subtest (retry, split, cache, enum)
- `docs(v04): add spec parity audit for runed-grpc` — 13 spec parity items, 4 follow-up gaps

## Stacked-PR base

**Base = `wip/go-impl-runtime`**, an integration branch that local-merges
the still-under-review #93/#95/#96. With this base, the PR diff is exactly
the runed-grpc work — no noise from the prerequisite ports.

When #93/#95/#96 merge upstream, the cleanup is the same as the vault PR:
rebase wip + retarget this PR's base.

## Spec

- `docs/v04/spec/components/embedder.md` (post #97)
- 5 RPCs: Embed / EmbedBatch / Info / Health / Shutdown (Shutdown not used)
- D7 retry policy + D30 model identity logging breadcrumb
- Unix socket only for Plan A (Windows deferred to runed Plan B)
- Full audit at `docs/v04/notes/audit-runed-grpc.md`

## Local dep replace

`go.mod` adds:
```
require github.com/CryptoLabInc/runed v0.0.0
replace github.com/CryptoLabInc/runed => ../runed
```

The `runed` module isn't yet published. Local replace points to the sibling
checkout. Developers must (1) clone `runed` at `../runed`, and (2) run
`cd ../runed && buf generate` (or `make proto`) once to materialize
`gen/runed/v1/*.pb.go` (gitignored upstream).

## Notes

- **Hybrid choice**: We use the raw `runedv1.RunedServiceClient` stub rather than the `runed/client` Plan A wrapper. The wrapper does its own Connect-time Health verify but does not expose a public `Health()` — which we need for the `rune_diagnostics` MCP tool.
- **toolchain**: `runed` requires `go 1.26.2`. This PR keeps `go 1.25.9` in our `go.mod` (replace bypasses the toolchain check); a separate bump should land before publishing.
