### PR TITLE
fix(dev/preflight): resolve REPO three levels up from script location

### DIFF
--- a/scripts/dev/v04/dev-preflight.sh
+++ b/scripts/dev/v04/dev-preflight.sh
@@ -18,7 +18,7 @@
 
 set -euo pipefail
 
-REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
 
 GREEN=$'\033[0;32m'
 RED=$'\033[0;31m'


### PR DESCRIPTION
The path-fix from PR #120 review never made it into the merged commit (staging order issue) — REPO landed pointing at scripts/dev/v04/ itself, so step 1's `cd "$REPO"` followed by `go build ./cmd/rune-mcp` tries to stat scripts/dev/v04/cmd/rune-mcp, which doesn't exist, and the script aborts with a build failure.

Going up three directories from scripts/dev/v04/ resolves to the repo root regardless of where the user invokes the script from, restoring the intended idempotent pre-flight behavior.

Verified locally: every section (build / plugin source / vault / runed / ~/.rune scrub / mcpServers / plugin cache) reports green and the script exits 0.
