### PR TITLE
fix(service): base64-encode envector cipher before Vault.DecryptScores

### DIFF
--- a/internal/service/capture.go
+++ b/internal/service/capture.go
@@ -10,6 +10,7 @@ package service
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -273,7 +274,11 @@ func (s *CaptureService) runNoveltyCheck(ctx context.Context, embeddingText stri
 		return &domain.NoveltyInfo{Score: 1.0, Class: "novel"}, nil, nil
 	}
 
-	entries, err := s.Vault.DecryptScores(ctx, string(blobs[0]), 3)
+	// Vault.DecryptScores's `EncryptedBlobB64` is a proto3 string field —
+	// envector's raw cipher bytes must be base64-encoded before sending.
+	// Mirrors recall.searchSingle.
+	encryptedBlobB64 := base64.StdEncoding.EncodeToString(blobs[0])
+	entries, err := s.Vault.DecryptScores(ctx, encryptedBlobB64, 3)
 	if err != nil || len(entries) == 0 {
 		slog.Warn("novelty check: decrypt failed (non-fatal)", "err", err)
 		return &domain.NoveltyInfo{Score: 1.0, Class: "novel"}, nil, nil

--- a/internal/service/recall.go
+++ b/internal/service/recall.go
@@ -159,8 +159,14 @@ func (s *RecallService) searchSingle(ctx context.Context, vec []float32, topk in
 		return nil, nil
 	}
 
-	// Vault decrypt scores
-	entries, err := s.Vault.DecryptScores(ctx, string(blobs[0]), topk)
+	// Vault decrypt scores. The Vault RPC field is `EncryptedBlobB64`
+	// (proto3 `string`, valid-UTF-8 only) — envector returns raw cipher
+	// bytes, so we must base64-encode before sending. A direct
+	// `string(blobs[0])` cast pushes random cipher bytes through the
+	// proto3 string-validation path and trips
+	// "grpc: error while marshaling: string field contains invalid UTF-8".
+	encryptedBlobB64 := base64.StdEncoding.EncodeToString(blobs[0])
+	entries, err := s.Vault.DecryptScores(ctx, encryptedBlobB64, topk)
 	if err != nil {
 		return nil, fmt.Errorf("vault decrypt scores: %w", err)
 	}


### PR DESCRIPTION
recall 할 때  envector cluster 에서 받은 raw cipher bytes 를 `vault.DecryptScores` 의 `EncryptedBlobB64` (proto3 string, valid-UTF-8 only) field 에 직접 string cast 로 넣어서 grpc-marshal 단계에서 "invalid UTF-8" reject가 되었습니다.

그래서 recall 이 항상 0이 나오고, capture 의 novelty check 도 같은 사유로 warning이 발생하고 있었는데 이를 해결하기 위한 PR 입니다. 
- field name 의 `B64` suffix 가 base64 contract 인데 v0.4 port 시 인코딩 단계가 두 호출 site (recall.go:163, capture.go:276) 모두에서 누락되어서 fix 는 base64.StdEncoding.EncodeToString 한 줄 추가해서 해결했습니다. 


The Vault gRPC `DecryptScoresRequest.encrypted_blob_b64` field is a proto3 `string` (valid-UTF-8 only). envector's `Score` returns raw cipher bytes, not a base64 string — so casting `string(blobs[0])` and passing it through trips proto3 string-validation:

    grpc: error while marshaling: string field contains invalid UTF-8

The bug surfaced as silent zero-result recall (fail point hidden inside the recall pipeline; envector cluster row count rises after capture but recall returns 0 hits) and an "invalid UTF-8" warning during the capture novelty check.

Two call sites, both fixed identically:

  recall.go:163  (RecallService.searchSingle)
  capture.go:276 (CaptureService novelty-check decrypt)

In both, encode the cipher with `base64.StdEncoding.EncodeToString` before passing it as the `EncryptedBlobB64` argument. The field name itself — `...B64` — was the contract; v0.4's port omitted the encoding step on both paths.
