### PR TITLE
fix(mcp): wire CaptureLog + ConfigDir in buildDeps for capture history

### DIFF
--- a/cmd/rune-mcp/main.go
+++ b/cmd/rune-mcp/main.go
@@ -20,10 +20,13 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/envector/rune-go/internal/adapters/config"
+	"github.com/envector/rune-go/internal/adapters/logio"
 	"github.com/envector/rune-go/internal/lifecycle"
 	"github.com/envector/rune-go/internal/mcp"
 	"github.com/envector/rune-go/internal/service"
@@ -87,11 +90,23 @@ func isNormalShutdown(err error) bool {
 func buildDeps() *mcp.Deps {
 	mgr := lifecycle.NewManager()
 
+	// ~/.rune as the config / log root. RuneDir() returns ~/.rune (creating
+	// the parent if needed); fallback to plain "$HOME/.rune" if HOME unset
+	// so handler dispatch never panics during boot/handshake.
+	runeDir, err := config.RuneDir()
+	if err != nil {
+		home, _ := os.UserHomeDir()
+		runeDir = filepath.Join(home, ".rune")
+	}
+	captureLog := logio.New(filepath.Join(runeDir, logio.DefaultFilename))
+
 	cap := service.NewCaptureService()
 	cap.State = mgr
+	cap.CaptureLog = captureLog
 
 	life := service.NewLifecycleService()
 	life.State = mgr
+	life.ConfigDir = runeDir
 
 	return &mcp.Deps{
 		State:     mgr,


### PR DESCRIPTION
CaptureService.CaptureLog stayed nil and LifecycleService.ConfigDir empty because buildDeps never set them. Capture writes succeeded against envector (records appeared in the team index) but capture_log.jsonl never got appended (capture.go:155 skips Append when CaptureLog is nil), and CaptureHistory tried to read "capture_log.jsonl" relative to the process cwd via filepath.Join("", logio.DefaultFilename).

buildDeps now resolves ~/.rune via config.RuneDir() (with $HOME fallback so handler dispatch never panics during boot), constructs a logio.New pointed at ~/.rune/capture_log.jsonl, and injects it into both services.

Surfaces the missing wiring noticed during local-smoke end-to-end verification: 6 records present in the envector index but /rune:capture_history empty.
