### PR TITLE
feat(plugin): v0.4 manifest — Go binary entry, version 0.4.0-dev

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "rune",
       "description": "FHE-encrypted organizational memory for teams. Capture and retrieve institutional knowledge with zero-knowledge privacy.",
-      "version": "0.3.1",
+      "version": "0.4.0-dev",
       "source": "./",
       "author": {
         "name": "Sunchul Jung",
@@ -21,7 +21,13 @@
       "homepage": "https://envector.io",
       "repository": "https://github.com/CryptoLabInc/rune",
       "license": "Apache-2.0",
-      "keywords": ["memory", "fhe", "encryption", "organizational-knowledge", "vector-search"],
+      "keywords": [
+        "memory",
+        "fhe",
+        "encryption",
+        "organizational-knowledge",
+        "vector-search"
+      ],
       "category": "productivity"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rune",
   "description": "FHE-encrypted organizational memory for teams. Capture and retrieve institutional knowledge with zero-knowledge privacy.",
-  "version": "0.3.1",
+  "version": "0.4.0-dev",
   "author": {
     "name": "Sunchul Jung",
     "email": "zotanika@cryptolab.co.kr"
@@ -13,12 +13,8 @@
   ],
   "mcpServers": {
     "envector": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap-mcp.sh",
-      "env": {
-        "ENVECTOR_CONFIG": "${HOME}/.rune/config.json",
-        "ENVECTOR_AUTO_KEY_SETUP": "false"
-      },
-      "description": "enVector MCP server for encrypted vector operations"
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/rune-mcp",
+      "description": "enVector MCP server (Go binary, v0.4 migration)"
     }
   }
 }


### PR DESCRIPTION
The v0.4 migration replaced the Python MCP server (mcp/server/server.py
+ scripts/bootstrap-mcp.sh) with a single Go binary (cmd/rune-mcp). Plugin manifest needs to point at that binary directly:

- mcpServers.envector.command: "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap-mcp.sh"  → "${CLAUDE_PLUGIN_ROOT}/bin/rune-mcp"
- env block dropped — the Go binary reads ~/.rune/config.json directly via internal/adapters/config (no ENVECTOR_CONFIG / ENVECTOR_AUTO_KEY_SETUP shell env needed).
- Version bumped 0.3.1 → 0.4.0-dev in both plugin.json and the matching marketplace.json plugin entry.

Distribution side note: the binary itself isn't yet shipped inside the plugin source tree. A follow-up will add a release-tarball flow that embeds platform-specific binaries under bin/ before publishing. Until then, dev sessions install via `claude --plugin-dir <source>` with a locally-built bin/rune-mcp.
