### PR TITLE
chore(deps): bump envector-go-sdk v0.1.0 → v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ go 1.26.2
 //   github.com/modelcontextprotocol/go-sdk v1.5.0  — MCP protocol (D2) ✅ Phase A
 //   google.golang.org/grpc v1.65.0                  — Vault / envector / embedder clients (Phase 4)
 //   google.golang.org/protobuf v1.34.0              — generated stubs (Phase 4)
-//   github.com/CryptoLabInc/envector-go-sdk         — envector FHE client (Q4 PR pending)
+//   github.com/CryptoLabInc/envector-go-sdk         — envector FHE client
 //
 // go 1.25.0 + toolchain pin required by the MCP SDK.
 
 require (
-	github.com/CryptoLabInc/envector-go-sdk v0.1.0
+	github.com/CryptoLabInc/envector-go-sdk v0.1.1
 	github.com/CryptoLabInc/rune-admin/vault v0.0.0-20260506055025-ad52b6bd549d
 	github.com/CryptoLabInc/runed v0.0.0
 	github.com/modelcontextprotocol/go-sdk v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1 h1:s6hzCXtND/ICdGPTMGk7C+/BFlr2Jg5GyH0NKf4XGXg=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
-github.com/CryptoLabInc/envector-go-sdk v0.1.0 h1:EaPiFtvLh33mrS1Nfjb/sF5tmDlOIHpjj3TJ6QIIFgM=
-github.com/CryptoLabInc/envector-go-sdk v0.1.0/go.mod h1:jXVwGkqUOmQUnJiEshq7sG2x0nveFCNlAU5J7xc7CDw=
+github.com/CryptoLabInc/envector-go-sdk v0.1.1 h1:SBwWMH522tjlERXOizDDH/8lmXT1oE0t+83wI8uk9oI=
+github.com/CryptoLabInc/envector-go-sdk v0.1.1/go.mod h1:jXVwGkqUOmQUnJiEshq7sG2x0nveFCNlAU5J7xc7CDw=
 github.com/CryptoLabInc/rune-admin/vault v0.0.0-20260506055025-ad52b6bd549d h1:BmK4Ync6jx4X9aN7IeiHNoweA1c/iD+x61+dY8fgIl0=
 github.com/CryptoLabInc/rune-admin/vault v0.0.0-20260506055025-ad52b6bd549d/go.mod h1:7Hb7PCl5auGCj2oX30SQU+B0xqzqvM6P4NjPH0jj9Xk=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
v0.1.1 lands KeysExist's WithKeyParts honoring fix (CryptoLabInc/envector-go-sdk#2), so the rune-mcp boot path's OpenKeysFromFile(WithKeyParts(KeyPartEnc)) no longer trips on the SDK's pre-flight checking for all three key slots when only EncKey is delivered to the client.

This was the underlying reason the v0.4 stack appeared to "fail at configure" on a freshly-spawned MCP server: SaveEncKey wrote ~/.rune/keys/<keyID>/EncKey.json correctly, but the SDK then refused to open the key dir because EvalKey.json / SecKey.json (held only by envector cluster + Vault, by design) were absent. v0.1.1's KeysExist mirrors OpenKeysFromFile's resolveKeyParts logic, so the parts query flows through end-to-end.

Removes the local `replace` directive that was used as a stop-gap while the upstream PR was in review.