### PR TITLE
 fix(vault): #103 follow-up — MapGRPCError + 256MB + tests

### DIFF
--- a/docs/v04/notes/audit-vault-grpc.md
+++ b/docs/v04/notes/audit-vault-grpc.md
@@ -1,0 +1,200 @@
+# Vault gRPC adapter audit (post-#103 contract)
+
+> Run on `couragehong/feat/vault-fixups` against `internal/adapters/vault/`
+> after #103 merged the `GetPublicKey` → `GetAgentManifest` rename and the
+> EvalKey ownership shift to Vault server-side.
+>
+> Spec: `docs/v04/spec/components/vault.md`.
+> Python reference: `mcp/adapter/vault_client.py` (~381 LoC).
+
+## Verdict
+
+**Pass after this PR's three fixups**. The vault adapter as merged in #103
+had three regressions that this branch addresses; with them applied the
+adapter is at full Python-parity for the new agent-manifest contract,
+plus three Go-only safety/observability improvements.
+
+## What this PR fixes
+
+### 1. `MapGRPCError` typed-error fix + complete coverage of server-emitted codes
+
+Two interlocking issues in one fix:
+
+**(1a)** #103 ported the typed-error pattern in `envector/errors.go`
+(`MapSDKError` using `status.FromError + codes.*`) but did not touch
+`vault/errors.go`, which still carried #95's hand-rolled `grpcStatuser`
+interface:
+
+```go
+type grpcStatuser interface {
+    GRPCStatus() interface {
+        Code() int          // ← real *status.Status returns codes.Code (uint32)
+        Message() string
+    }
+}
+```
+
+Go interface satisfaction is by exact signature match. `Code() codes.Code`
+does NOT satisfy `Code() int` (named type vs basic type), so
+`err.(grpcStatuser)` was `false` for every gRPC error. Every status fell
+into the `!ok` branch as `ErrVaultInternal/Retryable: true`, hiding the
+actual code.
+
+Worst impact: `Unauthenticated` (token revoked/expired) gets mis-flagged
+as retryable, triggering infinite retry on auth failure.
+
+**(1b)** While auditing `rune-admin/vault/internal/server/grpc.go`, found
+that the server actually returns three codes the original mapping never
+covered — they all fell to the `default` branch as
+`VAULT_INTERNAL/Retryable: true`:
+
+- `codes.PermissionDenied` (role scope check, role TopK limit) — should
+  be **non-retryable** (role can't be promoted by retry) and a distinct
+  code so callers see "permission denied" not "internal error".
+- `codes.InvalidArgument` (deserialization failure, base64 decode fail,
+  validator rejection) — should be **non-retryable** (same input won't
+  succeed on retry) and a distinct code.
+- `codes.ResourceExhausted` (token rate limit via `mapTokenError`) —
+  retryable=true is fine after backoff, but the code "INTERNAL" is
+  misleading; should be a distinct rate-limit code.
+
+Fix: switched to `status.FromError(err)` + `codes.*` constants, removed
+the hand-rolled `grpcStatus` struct + `statusFromError` helper + `code*`
+constants block, and added three new sentinels:
+
+```go
+ErrVaultPermissionDenied = &Error{Code: "VAULT_PERMISSION_DENIED", Retryable: false}
+ErrVaultInvalidInput     = &Error{Code: "VAULT_INVALID_INPUT",     Retryable: false}
+ErrVaultRateLimited      = &Error{Code: "VAULT_RATE_LIMITED",      Retryable: true}
+```
+
+Now the full code → sentinel table covers everything the server emits
+(`Unauthenticated`, `PermissionDenied`, `InvalidArgument`,
+`ResourceExhausted`, `Internal`) plus transport-layer codes
+(`Unavailable`, `DeadlineExceeded`) plus a legacy `NotFound` mapping
+that's reserved for future server changes.
+
+### 2. `MaxMessageLength` 256MB restored (commit `21a07e2`)
+
+#103 lowered the cap from 256MB → 16MB without justification. Spec
+(`vault.md` §256MB) and Python parity (`vault_client.py:L33`) both call
+for 256MB. Even with EvalKey no longer in the manifest (Vault now owns
+EvalKey/SecKey server-side), the manifest_json still carries EncKey JSON
+content which can run multiple MBs depending on FHE parameters. 16MB
+risks `ResourceExhausted` on future deployments; 256MB matches Python
+without measurable cost.
+
+### 3. bufconn unit tests + `NewBufconnClient` injector
+
+#103 added envector unit tests (`errors_test.go`, `client_integration_test.go`)
+but no vault coverage. Adds **34 test functions / 31 subtest cases** (65
+runs total) covering all four RPC paths, the error-mapping matrix, edge
+cases the original audit caught, and lifecycle invariants:
+
+| Surface | Coverage |
+|---|---|
+| `GetAgentManifest` happy / errors | full bundle equality, omitted `index_name`, response.error string, malformed JSON, ctx cancellation |
+| `decodeAgentDEK` paths | empty agent_dek, invalid base64, length matrix (0 / 16 / 31 / 32 / 33 / 64) |
+| `GetAgentManifest` ↔ MapGRPCError integration | per-RPC matrix for Unauthenticated / PermissionDenied / InvalidArgument / ResourceExhausted / Internal — verifies typed `*Error` reaches the caller |
+| `DecryptScores` | happy path, gRPC error, response.error string, empty results |
+| `DecryptMetadata` | happy path, gRPC error, response.error string, empty list |
+| `HealthCheck` | SERVING / NOT_SERVING / gRPC error → `VAULT_UNAVAILABLE` |
+| `ParseManifestJSON` direct | empty JSON, missing `agent_dek`, not-JSON, forward-compat with stray `EvalKey.json` field |
+| `MapGRPCError` matrix | full 9-code table (Unauthenticated / PermissionDenied / InvalidArgument / ResourceExhausted / NotFound / Unavailable / DeadlineExceeded / Internal / Aborted default), non-gRPC fallback, nil |
+| `MapGRPCError` invariants | `Cause` preservation across all 9 codes, `errors.Is(*Error, original)` chain, `Message` carry-through |
+| `*Error.Error()` formatter | code-only vs `code: message` |
+| Lifecycle | `Endpoint()` returns constructor value, `Close()` is nil-safe (idempotent) |
+
+Plus `NewBufconnClient(*grpc.ClientConn, token) Client` constructor
+factored through `newWithConn` so `NewClient` and `NewBufconnClient`
+share struct init. Useful for tests + production callers that pool
+conns externally.
+
+Run time ~0.4s. No real Vault dependency.
+
+## Spec parity (post-fixups)
+
+| Item | Status | Where |
+|---|---|---|
+| `GetAgentManifest` RPC + 7-field manifest_json parse | ✅ #103 | `client.go:200` |
+| `EvalKey` removed from plugin-side Bundle | ✅ #103 | `client.go:48` |
+| `agent_dek` length-32 validation | ✅ #103 | `client.go:decodeAgentDEK` |
+| `DecryptScores` (token + blob + top_k) | ✅ #103 | `client.go:212` |
+| `DecryptMetadata` (token + list) | ✅ #103 | `client.go:239` |
+| `HealthCheck` Tier 1 grpc_health_v1 service="" | ✅ #103 | `client.go:257` |
+| `MaxMessageLength = 256 MB` | ✅ this PR | `client.go:38` |
+| Endpoint normalization (4-form) | ✅ inherited (`endpoint.go`) | unchanged |
+| TLS modes (system CA / custom CA / insecure) | ✅ #103 | `client.go:160-176` |
+| Keepalive (Time=30s, Timeout=10s, PermitWithoutStream) | ✅ #103 | `client.go:142` |
+| `MapGRPCError` typed mapping (8 sentinels — full coverage of server-emitted + transport codes) | ✅ this PR | `errors.go` |
+| `withTimeout` helper preserves shorter caller deadline | ✅ #103 | `client.go:198` |
+
+## Go-only safety/observability still in place
+
+1. `ValidateAgentDEK`-equivalent length-32 check (now inlined as
+   `decodeAgentDEK`). Python `envector_sdk.py:L139` accepts any size silently.
+2. Typed `*Error` with Code / Retryable / Cause via `MapGRPCError`. Python
+   uses opaque `VaultError(str)` and re-parses by string at the service layer.
+3. `keepalive` params. Python has none — vulnerable to dead-conn first-RPC
+   failures after sleep/wake / NAT timeout.
+
+## Acceptable divergences (⚠️, not blocking)
+
+1. **DecryptResult wrapper vs plain error**. Python wraps app-level failures
+   as `DecryptResult{ok=false, error=…}`; Go returns Go `error` (`*Error`).
+   Service-layer behavior is equivalent.
+2. **DecryptMetadata JSON parse location**. Python parses each item in the
+   client; Go returns raw `[]string` and the service does `json.Unmarshal`
+   per envelope. Spec (`vault.md` L47-48) says caller parses — Go matches
+   spec.
+3. **HealthCheck Tier 2 (HTTP /health) auto-fallback**. Python chains Tier 2
+   inside `health_check()`; Go exposes `HealthFallback` as a standalone
+   function. Per `vault.md §Health 2-tier`, Tier 2 is for diagnostic
+   messaging only — caller (service/lifecycle) decides when to invoke.
+4. **Per-instance timeout configurability**. Python `timeout=30.0` is a
+   ctor param; Go uses package-level `DefaultTimeout` constant. Per-call
+   ctx timeout is the override path.
+5. **Bearer token in metadata header**. #103 sends `authorization: Bearer
+   <token>` as outgoing metadata via `authCtx`, but Vault server reads the
+   token only from `req.GetToken()`. Harmless; possibly future-proofing for
+   header-based auth migration.
+
+## Open follow-up items (not in this PR)
+
+1. **`RUNEVAULT_GRPC_TARGET` env override**. Python `vault_client.py:L108-110`
+   honors this as a gRPC target escape hatch for ops. Belongs in the config
+   loader / Deps construction layer, not the adapter. Track separately.
+2. **Cache `grpc_health_v1.HealthClient` as a struct field**. #103 allocates
+   a fresh client per `HealthCheck` call. Trivial perf, not blocking.
+3. **`response.error` string is uniformly mapped to `Retryable: true`**.
+   Some app-level errors (invalid input, role denied) shouldn't be
+   retryable. Consider a switch on the message — or, better, the server
+   returning a typed code in addition to the message.
+4. **MetadataRef type asymmetry**: `vault.ScoreEntry.ShardIdx` is `int32`
+   while `envector.MetadataRef.ShardIdx` is `uint64`. Same logical value
+   crossing a boundary — minor cleanup if/when it bites.
+
+## Test coverage status
+
+`go test ./internal/adapters/vault/...` reports **34 top-level functions /
+31 subtest cases (65 individual runs), all passing in ~0.4s**. No real
+Vault dependency; bufconn-backed in-process server.
+
+Coverage areas (post this PR):
+
+- All four RPCs (`GetAgentManifest`, `DecryptScores`, `DecryptMetadata`,
+  `HealthCheck`) — happy path + gRPC error path + response.error string
+  path + boundary inputs (empty list, empty results)
+- `decodeAgentDEK` — three error paths exercised (empty / invalid base64 /
+  length matrix 0–64)
+- `MapGRPCError` — full 9-code matrix matching every code rune-admin/vault
+  emits + transport-layer codes + non-gRPC fallback + nil
+- `MapGRPCError` invariants — `Cause` preservation, `errors.Is/As` chain,
+  `Message` carry-through
+- `ParseManifestJSON` direct — empty JSON, missing required field, not-JSON,
+  forward-compat with stale `EvalKey.json`
+- Lifecycle — `Endpoint()` constructor value, `Close()` idempotency,
+  context cancellation propagation
+
+For end-to-end testing against a real Vault (post boot loop landing),
+add a `//go:build integration` test similar to `envector/client_integration_test.go`.

--- a/internal/adapters/vault/client.go
+++ b/internal/adapters/vault/client.go
@@ -34,8 +34,15 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// Applied on both MaxCallRecvMsgSize and MaxCallSendMsgSize
-const MaxMessageLength = 16 * 1024 * 1024
+// MaxMessageLength — 256MB applied on both MaxCallRecvMsgSize and MaxCallSendMsgSize.
+// Python parity: vault_client.py:L33 + spec/components/vault.md §256MB.
+//
+// Even with EvalKey no longer included in the manifest (Vault now owns
+// EvalKey/SecKey server-side), the manifest_json still carries EncKey JSON
+// content which can be on the order of MBs depending on FHE parameters.
+// Keeping the cap at 256MB matches Python's grpcio settings and avoids
+// future ResourceExhausted surprises if EncKey size grows.
+const MaxMessageLength = 256 * 1024 * 1024
 
 // DefaultTimeout — Python vault_client.py:L84 (all RPCs: 30s)
 const DefaultTimeout = 30 * time.Second

--- a/internal/adapters/vault/client.go
+++ b/internal/adapters/vault/client.go
@@ -182,12 +182,26 @@ func NewClient(endpoint, token string, opts ClientOpts) (Client, error) {
 	}
 
 	slog.Info("vault: connected", "endpoint", normalized)
+	return newWithConn(normalized, token, conn), nil
+}
+
+// NewBufconnClient wraps an existing *grpc.ClientConn (e.g., from
+// google.golang.org/grpc/test/bufconn) so tests can exercise the same RPC
+// path without going through DNS / TLS / endpoint normalization.
+//
+// Production callers should prefer NewClient — this constructor intentionally
+// trusts whatever creds + options the conn was built with.
+func NewBufconnClient(conn *grpc.ClientConn, token string) Client {
+	return newWithConn("bufconn", token, conn)
+}
+
+func newWithConn(endpoint, token string, conn *grpc.ClientConn) *client {
 	return &client{
-		endpoint: normalized,
+		endpoint: endpoint,
 		token:    token,
 		conn:     conn,
 		stub:     vaultpb.NewVaultServiceClient(conn),
-	}, nil
+	}
 }
 
 func (c *client) authCtx(ctx context.Context) context.Context {

--- a/internal/adapters/vault/client_test.go
+++ b/internal/adapters/vault/client_test.go
@@ -1,0 +1,788 @@
+package vault_test
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	vaultpb "github.com/CryptoLabInc/rune-admin/vault/pkg/vaultpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/envector/rune-go/internal/adapters/vault"
+)
+
+// fakeServer implements VaultServiceServer + HealthServer for in-process tests.
+// All responses are programmable per-call via the corresponding func fields.
+type fakeServer struct {
+	vaultpb.UnimplementedVaultServiceServer
+	healthpb.UnimplementedHealthServer
+
+	getAgentManifestFn func(*vaultpb.GetAgentManifestRequest) (*vaultpb.GetAgentManifestResponse, error)
+	decryptScoresFn    func(*vaultpb.DecryptScoresRequest) (*vaultpb.DecryptScoresResponse, error)
+	decryptMetadataFn  func(*vaultpb.DecryptMetadataRequest) (*vaultpb.DecryptMetadataResponse, error)
+	healthFn           func(*healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error)
+}
+
+func (f *fakeServer) GetAgentManifest(_ context.Context, req *vaultpb.GetAgentManifestRequest) (*vaultpb.GetAgentManifestResponse, error) {
+	if f.getAgentManifestFn != nil {
+		return f.getAgentManifestFn(req)
+	}
+	return nil, status.Error(codes.Unimplemented, "test server: GetAgentManifest not stubbed")
+}
+
+func (f *fakeServer) DecryptScores(_ context.Context, req *vaultpb.DecryptScoresRequest) (*vaultpb.DecryptScoresResponse, error) {
+	if f.decryptScoresFn != nil {
+		return f.decryptScoresFn(req)
+	}
+	return nil, status.Error(codes.Unimplemented, "test server: DecryptScores not stubbed")
+}
+
+func (f *fakeServer) DecryptMetadata(_ context.Context, req *vaultpb.DecryptMetadataRequest) (*vaultpb.DecryptMetadataResponse, error) {
+	if f.decryptMetadataFn != nil {
+		return f.decryptMetadataFn(req)
+	}
+	return nil, status.Error(codes.Unimplemented, "test server: DecryptMetadata not stubbed")
+}
+
+func (f *fakeServer) Check(_ context.Context, req *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+	if f.healthFn != nil {
+		return f.healthFn(req)
+	}
+	return &healthpb.HealthCheckResponse{Status: healthpb.HealthCheckResponse_SERVING}, nil
+}
+
+// startFakeServer spins up a bufconn-backed server and returns a connected
+// vault.Client + cleanup function. Tests modify fake.* func fields between
+// dial and call to control responses.
+func startFakeServer(t *testing.T) (*fakeServer, vault.Client) {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	srv := grpc.NewServer()
+	fake := &fakeServer{}
+	vaultpb.RegisterVaultServiceServer(srv, fake)
+	healthpb.RegisterHealthServer(srv, fake)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	conn, err := grpc.NewClient(
+		"passthrough://bufconn",
+		grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(context.Background())
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	c := vault.NewBufconnClient(conn, "test-token")
+	return fake, c
+}
+
+// validManifestJSON returns a JSON string matching Vault's GetAgentManifest
+// payload shape (rune-admin/vault/internal/server/grpc.go buildBundle).
+// Note: post-#103 the manifest no longer carries EvalKey.json.
+func validManifestJSON(t *testing.T) string {
+	t.Helper()
+	dek := make([]byte, 32)
+	for i := range dek {
+		dek[i] = byte(i)
+	}
+	return `{
+		"EncKey.json": "<enc-bytes>",
+		"key_id": "key_test",
+		"index_name": "test-index",
+		"agent_id": "agent_test",
+		"agent_dek": "` + base64.StdEncoding.EncodeToString(dek) + `",
+		"envector_endpoint": "https://envector.test",
+		"envector_api_key": "env_apikey"
+	}`
+}
+
+func TestGetAgentManifest_HappyPath(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.getAgentManifestFn = func(req *vaultpb.GetAgentManifestRequest) (*vaultpb.GetAgentManifestResponse, error) {
+		if req.GetToken() != "test-token" {
+			return nil, status.Error(codes.Unauthenticated, "wrong token")
+		}
+		return &vaultpb.GetAgentManifestResponse{ManifestJson: validManifestJSON(t)}, nil
+	}
+
+	bundle, err := c.GetAgentManifest(context.Background())
+	if err != nil {
+		t.Fatalf("GetAgentManifest: %v", err)
+	}
+	if bundle.KeyID != "key_test" {
+		t.Errorf("KeyID: got %q, want key_test", bundle.KeyID)
+	}
+	if bundle.IndexName != "test-index" {
+		t.Errorf("IndexName: got %q, want test-index", bundle.IndexName)
+	}
+	if bundle.AgentID != "agent_test" {
+		t.Errorf("AgentID: got %q, want agent_test", bundle.AgentID)
+	}
+	if len(bundle.AgentDEK) != 32 {
+		t.Errorf("AgentDEK length: got %d, want 32", len(bundle.AgentDEK))
+	}
+	if bundle.EnvectorEndpoint != "https://envector.test" {
+		t.Errorf("EnvectorEndpoint: got %q", bundle.EnvectorEndpoint)
+	}
+}
+
+func TestGetAgentManifest_ResponseErrorString(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.getAgentManifestFn = func(*vaultpb.GetAgentManifestRequest) (*vaultpb.GetAgentManifestResponse, error) {
+		return &vaultpb.GetAgentManifestResponse{Error: "manifest build failed"}, nil
+	}
+
+	_, err := c.GetAgentManifest(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var ve *vault.Error
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *vault.Error, got %T: %v", err, err)
+	}
+	if ve.Code != "VAULT_INTERNAL" {
+		t.Errorf("Code: got %q, want VAULT_INTERNAL", ve.Code)
+	}
+	if !strings.Contains(ve.Message, "manifest build failed") {
+		t.Errorf("Message: got %q, want substring 'manifest build failed'", ve.Message)
+	}
+}
+
+func TestGetAgentManifest_BadDEKLength(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.getAgentManifestFn = func(*vaultpb.GetAgentManifestRequest) (*vaultpb.GetAgentManifestResponse, error) {
+		// 16 bytes — wrong (must be 32 for AES-256)
+		dek := base64.StdEncoding.EncodeToString(make([]byte, 16))
+		return &vaultpb.GetAgentManifestResponse{
+			ManifestJson: `{"agent_dek": "` + dek + `"}`,
+		}, nil
+	}
+
+	_, err := c.GetAgentManifest(context.Background())
+	if err == nil {
+		t.Fatal("expected error for bad DEK length, got nil")
+	}
+	if !strings.Contains(err.Error(), "agent_dek size 16") {
+		t.Errorf("error message: got %q, want substring 'agent_dek size 16'", err.Error())
+	}
+}
+
+func TestGetAgentManifest_MalformedJSON(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.getAgentManifestFn = func(*vaultpb.GetAgentManifestRequest) (*vaultpb.GetAgentManifestResponse, error) {
+		return &vaultpb.GetAgentManifestResponse{ManifestJson: "not json {"}, nil
+	}
+
+	_, err := c.GetAgentManifest(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse manifest_json") {
+		t.Errorf("error: got %q, want 'parse manifest_json' substring", err.Error())
+	}
+}
+
+func TestParseManifestJSON_DropsEvalKeyField(t *testing.T) {
+	// EvalKey.json field, if present (legacy manifest), is silently ignored — the
+	// new contract drops it from the plugin-side Bundle. Verifies forward compat
+	// with stale Vault responses that still include EvalKey.json.
+	rawWithEval := `{
+		"EncKey.json": "enc",
+		"EvalKey.json": "eval-should-be-ignored",
+		"key_id": "k",
+		"agent_id": "a",
+		"agent_dek": "` + base64.StdEncoding.EncodeToString(make([]byte, 32)) + `",
+		"envector_endpoint": "https://e",
+		"envector_api_key": "k",
+		"index_name": "i"
+	}`
+	bundle, err := vault.ParseManifestJSON(rawWithEval)
+	if err != nil {
+		t.Fatalf("ParseManifestJSON: %v", err)
+	}
+	// Bundle struct doesn't have an EvalKey field — extra JSON key is ignored.
+	if string(bundle.EncKey) != "enc" {
+		t.Errorf("EncKey: got %q, want enc", string(bundle.EncKey))
+	}
+}
+
+func TestDecryptScores_HappyPath(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.decryptScoresFn = func(req *vaultpb.DecryptScoresRequest) (*vaultpb.DecryptScoresResponse, error) {
+		if req.GetTopK() != 5 {
+			t.Errorf("top_k: got %d, want 5", req.GetTopK())
+		}
+		if req.GetEncryptedBlobB64() != "blob123" {
+			t.Errorf("blob: got %q", req.GetEncryptedBlobB64())
+		}
+		return &vaultpb.DecryptScoresResponse{
+			Results: []*vaultpb.ScoreEntry{
+				{ShardIdx: 0, RowIdx: 1, Score: 0.95},
+				{ShardIdx: 0, RowIdx: 2, Score: 0.80},
+			},
+		}, nil
+	}
+
+	out, err := c.DecryptScores(context.Background(), "blob123", 5)
+	if err != nil {
+		t.Fatalf("DecryptScores: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("results: got %d, want 2", len(out))
+	}
+	if out[0].Score != 0.95 || out[0].RowIdx != 1 {
+		t.Errorf("results[0]: got %+v", out[0])
+	}
+}
+
+func TestDecryptMetadata_HappyPath(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.decryptMetadataFn = func(req *vaultpb.DecryptMetadataRequest) (*vaultpb.DecryptMetadataResponse, error) {
+		if len(req.GetEncryptedMetadataList()) != 2 {
+			t.Errorf("list len: got %d, want 2", len(req.GetEncryptedMetadataList()))
+		}
+		return &vaultpb.DecryptMetadataResponse{
+			DecryptedMetadata: []string{`{"a":1}`, `{"b":2}`},
+		}, nil
+	}
+
+	out, err := c.DecryptMetadata(context.Background(), []string{"env1", "env2"})
+	if err != nil {
+		t.Fatalf("DecryptMetadata: %v", err)
+	}
+	if len(out) != 2 || out[0] != `{"a":1}` || out[1] != `{"b":2}` {
+		t.Errorf("decrypted: got %v", out)
+	}
+}
+
+func TestHealthCheck_Serving(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.healthFn = func(*healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+		return &healthpb.HealthCheckResponse{Status: healthpb.HealthCheckResponse_SERVING}, nil
+	}
+
+	healthy, err := c.HealthCheck(context.Background())
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if !healthy {
+		t.Error("expected healthy=true")
+	}
+}
+
+func TestHealthCheck_NotServing(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.healthFn = func(*healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+		return &healthpb.HealthCheckResponse{Status: healthpb.HealthCheckResponse_NOT_SERVING}, nil
+	}
+
+	healthy, err := c.HealthCheck(context.Background())
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if healthy {
+		t.Error("expected healthy=false")
+	}
+}
+
+// MapGRPCError code matrix — verifies every code rune-admin/vault server
+// emits (PermissionDenied, InvalidArgument, ResourceExhausted, Unauthenticated,
+// Internal) plus the transport-layer codes (Unavailable, DeadlineExceeded)
+// and the legacy NotFound mapping. Retryable flags follow the audit:
+// permission / input failures are non-retryable; transport / rate / internal
+// are retryable.
+func TestMapGRPCError_CodeMatrix(t *testing.T) {
+	cases := []struct {
+		name      string
+		grpcCode  codes.Code
+		wantCode  string
+		retryable bool
+	}{
+		{"Unauthenticated → AUTH_FAILED", codes.Unauthenticated, "VAULT_AUTH_FAILED", false},
+		{"PermissionDenied → PERMISSION_DENIED", codes.PermissionDenied, "VAULT_PERMISSION_DENIED", false},
+		{"InvalidArgument → INVALID_INPUT", codes.InvalidArgument, "VAULT_INVALID_INPUT", false},
+		{"ResourceExhausted → RATE_LIMITED", codes.ResourceExhausted, "VAULT_RATE_LIMITED", true},
+		{"NotFound → KEY_NOT_FOUND", codes.NotFound, "VAULT_KEY_NOT_FOUND", false},
+		{"Unavailable → UNAVAILABLE", codes.Unavailable, "VAULT_UNAVAILABLE", true},
+		{"DeadlineExceeded → TIMEOUT", codes.DeadlineExceeded, "VAULT_TIMEOUT", true},
+		{"Internal → INTERNAL", codes.Internal, "VAULT_INTERNAL", true},
+		{"Aborted → INTERNAL (default)", codes.Aborted, "VAULT_INTERNAL", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := vault.MapGRPCError(status.Error(tc.grpcCode, "test message"))
+			var ve *vault.Error
+			if !errors.As(err, &ve) {
+				t.Fatalf("expected *vault.Error, got %T", err)
+			}
+			if ve.Code != tc.wantCode {
+				t.Errorf("Code: got %q, want %q", ve.Code, tc.wantCode)
+			}
+			if ve.Retryable != tc.retryable {
+				t.Errorf("Retryable: got %v, want %v", ve.Retryable, tc.retryable)
+			}
+		})
+	}
+}
+
+func TestMapGRPCError_NonGRPCFallback(t *testing.T) {
+	err := vault.MapGRPCError(errors.New("plain error"))
+	var ve *vault.Error
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *vault.Error, got %T", err)
+	}
+	if ve.Code != "VAULT_INTERNAL" {
+		t.Errorf("non-gRPC error: got Code %q, want VAULT_INTERNAL", ve.Code)
+	}
+}
+
+func TestMapGRPCError_NilReturnsNil(t *testing.T) {
+	if got := vault.MapGRPCError(nil); got != nil {
+		t.Errorf("MapGRPCError(nil): got %v, want nil", got)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Edge-case coverage for decodeAgentDEK paths via GetAgentManifest.
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestGetAgentManifest_EmptyDEK(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.getAgentManifestFn = func(*vaultpb.GetAgentManifestRequest) (*vaultpb.GetAgentManifestResponse, error) {
+		// agent_dek empty string → fast-path "agent_dek is empty"
+		return &vaultpb.GetAgentManifestResponse{
+			ManifestJson: `{"agent_dek": ""}`,
+		}, nil
+	}
+
+	_, err := c.GetAgentManifest(context.Background())
+	if err == nil {
+		t.Fatal("expected error for empty agent_dek, got nil")
+	}
+	if !strings.Contains(err.Error(), "agent_dek is empty") {
+		t.Errorf("error: got %q, want substring 'agent_dek is empty'", err.Error())
+	}
+}
+
+func TestGetAgentManifest_InvalidBase64DEK(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.getAgentManifestFn = func(*vaultpb.GetAgentManifestRequest) (*vaultpb.GetAgentManifestResponse, error) {
+		// invalid base64 chars
+		return &vaultpb.GetAgentManifestResponse{
+			ManifestJson: `{"agent_dek": "!!!@@@$$$"}`,
+		}, nil
+	}
+
+	_, err := c.GetAgentManifest(context.Background())
+	if err == nil {
+		t.Fatal("expected error for invalid base64 agent_dek, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid base64") {
+		t.Errorf("error: got %q, want substring 'invalid base64'", err.Error())
+	}
+}
+
+func TestGetAgentManifest_DEKLengthMatrix(t *testing.T) {
+	cases := []struct {
+		name      string
+		dekLen    int
+		shouldErr bool
+	}{
+		{"0 bytes (would hit empty path if base64 round-trips to '')", 0, true}, // base64("") = "" → empty fast path
+		{"16 bytes (AES-128)", 16, true},
+		{"31 bytes (off-by-one)", 31, true},
+		{"32 bytes (AES-256, valid)", 32, false},
+		{"33 bytes (off-by-one)", 33, true},
+		{"64 bytes (AES-512, mistakenly used)", 64, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake, c := startFakeServer(t)
+			fake.getAgentManifestFn = func(*vaultpb.GetAgentManifestRequest) (*vaultpb.GetAgentManifestResponse, error) {
+				dek := base64.StdEncoding.EncodeToString(make([]byte, tc.dekLen))
+				return &vaultpb.GetAgentManifestResponse{
+					ManifestJson: `{"agent_dek": "` + dek + `"}`,
+				}, nil
+			}
+
+			_, err := c.GetAgentManifest(context.Background())
+			if tc.shouldErr && err == nil {
+				t.Fatalf("expected error for DEK length %d", tc.dekLen)
+			}
+			if !tc.shouldErr && err != nil {
+				t.Fatalf("unexpected error for DEK length %d: %v", tc.dekLen, err)
+			}
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RPC integration → MapGRPCError → typed *Error end-to-end coverage.
+// Server emits gRPC status; client must surface a typed *vault.Error with
+// correct Code/Retryable.
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestGetAgentManifest_GRPCErrorMatrix(t *testing.T) {
+	cases := []struct {
+		name      string
+		grpcCode  codes.Code
+		wantCode  string
+		retryable bool
+	}{
+		{"Unauthenticated", codes.Unauthenticated, "VAULT_AUTH_FAILED", false},
+		{"PermissionDenied", codes.PermissionDenied, "VAULT_PERMISSION_DENIED", false},
+		{"InvalidArgument", codes.InvalidArgument, "VAULT_INVALID_INPUT", false},
+		{"ResourceExhausted", codes.ResourceExhausted, "VAULT_RATE_LIMITED", true},
+		{"Internal", codes.Internal, "VAULT_INTERNAL", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake, c := startFakeServer(t)
+			fake.getAgentManifestFn = func(*vaultpb.GetAgentManifestRequest) (*vaultpb.GetAgentManifestResponse, error) {
+				return nil, status.Error(tc.grpcCode, "server says "+tc.name)
+			}
+
+			_, err := c.GetAgentManifest(context.Background())
+			if err == nil {
+				t.Fatal("expected error from gRPC status")
+			}
+			var ve *vault.Error
+			if !errors.As(err, &ve) {
+				t.Fatalf("expected *vault.Error, got %T: %v", err, err)
+			}
+			if ve.Code != tc.wantCode {
+				t.Errorf("Code: got %q, want %q", ve.Code, tc.wantCode)
+			}
+			if ve.Retryable != tc.retryable {
+				t.Errorf("Retryable: got %v, want %v", ve.Retryable, tc.retryable)
+			}
+		})
+	}
+}
+
+func TestDecryptScores_GRPCError(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.decryptScoresFn = func(*vaultpb.DecryptScoresRequest) (*vaultpb.DecryptScoresResponse, error) {
+		return nil, status.Error(codes.PermissionDenied, "topk exceeds role limit")
+	}
+
+	_, err := c.DecryptScores(context.Background(), "blob", 100)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var ve *vault.Error
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *vault.Error, got %T", err)
+	}
+	if ve.Code != "VAULT_PERMISSION_DENIED" {
+		t.Errorf("Code: got %q, want VAULT_PERMISSION_DENIED", ve.Code)
+	}
+	if ve.Retryable {
+		t.Error("PermissionDenied must not be retryable")
+	}
+}
+
+func TestDecryptMetadata_GRPCError(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.decryptMetadataFn = func(*vaultpb.DecryptMetadataRequest) (*vaultpb.DecryptMetadataResponse, error) {
+		return nil, status.Error(codes.InvalidArgument, "list size exceeds 1000")
+	}
+
+	_, err := c.DecryptMetadata(context.Background(), []string{"x"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var ve *vault.Error
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *vault.Error, got %T", err)
+	}
+	if ve.Code != "VAULT_INVALID_INPUT" {
+		t.Errorf("Code: got %q, want VAULT_INVALID_INPUT", ve.Code)
+	}
+	if ve.Retryable {
+		t.Error("InvalidArgument must not be retryable")
+	}
+}
+
+func TestHealthCheck_GRPCError(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.healthFn = func(*healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+		return nil, status.Error(codes.Unavailable, "server down")
+	}
+
+	healthy, err := c.HealthCheck(context.Background())
+	if err == nil {
+		t.Fatal("expected error from gRPC status")
+	}
+	if healthy {
+		t.Error("expected healthy=false on error")
+	}
+	var ve *vault.Error
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *vault.Error, got %T", err)
+	}
+	if ve.Code != "VAULT_UNAVAILABLE" {
+		t.Errorf("Code: got %q, want VAULT_UNAVAILABLE", ve.Code)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MapGRPCError invariants — Cause preservation + errors.As chain + Message.
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestMapGRPCError_PreservesCause(t *testing.T) {
+	allCodes := []codes.Code{
+		codes.Unauthenticated, codes.PermissionDenied, codes.InvalidArgument,
+		codes.ResourceExhausted, codes.NotFound, codes.Unavailable,
+		codes.DeadlineExceeded, codes.Internal, codes.Aborted, // last = default branch
+	}
+	for _, code := range allCodes {
+		t.Run(code.String(), func(t *testing.T) {
+			origin := status.Error(code, "x")
+			err := vault.MapGRPCError(origin)
+			var ve *vault.Error
+			if !errors.As(err, &ve) {
+				t.Fatalf("expected *vault.Error, got %T", err)
+			}
+			if ve.Cause != origin {
+				t.Errorf("Cause: got %v, want original gRPC err", ve.Cause)
+			}
+			// errors.Is should walk Unwrap → find the original gRPC status err
+			if !errors.Is(err, origin) {
+				t.Error("errors.Is(*Error, originalErr) should be true via Unwrap")
+			}
+		})
+	}
+}
+
+func TestMapGRPCError_PreservesMessage(t *testing.T) {
+	msg := "very specific server message"
+	err := vault.MapGRPCError(status.Error(codes.PermissionDenied, msg))
+	var ve *vault.Error
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *vault.Error, got %T", err)
+	}
+	if ve.Message != msg {
+		t.Errorf("Message: got %q, want %q", ve.Message, msg)
+	}
+}
+
+func TestError_ErrorString(t *testing.T) {
+	cases := []struct {
+		ve   *vault.Error
+		want string
+	}{
+		{&vault.Error{Code: "X"}, "X"},
+		{&vault.Error{Code: "X", Message: "y"}, "X: y"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			if got := tc.ve.Error(); got != tc.want {
+				t.Errorf("Error(): got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bundle / response-error / boundary-input coverage.
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestGetAgentManifest_FullBundleEquality(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.getAgentManifestFn = func(*vaultpb.GetAgentManifestRequest) (*vaultpb.GetAgentManifestResponse, error) {
+		return &vaultpb.GetAgentManifestResponse{ManifestJson: validManifestJSON(t)}, nil
+	}
+
+	bundle, err := c.GetAgentManifest(context.Background())
+	if err != nil {
+		t.Fatalf("GetAgentManifest: %v", err)
+	}
+	// The fields not asserted in TestGetAgentManifest_HappyPath:
+	if string(bundle.EncKey) != "<enc-bytes>" {
+		t.Errorf("EncKey: got %q, want '<enc-bytes>'", string(bundle.EncKey))
+	}
+	if bundle.EnvectorAPIKey != "env_apikey" {
+		t.Errorf("EnvectorAPIKey: got %q", bundle.EnvectorAPIKey)
+	}
+}
+
+func TestGetAgentManifest_OmittedIndexName(t *testing.T) {
+	// Server omits index_name when not configured (buildBundle:140-142).
+	fake, c := startFakeServer(t)
+	fake.getAgentManifestFn = func(*vaultpb.GetAgentManifestRequest) (*vaultpb.GetAgentManifestResponse, error) {
+		dek := base64.StdEncoding.EncodeToString(make([]byte, 32))
+		return &vaultpb.GetAgentManifestResponse{
+			ManifestJson: `{"EncKey.json":"e","key_id":"k","agent_id":"a","agent_dek":"` + dek + `","envector_endpoint":"x","envector_api_key":"y"}`,
+		}, nil
+	}
+	bundle, err := c.GetAgentManifest(context.Background())
+	if err != nil {
+		t.Fatalf("GetAgentManifest: %v", err)
+	}
+	if bundle.IndexName != "" {
+		t.Errorf("IndexName when omitted: got %q, want empty string", bundle.IndexName)
+	}
+}
+
+func TestDecryptScores_ResponseErrorString(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.decryptScoresFn = func(*vaultpb.DecryptScoresRequest) (*vaultpb.DecryptScoresResponse, error) {
+		return &vaultpb.DecryptScoresResponse{Error: "fhe decryption failed"}, nil
+	}
+	_, err := c.DecryptScores(context.Background(), "x", 5)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "fhe decryption failed") {
+		t.Errorf("error msg: got %q", err.Error())
+	}
+}
+
+func TestDecryptMetadata_ResponseErrorString(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.decryptMetadataFn = func(*vaultpb.DecryptMetadataRequest) (*vaultpb.DecryptMetadataResponse, error) {
+		return &vaultpb.DecryptMetadataResponse{Error: "envelope corrupted"}, nil
+	}
+	_, err := c.DecryptMetadata(context.Background(), []string{"x"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "envelope corrupted") {
+		t.Errorf("error msg: got %q", err.Error())
+	}
+}
+
+func TestDecryptScores_EmptyResults(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.decryptScoresFn = func(*vaultpb.DecryptScoresRequest) (*vaultpb.DecryptScoresResponse, error) {
+		return &vaultpb.DecryptScoresResponse{Results: nil}, nil
+	}
+	out, err := c.DecryptScores(context.Background(), "x", 5)
+	if err != nil {
+		t.Fatalf("DecryptScores: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("results: got %d, want 0", len(out))
+	}
+}
+
+func TestDecryptMetadata_EmptyList(t *testing.T) {
+	fake, c := startFakeServer(t)
+	called := false
+	fake.decryptMetadataFn = func(req *vaultpb.DecryptMetadataRequest) (*vaultpb.DecryptMetadataResponse, error) {
+		called = true
+		if len(req.GetEncryptedMetadataList()) != 0 {
+			t.Errorf("server got list of %d, want 0", len(req.GetEncryptedMetadataList()))
+		}
+		return &vaultpb.DecryptMetadataResponse{DecryptedMetadata: nil}, nil
+	}
+	out, err := c.DecryptMetadata(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("DecryptMetadata: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("got %d, want 0", len(out))
+	}
+	if !called {
+		t.Error("server should have been called even for empty list (current behavior)")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ParseManifestJSON direct cases — required-field absence + structurally bad
+// inputs. (forward-compat case is in TestParseManifestJSON_DropsEvalKeyField.)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestParseManifestJSON_EmptyJSON(t *testing.T) {
+	_, err := vault.ParseManifestJSON(`{}`)
+	if err == nil {
+		t.Fatal("expected error for empty JSON (missing agent_dek)")
+	}
+	if !strings.Contains(err.Error(), "agent_dek is empty") {
+		t.Errorf("error: got %q, want 'agent_dek is empty'", err.Error())
+	}
+}
+
+func TestParseManifestJSON_MissingAgentDEK(t *testing.T) {
+	raw := `{"EncKey.json":"e","key_id":"k","agent_id":"a","envector_endpoint":"x","envector_api_key":"y"}`
+	_, err := vault.ParseManifestJSON(raw)
+	if err == nil {
+		t.Fatal("expected error for missing agent_dek")
+	}
+}
+
+func TestParseManifestJSON_NotJSON(t *testing.T) {
+	_, err := vault.ParseManifestJSON("not json at all")
+	if err == nil {
+		t.Fatal("expected JSON parse error")
+	}
+	if !strings.Contains(err.Error(), "parse manifest_json") {
+		t.Errorf("error: got %q", err.Error())
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Lifecycle / boundary — Endpoint + Close + ctx cancellation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestEndpoint_ReturnsConstructorValue(t *testing.T) {
+	_, c := startFakeServer(t)
+	if c.Endpoint() != "bufconn" {
+		t.Errorf("Endpoint(): got %q, want bufconn", c.Endpoint())
+	}
+}
+
+func TestClose_NilSafe(t *testing.T) {
+	_, c := startFakeServer(t)
+	if err := c.Close(); err != nil {
+		t.Errorf("first Close: %v", err)
+	}
+	// Calling Close twice — second call should not panic. grpc.ClientConn.Close
+	// returns a "connection is closing" error after first call; we tolerate
+	// either nil or non-nil but no panic.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("second Close panicked: %v", r)
+		}
+	}()
+	_ = c.Close()
+}
+
+func TestGetAgentManifest_ContextCanceled(t *testing.T) {
+	fake, c := startFakeServer(t)
+	fake.getAgentManifestFn = func(*vaultpb.GetAgentManifestRequest) (*vaultpb.GetAgentManifestResponse, error) {
+		// server intentionally hangs — simulate slow/unresponsive Vault.
+		time.Sleep(2 * time.Second)
+		return &vaultpb.GetAgentManifestResponse{ManifestJson: validManifestJSON(t)}, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	_, err := c.GetAgentManifest(ctx)
+	if err == nil {
+		t.Fatal("expected error from cancelled ctx")
+	}
+	// Cancelled context surfaces as gRPC Canceled status → MapGRPCError default → VAULT_INTERNAL
+	// (or Canceled-specific behavior depending on grpc-go runtime).
+	if !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "context canceled") &&
+		!strings.Contains(err.Error(), "Canceled") && !strings.Contains(err.Error(), "VAULT_INTERNAL") {
+		t.Errorf("expected ctx cancel signal in error, got %v", err)
+	}
+}
+
+// _ = time keeps the import warm if other tests are deleted.
+var _ = time.Second

--- a/internal/adapters/vault/errors.go
+++ b/internal/adapters/vault/errors.go
@@ -1,6 +1,11 @@
 package vault
 
-import "errors"
+import (
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
 
 // Error — vault adapter's typed error. Wraps a cause (gRPC error or IO error).
 // Service layer catches these and converts to domain.RuneError for MCP responses.
@@ -23,13 +28,24 @@ func (e *Error) Error() string {
 // Unwrap allows errors.Is / errors.As to inspect the cause.
 func (e *Error) Unwrap() error { return e.Cause }
 
-// Sentinel errors — vault.md §에러 분류 L275-283.
+// Sentinel errors — vault.md §에러 분류.
+//
+// The first five mirror Python rune-vault categories. The next three were
+// added after auditing rune-admin/vault/internal/server/grpc.go: the server
+// actually returns codes.PermissionDenied, codes.InvalidArgument, and
+// codes.ResourceExhausted as part of role / input / rate-limit handling, and
+// these need distinct sentinels so callers can tell them apart from generic
+// VAULT_INTERNAL (and avoid retry-storming on permanent failures like a
+// role that lacks a scope).
 var (
-	ErrVaultUnavailable = &Error{Code: "VAULT_UNAVAILABLE", Retryable: true}
-	ErrVaultAuthFailed  = &Error{Code: "VAULT_AUTH_FAILED", Retryable: false}
-	ErrVaultKeyNotFound = &Error{Code: "VAULT_KEY_NOT_FOUND", Retryable: false}
-	ErrVaultInternal    = &Error{Code: "VAULT_INTERNAL", Retryable: true}
-	ErrVaultTimeout     = &Error{Code: "VAULT_TIMEOUT", Retryable: true}
+	ErrVaultUnavailable      = &Error{Code: "VAULT_UNAVAILABLE", Retryable: true}
+	ErrVaultAuthFailed       = &Error{Code: "VAULT_AUTH_FAILED", Retryable: false}
+	ErrVaultKeyNotFound      = &Error{Code: "VAULT_KEY_NOT_FOUND", Retryable: false}
+	ErrVaultInternal         = &Error{Code: "VAULT_INTERNAL", Retryable: true}
+	ErrVaultTimeout          = &Error{Code: "VAULT_TIMEOUT", Retryable: true}
+	ErrVaultPermissionDenied = &Error{Code: "VAULT_PERMISSION_DENIED", Retryable: false}
+	ErrVaultInvalidInput     = &Error{Code: "VAULT_INVALID_INPUT", Retryable: false}
+	ErrVaultRateLimited      = &Error{Code: "VAULT_RATE_LIMITED", Retryable: true}
 
 	// ErrNotHTTPScheme — returned by HealthFallback when endpoint is not http(s).
 	ErrNotHTTPScheme = errors.New("vault: endpoint not http(s) scheme")
@@ -37,13 +53,17 @@ var (
 
 // MapGRPCError maps a gRPC status error to the appropriate vault sentinel + cause.
 //
-// gRPC → sentinel (spec §에러 분류 L286-290):
+// Mappings cover both server-emitted codes (rune-admin/vault/internal/server/
+// grpc.go) and transport-layer codes (gRPC runtime / client deadline):
 //
-//	Unauthenticated     → ErrVaultAuthFailed
-//	NotFound            → ErrVaultKeyNotFound
-//	Unavailable         → ErrVaultUnavailable
-//	DeadlineExceeded    → ErrVaultTimeout
-//	<other / non-gRPC>  → ErrVaultInternal
+//	Unauthenticated     → ErrVaultAuthFailed       (token validation)
+//	PermissionDenied    → ErrVaultPermissionDenied (role scope check)
+//	InvalidArgument     → ErrVaultInvalidInput     (bad client input)
+//	ResourceExhausted   → ErrVaultRateLimited      (token rate limit)
+//	NotFound            → ErrVaultKeyNotFound      (server doesn't emit this today; mapped for future)
+//	Unavailable         → ErrVaultUnavailable      (transport: network / server down)
+//	DeadlineExceeded    → ErrVaultTimeout          (transport: client deadline)
+//	Internal / <other>  → ErrVaultInternal         (server failures + non-gRPC fallback)
 //
 // Returns nil for nil input.
 func MapGRPCError(err error) error {
@@ -51,7 +71,7 @@ func MapGRPCError(err error) error {
 		return nil
 	}
 
-	st, ok := statusFromError(err)
+	st, ok := status.FromError(err)
 	if !ok {
 		return &Error{
 			Code:      ErrVaultInternal.Code,
@@ -61,70 +81,62 @@ func MapGRPCError(err error) error {
 		}
 	}
 
-	switch st.code {
-	case codeUnauthenticated:
+	switch st.Code() {
+	case codes.Unauthenticated:
 		return &Error{
 			Code:      ErrVaultAuthFailed.Code,
-			Message:   st.message,
+			Message:   st.Message(),
 			Retryable: false,
 			Cause:     err,
 		}
-	case codeNotFound:
+	case codes.PermissionDenied:
 		return &Error{
-			Code:      ErrVaultKeyNotFound.Code,
-			Message:   st.message,
+			Code:      ErrVaultPermissionDenied.Code,
+			Message:   st.Message(),
 			Retryable: false,
 			Cause:     err,
 		}
-	case codeUnavailable:
+	case codes.InvalidArgument:
 		return &Error{
-			Code:      ErrVaultUnavailable.Code,
-			Message:   st.message,
+			Code:      ErrVaultInvalidInput.Code,
+			Message:   st.Message(),
+			Retryable: false,
+			Cause:     err,
+		}
+	case codes.ResourceExhausted:
+		return &Error{
+			Code:      ErrVaultRateLimited.Code,
+			Message:   st.Message(),
 			Retryable: true,
 			Cause:     err,
 		}
-	case codeDeadlineExceeded:
+	case codes.NotFound:
+		return &Error{
+			Code:      ErrVaultKeyNotFound.Code,
+			Message:   st.Message(),
+			Retryable: false,
+			Cause:     err,
+		}
+	case codes.Unavailable:
+		return &Error{
+			Code:      ErrVaultUnavailable.Code,
+			Message:   st.Message(),
+			Retryable: true,
+			Cause:     err,
+		}
+	case codes.DeadlineExceeded:
 		return &Error{
 			Code:      ErrVaultTimeout.Code,
-			Message:   st.message,
+			Message:   st.Message(),
 			Retryable: true,
 			Cause:     err,
 		}
 	default:
 		return &Error{
 			Code:      ErrVaultInternal.Code,
-			Message:   st.message,
+			Message:   st.Message(),
 			Retryable: true,
 			Cause:     err,
 		}
 	}
-}
-
-type grpcStatus struct {
-	code    int
-	message string
-}
-
-// ref: google.golang.org/grpc/codes
-const (
-	codeUnauthenticated  = 16
-	codeNotFound         = 5
-	codeUnavailable      = 14
-	codeDeadlineExceeded = 4
-)
-
-func statusFromError(err error) (grpcStatus, bool) {
-	type grpcStatuser interface {
-		GRPCStatus() interface {
-			Code() int
-			Message() string
-		}
-	}
-
-	if gs, ok := err.(grpcStatuser); ok {
-		st := gs.GRPCStatus()
-		return grpcStatus{code: st.Code(), message: st.Message()}, true
-	}
-
-	return grpcStatus{}, false
 }


### PR DESCRIPTION


#103 후속 PR입니다. Vault 어댑터에서 빠진 항목 + 회귀된 항목 정리했습니다.

1. **`MapGRPCError` 버그 수정 + server 가 emit 하는 code 전수 커버** — #103 가 envector 쪽은 표준 패턴(`status.FromError + codes.*`)으로 정리했는데 vault 는 수정이 되지 않아서, 기존 hand-rolled interface (`Code() int`) 가 실제 gRPC 시그니처(`codes.Code` = `uint32`)와 안 맞아 모든 에러가 `VAULT_INTERNAL/Retryable=true` 로 잘못 분류되고 있었습니다.  
- 특히 토큰 만료가 retryable=true 로 마킹돼 무한 재시도 위험이 있었습니다. 
- 추가로 server 가 실제 emit 하는 `PermissionDenied`/`InvalidArgument`/`ResourceExhausted` 가 매핑 자체에 빠져있어서 default 분기로 흘러가던 것도 같이 정리했습니다. 

2. **`MaxMessageLength` 256MB 복원** — #103에서 16MB 로 줄었는데, 일단 기존 Python rune 과 server의 `MaxMessageSize` 도 256MB이어서 256MB로 수정했습니다.

3. **vault bufconn unit test + `NewBufconnClient` injector 추가** 
- 기존에 작성했던 #100 에 있던 테스트를 가져왔습니다. (GetPublickey 등의 변화로 기존 PR은 닫고 103으로 옮겨가면서 테스트만 가져옴)
   - 4 RPC (`GetAgentManifest`, `DecryptScores`, `DecryptMetadata`, `HealthCheck`) 의 happy path + gRPC error path + response.error string + boundary input
   - `decodeAgentDEK` 의 3 error path (empty / invalid base64 / length matrix 0~64)
   - `MapGRPCError` 9-code matrix (server emit + transport + legacy + default) + `Cause` 보존 + `errors.Is/As` chain + `Message` carry-through
   - `ParseManifestJSON` 직접 (empty / missing field / not-json / forward-compat)
   - 라이프사이클 (`Endpoint()` / `Close()` 멱등성 / ctx cancellation)

