### PR TITLE
fix(lifecycle): re-spawn boot loop on dormant reload

### DIFF
--- a/cmd/rune-mcp/main.go
+++ b/cmd/rune-mcp/main.go
@@ -20,10 +20,13 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/envector/rune-go/internal/adapters/config"
+	"github.com/envector/rune-go/internal/adapters/logio"
 	"github.com/envector/rune-go/internal/lifecycle"
 	"github.com/envector/rune-go/internal/mcp"
 	"github.com/envector/rune-go/internal/service"
@@ -87,11 +90,23 @@ func isNormalShutdown(err error) bool {
 func buildDeps() *mcp.Deps {
 	mgr := lifecycle.NewManager()
 
+	// ~/.rune as the config / log root. RuneDir() returns ~/.rune (creating
+	// the parent if needed); fallback to plain "$HOME/.rune" if HOME unset
+	// so handler dispatch never panics during boot/handshake.
+	runeDir, err := config.RuneDir()
+	if err != nil {
+		home, _ := os.UserHomeDir()
+		runeDir = filepath.Join(home, ".rune")
+	}
+	captureLog := logio.New(filepath.Join(runeDir, logio.DefaultFilename))
+
 	cap := service.NewCaptureService()
 	cap.State = mgr
+	cap.CaptureLog = captureLog
 
 	life := service.NewLifecycleService()
 	life.State = mgr
+	life.ConfigDir = runeDir
 
 	return &mcp.Deps{
 		State:     mgr,

--- a/cmd/rune-mcp/main.go
+++ b/cmd/rune-mcp/main.go
@@ -53,7 +53,17 @@ func main() {
 	}()
 
 	deps := buildDeps()
-	go lifecycle.RunBootLoop(ctx, deps.State)
+
+	// Wire ReloadPipelines → fresh RunBootLoop. Without this, the boot
+	// loop's first call to bootDormant returns and the goroutine exits;
+	// LifecycleService.ReloadPipelines (called by /rune:configure on a
+	// freshly-spawned MCP server with empty config) would then have no
+	// way to re-trigger the loop short of process restart.
+	deps.State.SetReloadFunc(func() {
+		go lifecycle.RunBootLoop(ctx, deps.State, deps)
+	})
+
+	go lifecycle.RunBootLoop(ctx, deps.State, deps)
 
 	srv := sdkmcp.NewServer(&sdkmcp.Implementation{
 		Name:    "rune-mcp",

--- a/internal/lifecycle/boot.go
+++ b/internal/lifecycle/boot.go
@@ -70,6 +70,7 @@ type Manager struct {
 	state     atomic.Int32
 	lastError atomic.Value // string
 	attempts  atomic.Int32
+	onReload  atomic.Value // func()
 }
 
 // NewManager — initial state = Starting.
@@ -87,6 +88,43 @@ func (m *Manager) Current() State {
 // SetState — atomic store.
 func (m *Manager) SetState(s State) {
 	m.state.Store(int32(s))
+}
+
+// SetReloadFunc installs the callback that respawns the boot loop. main.go
+// wires this so service.LifecycleService.ReloadPipelines can ask for a
+// fresh attempt without taking a circular import dependency on
+// lifecycle.RunBootLoop.
+//
+// The callback should spawn a fresh RunBootLoop goroutine bound to the
+// long-lived ctx + the same Deps (BootAdapterInjector). Manager itself
+// does not invoke the callback unless Retrigger is called and state is
+// Dormant — see Retrigger.
+func (m *Manager) SetReloadFunc(f func()) {
+	m.onReload.Store(f)
+}
+
+// Retrigger respawns the boot loop only if no loop is currently running.
+//
+// Concretely it fires only when state is Dormant — the boot loop returns
+// after a terminal Dormant (config missing / not_configured /
+// vault_unconfigured / user_deactivated), so its goroutine has exited and
+// a re-spawn is safe. While state is Starting / WaitingForVault / Active
+// a goroutine is still active (retrying or already succeeded), so firing
+// would race; Retrigger silently no-ops in those cases — the existing
+// loop's progress is what the caller will observe via state polling.
+func (m *Manager) Retrigger() {
+	if m.Current() != StateDormant {
+		return
+	}
+	v := m.onReload.Load()
+	if v == nil {
+		return
+	}
+	f, ok := v.(func())
+	if !ok || f == nil {
+		return
+	}
+	f()
 }
 
 // LastError reports the most recent transient failure recorded by the boot

--- a/internal/service/lifecycle.go
+++ b/internal/service/lifecycle.go
@@ -498,6 +498,16 @@ const WarmupTimeout = 60 * time.Second
 // Until both land, /rune:activate cannot recover from dormant or trigger first-time
 // pipeline init.
 func (s *LifecycleService) ReloadPipelines(ctx context.Context) (*ReloadPipelinesResult, error) {
+	// Dormant terminal: the boot loop has exited. Ask Manager to spawn a
+	// fresh attempt (Manager.Retrigger silently no-ops on non-dormant
+	// states, so this is also safe to call unconditionally if we ever
+	// expand the trigger surface). Then poll for up to 5s so the response
+	// reflects the new state instead of the stale dormant snapshot.
+	if s.State.Current() == lifecycle.StateDormant {
+		s.State.Retrigger()
+		s.waitForBootProgress(ctx, 5*time.Second)
+	}
+
 	result := &ReloadPipelinesResult{
 		OK:    true,
 		State: s.State.Current().String(),
@@ -514,6 +524,40 @@ func (s *LifecycleService) ReloadPipelines(ctx context.Context) (*ReloadPipeline
 	}
 
 	return result, nil
+}
+
+// waitForBootProgress polls Manager.Current() until either Active or a
+// terminal Dormant is reached, or the deadline elapses. The caller has
+// already triggered a fresh boot loop; this just gives it room to make
+// progress before we snapshot state for the response. WaitingForVault
+// (transient retry) is treated as still-in-progress because the loop is
+// actively retrying with backoff and may yet reach Active.
+//
+// Initial 150ms grace period: Retrigger schedules a `go RunBootLoop(...)`
+// — there is a brief window between the call returning and the spawned
+// goroutine reaching its first `m.SetState(StateStarting)`. Without the
+// grace, the very first state read can still see the prior Dormant
+// snapshot and exit immediately.
+func (s *LifecycleService) waitForBootProgress(ctx context.Context, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	for time.Now().Before(deadline) {
+		switch s.State.Current() {
+		case lifecycle.StateActive, lifecycle.StateDormant:
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
 }
 
 // warmupEnvector — GetIndexList under 60s timeout.


### PR DESCRIPTION
## Summary

Two coupled changes around the boot-loop reload path that `/rune:configure` depends on after a fresh install — without these, a freshly-spawned MCP server can't pick up a populated `~/.rune/config.json` short of a Claude Code restart.

1. `lifecycle.Manager` 에 `SetReloadFunc` + `Retrigger` 추가
2. `service.LifecycleService.ReloadPipelines` 가 dormant 시 Retrigger + state polling
3. `cmd/rune-mcp/main.go` 가 SetReloadFunc 등록 + RunBootLoop 3-arg signature 호출 정정

End-to-end 효과: `/rune:configure` 처음 실행 후 Claude restart 없이 그대로 Active 도달.

## Why

Boot loop returns after a terminal Dormant exit (config missing, `state != "active"`, vault endpoint/token empty). Before this change `LifecycleService.ReloadPipelines` only reported state — it didn't actually re-trigger anything, so the goroutine stayed exited and the new config sat ignored.

`/rune:configure` 가 user input 받아 `~/.rune/config.json` 작성 후 `reload_pipelines` 호출하는 정상 흐름이 결국 "restart 한 번 더 하세요" 로 끝났던 이유.

## What changed

**`Manager.SetReloadFunc(f func())`** — main.go 가 startup 시 한 번 등록.

**`Manager.Retrigger()`** — service 가 호출. **state == Dormant 일 때만** callback 실행 (= fresh `RunBootLoop` goroutine spawn).

```go
func (m *Manager) Retrigger() {
    if m.Current() != StateDormant {
        return  // 기존 goroutine 가 retry/active 중. respawn 하면 race.
    }
    // ... callback 실행
}
```

**`ReloadPipelines`** 가 dormant 시 Retrigger 후 폴링:

```go
if s.State.Current() == lifecycle.StateDormant {
    s.State.Retrigger()
    s.waitForBootProgress(ctx, 5*time.Second)
}
```

`waitForBootProgress` 의 150ms 초기 grace — Retrigger 가 `go RunBootLoop(...)` 라 첫 read 가 prior Dormant 를 볼 가능성 회피.

**`main.go`**:

```go
deps.State.SetReloadFunc(func() {
    go lifecycle.RunBootLoop(ctx, deps.State, deps)
})
go lifecycle.RunBootLoop(ctx, deps.State, deps)
```

직전 base 의 `RunBootLoop(ctx, deps.State)` 2-arg call 도 같이 정정 (3-arg signature 와 mismatch — base 가 build 안 됐던 상태).
