### PR TITLE
feat(observability): recall pipeline tracing + log file

### DIFF
--- a/cmd/rune-mcp/main.go
+++ b/cmd/rune-mcp/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -39,6 +40,25 @@ const version = "0.4.0-alpha"
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Tee slog to ~/.rune/logs/rune-mcp.log so users can inspect what the
+	// MCP server saw when something went sideways. stderr stays the
+	// primary sink (Claude Code captures it however it sees fit); the
+	// file is a best-effort secondary that survives Claude's stderr
+	// handling. Failures here are non-fatal — slog falls back to the
+	// default text handler on stderr only.
+	if home, err := os.UserHomeDir(); err == nil {
+		logDir := filepath.Join(home, ".rune", "logs")
+		if err := os.MkdirAll(logDir, 0o700); err == nil {
+			logPath := filepath.Join(logDir, "rune-mcp.log")
+			if f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600); err == nil {
+				slog.SetDefault(slog.New(slog.NewTextHandler(
+					io.MultiWriter(os.Stderr, f),
+					&slog.HandlerOptions{Level: slog.LevelInfo},
+				)))
+			}
+		}
+	}
 
 	// SIGINT / SIGTERM → cancel ctx → srv.Run unblocks.
 	// stdin EOF (Claude window closed) also unblocks Run via the StdioTransport.

--- a/cmd/rune-mcp/main.go
+++ b/cmd/rune-mcp/main.go
@@ -41,21 +41,26 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Tee slog to ~/.rune/logs/rune-mcp.log so users can inspect what the
-	// MCP server saw when something went sideways. stderr stays the
-	// primary sink (Claude Code captures it however it sees fit); the
-	// file is a best-effort secondary that survives Claude's stderr
-	// handling. Failures here are non-fatal — slog falls back to the
-	// default text handler on stderr only.
-	if home, err := os.UserHomeDir(); err == nil {
-		logDir := filepath.Join(home, ".rune", "logs")
-		if err := os.MkdirAll(logDir, 0o700); err == nil {
-			logPath := filepath.Join(logDir, "rune-mcp.log")
-			if f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600); err == nil {
-				slog.SetDefault(slog.New(slog.NewTextHandler(
-					io.MultiWriter(os.Stderr, f),
-					&slog.HandlerOptions{Level: slog.LevelInfo},
-				)))
+	// Optional file tee for slog. Default off — production stays on
+	// stderr only (Claude Code captures it). Devs opt in via env var:
+	//   RUNE_MCP_LOG_FILE unset       → stderr only (default)
+	//   RUNE_MCP_LOG_FILE=""          → tee to ~/.rune/logs/rune-mcp.log
+	//   RUNE_MCP_LOG_FILE=/some/path  → tee to that path
+	// Failures (mkdir / open) are non-fatal — slog falls back to stderr.
+	if path, ok := os.LookupEnv("RUNE_MCP_LOG_FILE"); ok {
+		if path == "" {
+			if home, err := os.UserHomeDir(); err == nil {
+				path = filepath.Join(home, ".rune", "logs", "rune-mcp.log")
+			}
+		}
+		if path != "" {
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err == nil {
+				if f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600); err == nil {
+					slog.SetDefault(slog.New(slog.NewTextHandler(
+						io.MultiWriter(os.Stderr, f),
+						&slog.HandlerOptions{Level: slog.LevelInfo},
+					)))
+				}
 			}
 		}
 	}

--- a/internal/service/capture.go
+++ b/internal/service/capture.go
@@ -10,6 +10,7 @@ package service
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -273,7 +274,11 @@ func (s *CaptureService) runNoveltyCheck(ctx context.Context, embeddingText stri
 		return &domain.NoveltyInfo{Score: 1.0, Class: "novel"}, nil, nil
 	}
 
-	entries, err := s.Vault.DecryptScores(ctx, string(blobs[0]), 3)
+	// Vault.DecryptScores's `EncryptedBlobB64` is a proto3 string field —
+	// envector's raw cipher bytes must be base64-encoded before sending.
+	// Mirrors recall.searchSingle.
+	encryptedBlobB64 := base64.StdEncoding.EncodeToString(blobs[0])
+	entries, err := s.Vault.DecryptScores(ctx, encryptedBlobB64, 3)
 	if err != nil || len(entries) == 0 {
 		slog.Warn("novelty check: decrypt failed (non-fatal)", "err", err)
 		return &domain.NoveltyInfo{Score: 1.0, Class: "novel"}, nil, nil

--- a/internal/service/recall.go
+++ b/internal/service/recall.go
@@ -159,8 +159,14 @@ func (s *RecallService) searchSingle(ctx context.Context, vec []float32, topk in
 		return nil, nil
 	}
 
-	// Vault decrypt scores
-	entries, err := s.Vault.DecryptScores(ctx, string(blobs[0]), topk)
+	// Vault decrypt scores. The Vault RPC field is `EncryptedBlobB64`
+	// (proto3 `string`, valid-UTF-8 only) — envector returns raw cipher
+	// bytes, so we must base64-encode before sending. A direct
+	// `string(blobs[0])` cast pushes random cipher bytes through the
+	// proto3 string-validation path and trips
+	// "grpc: error while marshaling: string field contains invalid UTF-8".
+	encryptedBlobB64 := base64.StdEncoding.EncodeToString(blobs[0])
+	entries, err := s.Vault.DecryptScores(ctx, encryptedBlobB64, topk)
 	if err != nil {
 		return nil, fmt.Errorf("vault decrypt scores: %w", err)
 	}

--- a/internal/service/recall.go
+++ b/internal/service/recall.go
@@ -149,12 +149,25 @@ func (s *RecallService) searchWithExpansions(
 }
 
 // searchSingle — Python: searcher.py:L371-373 + L375-470 _search_via_vault.
+//
+// Logs each phase (score blob count → decrypt entry count → metadata hit
+// count → resolved hit count) at INFO so a user-facing 0-result recall
+// can be triaged without adding fresh instrumentation. The branches that
+// intentionally abort (silent return on 0 blobs / 0 entries) leave a
+// breadcrumb, since callers used to see only "no results" with no signal
+// as to where the pipeline shed rows.
 func (s *RecallService) searchSingle(ctx context.Context, vec []float32, topk int) ([]domain.SearchHit, error) {
 	// Score
 	blobs, err := s.Envector.Score(ctx, vec)
 	if err != nil {
+		slog.Warn("recall: envector score failed", "err", err)
 		return nil, fmt.Errorf("envector score: %w", err)
 	}
+	slog.Info("recall: envector score returned",
+		"blobs", len(blobs),
+		"first_blob_bytes", firstBlobLen(blobs),
+		"topk", topk,
+	)
 	if len(blobs) == 0 {
 		return nil, nil
 	}
@@ -168,8 +181,10 @@ func (s *RecallService) searchSingle(ctx context.Context, vec []float32, topk in
 	encryptedBlobB64 := base64.StdEncoding.EncodeToString(blobs[0])
 	entries, err := s.Vault.DecryptScores(ctx, encryptedBlobB64, topk)
 	if err != nil {
+		slog.Warn("recall: vault decrypt_scores failed", "err", err)
 		return nil, fmt.Errorf("vault decrypt scores: %w", err)
 	}
+	slog.Info("recall: vault decrypt_scores returned", "entries", len(entries))
 	if len(entries) == 0 {
 		return nil, nil
 	}
@@ -181,16 +196,32 @@ func (s *RecallService) searchSingle(ctx context.Context, vec []float32, topk in
 	}
 	metaEntries, err := s.Envector.GetMetadata(ctx, refs, []string{"metadata"})
 	if err != nil {
+		slog.Warn("recall: envector get_metadata failed", "err", err, "refs", len(refs))
 		return nil, fmt.Errorf("envector get_metadata: %w", err)
 	}
+	slog.Info("recall: envector get_metadata returned",
+		"metaEntries", len(metaEntries),
+		"refs", len(refs),
+	)
 
 	// Search hit
 	hits, err := s.resolveMetadata(ctx, metaEntries, entries)
 	if err != nil {
+		slog.Warn("recall: resolve metadata failed", "err", err)
 		return nil, fmt.Errorf("resolve metadata: %w", err)
 	}
+	slog.Info("recall: hits resolved", "hits", len(hits))
 
 	return hits, nil
+}
+
+// firstBlobLen surfaces the byte size of blobs[0] in slog without
+// nil-deref'ing the slice when blobs is empty.
+func firstBlobLen(blobs [][]byte) int {
+	if len(blobs) == 0 {
+		return 0
+	}
+	return len(blobs[0])
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
recall.searchSingle 의 4-phase trace (Score → DecryptScores → GetMetadata → resolve) + slog 를 `~/.rune/logs/rune-mcp.log` 에 저장합니다. 

- capture로 envector cloud cluster의 row count 는 증가하는데 recall이 안돼서 디버깅하다가 넣음 