### PR TITLE
feat(obs): wire redacting slog handler into rune-mcp

### DIFF
--- a/cmd/rune-mcp/main.go
+++ b/cmd/rune-mcp/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/envector/rune-go/internal/adapters/logio"
 	"github.com/envector/rune-go/internal/lifecycle"
 	"github.com/envector/rune-go/internal/mcp"
+	"github.com/envector/rune-go/internal/obs"
 	"github.com/envector/rune-go/internal/service"
 )
 
@@ -41,12 +42,17 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Optional file tee for slog. Default off — production stays on
-	// stderr only (Claude Code captures it). Devs opt in via env var:
-	//   RUNE_MCP_LOG_FILE unset       → stderr only (default)
-	//   RUNE_MCP_LOG_FILE=""          → tee to ~/.rune/logs/rune-mcp.log
-	//   RUNE_MCP_LOG_FILE=/some/path  → tee to that path
-	// Failures (mkdir / open) are non-fatal — slog falls back to stderr.
+	// Slog wiring. Two layers:
+	//
+	//   1. writer: stderr by default; tee to a file if RUNE_MCP_LOG_FILE
+	//      is set (unset → stderr only / "" → ~/.rune/logs/rune-mcp.log
+	//      / path → that path). Failures (mkdir / open) are non-fatal;
+	//      slog quietly falls back to stderr alone.
+	//   2. handler: obs.NewHandler wraps a TextHandler with sensitive-
+	//      data redaction (SensitivePatterns). Every log destination
+	//      goes through redaction — leaking via stderr-only is just as
+	//      bad as leaking via the file tee.
+	var w io.Writer = os.Stderr
 	if path, ok := os.LookupEnv("RUNE_MCP_LOG_FILE"); ok {
 		if path == "" {
 			if home, err := os.UserHomeDir(); err == nil {
@@ -56,14 +62,13 @@ func main() {
 		if path != "" {
 			if err := os.MkdirAll(filepath.Dir(path), 0o700); err == nil {
 				if f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600); err == nil {
-					slog.SetDefault(slog.New(slog.NewTextHandler(
-						io.MultiWriter(os.Stderr, f),
-						&slog.HandlerOptions{Level: slog.LevelInfo},
-					)))
+					w = io.MultiWriter(os.Stderr, f)
 				}
 			}
 		}
 	}
+	inner := slog.NewTextHandler(w, &slog.HandlerOptions{Level: slog.LevelInfo})
+	slog.SetDefault(slog.New(obs.NewHandler(inner, slog.LevelInfo)))
 
 	// SIGINT / SIGTERM → cancel ctx → srv.Run unblocks.
 	// stdin EOF (Claude window closed) also unblocks Run via the StdioTransport.

--- a/internal/obs/slog.go
+++ b/internal/obs/slog.go
@@ -31,9 +31,13 @@ import (
 
 // SensitivePatterns — runtime-compiled. Order matters only for callers
 // that introspect (none today); both apply on every string.
+//
+// The labelled-secret pattern uses `\b` so substrings inside a longer
+// identifier (mykey, keystore, keyboard, tokenizer) are not mistakenly
+// treated as the bare `key` / `token` label and over-redacted.
 var SensitivePatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(sk-|pk-|api_|envector_|evt_)[a-zA-Z0-9_-]{10,}`),
-	regexp.MustCompile(`(?i)(token|key|secret|password)["\s:=]+[a-zA-Z0-9_-]{20,}`),
+	regexp.MustCompile(`(?i)\b(token|key|secret|password)["\s:=]+[a-zA-Z0-9_-]{20,}`),
 }
 
 // redact applies every SensitivePatterns regex, replacing each match
@@ -112,16 +116,42 @@ func redactAttr(a slog.Attr) slog.Attr {
 			out[i] = redactAttr(g)
 		}
 		return slog.Attr{Key: a.Key, Value: slog.GroupValue(out...)}
+	case slog.KindLogValuer:
+		// slog.Logger does not pre-resolve LogValuer when a wrapping
+		// Handler sits above the leaf — the Resolve happens inside the
+		// inner Handler.Handle, after our filter. So secrets wrapped in
+		// LogValuer would otherwise leak. Resolve here, then recurse so
+		// the resolved value (may be string / group / any) flows back
+		// through the same redactor.
+		return redactAttr(slog.Attr{Key: a.Key, Value: a.Value.Resolve()})
 	case slog.KindAny:
-		// Stringer values may hold secrets too. LogValuer is resolved
-		// upstream before slog calls us; plain Stringer is best-effort.
+		// Stringer values may hold secrets too. Best-effort: a panicking
+		// Stringer must not take the whole logger down — log lines are
+		// for incident response, not the source of new incidents. The
+		// recover scope is per-attr so one bad attr only loses its own
+		// redaction, not the rest of the record.
 		if v := a.Value.Any(); v != nil {
 			if s, ok := v.(fmt.Stringer); ok {
-				return slog.String(a.Key, redact(s.String()))
+				if str, ok := safeStringer(s); ok {
+					return slog.String(a.Key, redact(str))
+				}
 			}
 		}
 	}
 	return a
+}
+
+// safeStringer returns s.String() with panics swallowed. If String
+// panics, ok=false and the caller should leave the attr unredacted —
+// dropping the attr entirely would be worse than logging it raw.
+func safeStringer(s fmt.Stringer) (out string, ok bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			out = ""
+			ok = false
+		}
+	}()
+	return s.String(), true
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/internal/obs/slog.go
+++ b/internal/obs/slog.go
@@ -1,35 +1,127 @@
-// Package obs — observability: slog handler with sensitive data filter + request_id.
+// Package obs — observability: slog handler with sensitive-data redaction
+// + per-request id helpers.
+//
+// The redacting handler wraps another slog.Handler and rewrites every
+// string-typed attribute value through SensitivePatterns before
+// dispatch. Two patterns are compiled (Python parity —
+// mcp/server/server.py:L25-40 _SensitiveFilter):
+//
+//  1. token-shaped strings starting with sk- / pk- / api_ / envector_ /
+//     evt_ followed by 10+ identifier chars
+//  2. labelled secrets like `token:`, `key=`, `secret "`, `password ` —
+//     case-insensitive — followed by a separator and 20+ identifier
+//     chars
+//
+// Replacement keeps the first 8 characters of the match plus "***" so
+// log readers retain enough prefix to disambiguate without exposing
+// the body. Log lines stay grep-able for the unredacted prefix.
+//
 // Spec: docs/v04/spec/components/rune-mcp.md §Observability.
-// Python: mcp/server/server.py:L25-40 _SensitiveFilter.
 package obs
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
 	"log/slog"
 	"os"
+	"regexp"
 )
 
-// SensitivePatterns — 2 regex (Python server.py:L28-31):
-//
-//  1. (sk-|pk-|api_|envector_|evt_)[a-zA-Z0-9_-]{10,}
-//     — 6 prefixes, 10+ chars
-//
-//  2. (?i)(token|key|secret|password)["\s:=]+[a-zA-Z0-9_-]{20,}
-//     — 4 field names + separator + 20+ chars
-//
-// Replacement: m.group()[:8] + "***" (preserve first 8 chars).
-//
-// TODO: port both regex + replacement into a slog.Handler.
-var SensitivePatterns = []string{
-	// TODO: compile `(sk-|pk-|api_|envector_|evt_)[a-zA-Z0-9_-]{10,}`
-	// TODO: compile `(?i)(token|key|secret|password)["\s:=]+[a-zA-Z0-9_-]{20,}`
+// SensitivePatterns — runtime-compiled. Order matters only for callers
+// that introspect (none today); both apply on every string.
+var SensitivePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(sk-|pk-|api_|envector_|evt_)[a-zA-Z0-9_-]{10,}`),
+	regexp.MustCompile(`(?i)(token|key|secret|password)["\s:=]+[a-zA-Z0-9_-]{20,}`),
 }
 
-// NewHandler returns a slog.Handler that scrubs sensitive data from messages.
-// TODO: wrap slog.NewJSONHandler and redact per SensitivePatterns.
-func NewHandler(level slog.Level) slog.Handler {
-	// TODO: return &filteringHandler{inner: slog.NewJSONHandler(os.Stderr, ...), patterns: compiled}
-	return slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level})
+// redact applies every SensitivePatterns regex, replacing each match
+// with `match[:8] + "***"`. Strings shorter than 8 runes get the full
+// "***" — preserving prefix would leak the secret.
+func redact(s string) string {
+	for _, re := range SensitivePatterns {
+		s = re.ReplaceAllStringFunc(s, func(m string) string {
+			if len(m) <= 8 {
+				return "***"
+			}
+			return m[:8] + "***"
+		})
+	}
+	return s
+}
+
+// NewHandler wraps an inner slog.Handler with sensitive-data redaction.
+// Falls back to a stderr text handler at the given level when inner is
+// nil.
+func NewHandler(inner slog.Handler, level slog.Level) slog.Handler {
+	if inner == nil {
+		inner = slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
+	}
+	return &filteringHandler{inner: inner}
+}
+
+// filteringHandler walks every Record's attrs and rewrites string
+// values via redact, then forwards to inner. It also rewrites the
+// Record's Message itself (capture/recall payload sometimes lands
+// there during incident-time logging).
+type filteringHandler struct {
+	inner slog.Handler
+}
+
+func (h *filteringHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h *filteringHandler) Handle(ctx context.Context, r slog.Record) error {
+	r.Message = redact(r.Message)
+
+	// Rebuild attrs through the redactor. We construct a new Record so
+	// the original (which may be cached upstream) stays untouched.
+	out := slog.NewRecord(r.Time, r.Level, r.Message, r.PC)
+	r.Attrs(func(a slog.Attr) bool {
+		out.AddAttrs(redactAttr(a))
+		return true
+	})
+	return h.inner.Handle(ctx, out)
+}
+
+func (h *filteringHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	scrubbed := make([]slog.Attr, len(attrs))
+	for i, a := range attrs {
+		scrubbed[i] = redactAttr(a)
+	}
+	return &filteringHandler{inner: h.inner.WithAttrs(scrubbed)}
+}
+
+func (h *filteringHandler) WithGroup(name string) slog.Handler {
+	return &filteringHandler{inner: h.inner.WithGroup(name)}
+}
+
+// redactAttr rewrites string-valued attrs and recurses into groups.
+// Non-string scalar kinds (int / bool / float / time / duration) pass
+// through untouched — secrets only appear as strings in this codebase.
+func redactAttr(a slog.Attr) slog.Attr {
+	switch a.Value.Kind() {
+	case slog.KindString:
+		return slog.String(a.Key, redact(a.Value.String()))
+	case slog.KindGroup:
+		group := a.Value.Group()
+		out := make([]slog.Attr, len(group))
+		for i, g := range group {
+			out[i] = redactAttr(g)
+		}
+		return slog.Attr{Key: a.Key, Value: slog.GroupValue(out...)}
+	case slog.KindAny:
+		// Stringer values may hold secrets too. LogValuer is resolved
+		// upstream before slog calls us; plain Stringer is best-effort.
+		if v := a.Value.Any(); v != nil {
+			if s, ok := v.(fmt.Stringer); ok {
+				return slog.String(a.Key, redact(s.String()))
+			}
+		}
+	}
+	return a
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -51,9 +143,19 @@ func RequestID(ctx context.Context) string {
 	return v
 }
 
-// NewRequestID generates a UUID-like request ID.
-// TODO: use crypto/rand for UUID v4 or sequential monotonic ID.
+// NewRequestID returns a UUID v4 string. crypto/rand is used so multiple
+// MCP servers across different processes can't collide; the cost
+// (~1µs per call) is negligible vs the request itself. Falls back to
+// "req-anon" when crypto/rand is unavailable — logging an anonymous
+// request beats panicking on a broken host RNG.
 func NewRequestID() string {
-	// TODO
-	return ""
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "req-anon"
+	}
+	// RFC 4122 v4: clear/set version + variant bits.
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	hexed := hex.EncodeToString(b[:])
+	return hexed[0:8] + "-" + hexed[8:12] + "-" + hexed[12:16] + "-" + hexed[16:20] + "-" + hexed[20:32]
 }

--- a/internal/obs/slog_test.go
+++ b/internal/obs/slog_test.go
@@ -1,0 +1,175 @@
+package obs
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestRedact_Tokens(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"sk- prefix", "auth=sk-ABCD1234567890XYZ ok", "auth=sk-ABCD1*** ok"},
+		{"pk- prefix", "key pk-1234567890abc", "key pk-12345***"},
+		{"api_ prefix", "use api_FOOBARBAZ12345", "use api_FOOB***"},
+		{"envector_ prefix", "tok=envector_secret_12345", "tok=envector***"},
+		{"evt_ prefix", "evt_AABBCCDD11223344", "evt_AABB***"},
+		{"too short to redact prefix kept literal", "sk-AB", "sk-AB"},
+		{"no match", "hello world 123", "hello world 123"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := redact(c.in); got != c.want {
+				t.Fatalf("redact(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestRedact_LabeledSecrets(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"token: ABCDEFGHIJKLMNOPQRSTUVWX", "token: A***"},
+		{`{"key":"ABCDEFGHIJKLMNOPQRSTUVWX"}`, `{"key":"AB***"}`},
+		{"SECRET=ABCDEFGHIJKLMNOPQRSTUVWX", "SECRET=A***"},
+		{"Password \"ABCDEFGHIJKLMNOPQRSTUVWX\"", "Password***\""},
+		{"token: short", "token: short"},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			if got := redact(c.in); got != c.want {
+				t.Fatalf("redact(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// captureHandler — collects emitted records for assertion.
+type captureHandler struct {
+	buf     *bytes.Buffer
+	handler slog.Handler
+}
+
+func newCapture() *captureHandler {
+	buf := &bytes.Buffer{}
+	return &captureHandler{
+		buf:     buf,
+		handler: slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo}),
+	}
+}
+
+func (c *captureHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return c.handler.Enabled(ctx, l)
+}
+func (c *captureHandler) Handle(ctx context.Context, r slog.Record) error {
+	return c.handler.Handle(ctx, r)
+}
+func (c *captureHandler) WithAttrs(a []slog.Attr) slog.Handler {
+	return &captureHandler{buf: c.buf, handler: c.handler.WithAttrs(a)}
+}
+func (c *captureHandler) WithGroup(n string) slog.Handler {
+	return &captureHandler{buf: c.buf, handler: c.handler.WithGroup(n)}
+}
+
+func TestFilteringHandler_RedactsAttrs(t *testing.T) {
+	cap := newCapture()
+	logger := slog.New(NewHandler(cap, slog.LevelInfo))
+	logger.Info("vault dial",
+		slog.String("token", "evt_AABBCCDDEEFF112233"),
+		slog.String("endpoint", "tcp://vault.example.com:50051"),
+		slog.Int("attempt", 1),
+	)
+
+	out := cap.buf.String()
+	if !strings.Contains(out, "evt_AABB***") {
+		t.Errorf("expected redacted token in output, got: %q", out)
+	}
+	if strings.Contains(out, "evt_AABBCCDDEEFF112233") {
+		t.Errorf("raw token should not appear in output: %q", out)
+	}
+	if !strings.Contains(out, "tcp://vault.example.com:50051") {
+		t.Errorf("non-secret string should pass through: %q", out)
+	}
+	if !strings.Contains(out, "attempt=1") {
+		t.Errorf("non-string attrs should pass through: %q", out)
+	}
+}
+
+func TestFilteringHandler_RedactsMessage(t *testing.T) {
+	cap := newCapture()
+	logger := slog.New(NewHandler(cap, slog.LevelInfo))
+	logger.Info("auth via sk-AAABBBCCCDDD failed")
+
+	out := cap.buf.String()
+	if !strings.Contains(out, "sk-AAABB***") {
+		t.Errorf("expected redacted token in message, got: %q", out)
+	}
+	if strings.Contains(out, "sk-AAABBBCCCDDD") {
+		t.Errorf("raw token should not appear in message: %q", out)
+	}
+}
+
+func TestFilteringHandler_WithAttrs(t *testing.T) {
+	cap := newCapture()
+	logger := slog.New(NewHandler(cap, slog.LevelInfo))
+	scoped := logger.With(slog.String("api_key", "api_ABCDEFGHIJKLMN"))
+	scoped.Info("request")
+
+	out := cap.buf.String()
+	if !strings.Contains(out, "api_ABCD***") {
+		t.Errorf("expected redacted attr from With(), got: %q", out)
+	}
+	if strings.Contains(out, "api_ABCDEFGHIJKLMN") {
+		t.Errorf("raw token should not appear: %q", out)
+	}
+}
+
+func TestNewRequestID_Format(t *testing.T) {
+	id := NewRequestID()
+	// 8-4-4-4-12 hex with 4 dashes
+	if len(id) != 36 {
+		t.Fatalf("expected length 36, got %d (%q)", len(id), id)
+	}
+	for _, i := range []int{8, 13, 18, 23} {
+		if id[i] != '-' {
+			t.Fatalf("expected '-' at index %d, got %q (%q)", i, id[i], id)
+		}
+	}
+	// v4 marker
+	if id[14] != '4' {
+		t.Fatalf("expected v4 marker at index 14, got %q (%q)", id[14], id)
+	}
+	// variant marker (one of 8/9/a/b)
+	switch id[19] {
+	case '8', '9', 'a', 'b':
+	default:
+		t.Fatalf("unexpected variant marker at index 19: %q (%q)", id[19], id)
+	}
+}
+
+func TestNewRequestID_Unique(t *testing.T) {
+	seen := make(map[string]bool, 1024)
+	for i := 0; i < 1024; i++ {
+		id := NewRequestID()
+		if seen[id] {
+			t.Fatalf("duplicate id %q at iteration %d", id, i)
+		}
+		seen[id] = true
+	}
+}
+
+func TestRequestID_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	if got := RequestID(ctx); got != "" {
+		t.Errorf("expected empty RequestID for bare context, got %q", got)
+	}
+	id := NewRequestID()
+	ctx = WithRequestID(ctx, id)
+	if got := RequestID(ctx); got != id {
+		t.Errorf("RequestID = %q, want %q", got, id)
+	}
+}

--- a/internal/obs/slog_test.go
+++ b/internal/obs/slog_test.go
@@ -48,6 +48,28 @@ func TestRedact_LabeledSecrets(t *testing.T) {
 	}
 }
 
+// TestRedact_NoFalsePositive — substrings inside longer identifiers
+// must not trigger the labelled-secret pattern. mykey/keystore/keyboard
+// /tokenizer all share a substring with the bare label list but are
+// not themselves secret declarations.
+func TestRedact_NoFalsePositive(t *testing.T) {
+	inputs := []string{
+		"mykey: ABCDEFGHIJKLMNOPQRSTUVWX",
+		"keystore=ABCDEFGHIJKLMNOPQRSTUVWX",
+		"keyboard=ABCDEFGHIJKLMNOPQRSTUVWX",
+		"tokenizer: ABCDEFGHIJKLMNOPQRSTUVWX",
+		"my_key=ABCDEFGHIJKLMNOPQRSTUVWX",
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			got := redact(in)
+			if got != in {
+				t.Fatalf("redact(%q) modified the string to %q — false positive", in, got)
+			}
+		})
+	}
+}
+
 // captureHandler — collects emitted records for assertion.
 type captureHandler struct {
 	buf     *bytes.Buffer
@@ -125,6 +147,53 @@ func TestFilteringHandler_WithAttrs(t *testing.T) {
 	}
 	if strings.Contains(out, "api_ABCDEFGHIJKLMN") {
 		t.Errorf("raw token should not appear: %q", out)
+	}
+}
+
+// secretValuer wraps a secret in a slog.LogValuer. The Resolve()
+// returns a string; without KindLogValuer handling in redactAttr the
+// secret would land in the inner handler unredacted.
+type secretValuer string
+
+func (s secretValuer) LogValue() slog.Value { return slog.StringValue(string(s)) }
+
+func TestFilteringHandler_RedactsLogValuer(t *testing.T) {
+	cap := newCapture()
+	logger := slog.New(NewHandler(cap, slog.LevelInfo))
+	logger.Info("vault dial",
+		slog.Any("token", secretValuer("evt_AABBCCDDEEFF112233")),
+	)
+
+	out := cap.buf.String()
+	if !strings.Contains(out, "evt_AABB***") {
+		t.Errorf("expected redacted token from LogValuer, got: %q", out)
+	}
+	if strings.Contains(out, "evt_AABBCCDDEEFF112233") {
+		t.Errorf("raw token leaked through LogValuer: %q", out)
+	}
+}
+
+// panickyStringer panics from String(). The handler must not crash
+// the program — losing redaction on this attr is acceptable; taking
+// down the logger is not.
+type panickyStringer struct{}
+
+func (panickyStringer) String() string { panic("intentional test panic") }
+
+func TestFilteringHandler_StringerPanicNonFatal(t *testing.T) {
+	cap := newCapture()
+	logger := slog.New(NewHandler(cap, slog.LevelInfo))
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("logger should swallow Stringer panic, got: %v", r)
+		}
+	}()
+
+	logger.Info("attempt", slog.Any("payload", panickyStringer{}))
+
+	if cap.buf.Len() == 0 {
+		t.Errorf("expected the rest of the record to still be logged after Stringer panic")
 	}
 }
 


### PR DESCRIPTION
문제점: 그동안 obs 패키지는 TODO 투성이 stub. 즉
  - Vault 토큰이 error message 에 그대로 노출
  - envector API key 가 attr 으로 stderr 직출
  - ~/.rune/logs/rune-mcp.log 도 동일 — dev 가 화면공유로 tail 하면 그대로 새는 구조

또한 obs.NewHandler 는 어디서도 안 쓰이고 있어서 현재 default slog 가 raw text 만 출력.

변경 — 3가지 layer:

(1) filteringHandler 새 타입 — slog.Handler 인터페이스의 4 메서드 구현:
- Handle: Record 의 Message + 모든 string-typed attr 을 redact 통과시킴
- WithAttrs: logger.With(slog.String("api_key", ...)) 도 redact
- WithGroup: 중첩 group attr 도 redact (재귀)
- Enabled: inner handler 에 위임

(2) Redaction regex 두 개 (Python _SensitiveFilter 와 1:1 동일):
(sk-|pk-|api_|envector_|evt_)[a-zA-Z0-9_-]{10,}
(?i)(token|key|secret|password)["\s:=]+[a-zA-Z0-9_-]{20,}
match 의 첫 8글자만 보존 + *** 추가:
- evt_AABBCCDD11223344 → evt_AABB***
- token: ABCDEFGHIJKLMNOP... → token: A***

prefix 일부는 grep 가능하게 남겨서 incident 조사 시 매칭 가능.

(3) NewRequestID UUID v4 — crypto/rand 기반 36자 UUID. rand.Read 실패하면 panic 대신 req-anon 으로 fallback (broken host RNG 에서도 서버는 살아있게).

(4) main.go wire: stderr 와 file tee (있을 시) 둘 다 obs.NewHandler 거쳐서 redaction 적용. RUNE_MCP_LOG_FILE 안 셋팅한 production 도 redaction 활성화.



internal/obs/slog.go was full of TODOs that left rune-mcp logging unfiltered: a Vault token in an error message, an envector_ API key in an attr, or a labeled secret in a debug message all flowed through to stderr (and the optional file tee) verbatim. This is a real exposure on dev hosts where users tail ~/.rune/logs/rune-mcp.log over screen share, and a worse one for any future production deploy that ships logs off-host.

Implementation
--------------

filteringHandler wraps an inner slog.Handler. Each Record's Message plus every string-typed attr (recursing into KindGroup, best-effort on KindAny w/ fmt.Stringer) is rewritten through two regexes ported 1-for-1 from Python's _SensitiveFilter:

  (sk-|pk-|api_|envector_|evt_)[a-zA-Z0-9_-]{10,}
  (?i)(token|key|secret|password)["\s:=]+[a-zA-Z0-9_-]{20,}

Replacement keeps the first 8 chars of the match plus "***", so prefixes like "evt_AABB***" stay grep-able for incident investigation while the body is destroyed. Strings ≤8 chars get the full "***" treatment — preserving prefix would leak the secret.

WithAttrs / WithGroup chain through the inner handler so logger.With( slog.String("api_key", ...)) is also caught.

NewRequestID returns RFC 4122 v4 UUIDs from crypto/rand. Falls back to "req-anon" on rand.Read failure rather than panicking — a working log without per-request correlation beats a crashing server. Format
+ uniqueness + roundtrip-via-context are all covered.

Wiring
------

cmd/rune-mcp/main.go now always wraps the chosen TextHandler with obs.NewHandler before SetDefault. Both stderr-only and tee-to-file flows go through redaction; an unset RUNE_MCP_LOG_FILE no longer means "skip filtering."

Tests
-----

Adds slog_test.go covering: each token prefix once, labeled-secret edge cases (JSON quoting, =, " ", short-fail), filteringHandler vs attrs / message / With(), UUID format + uniqueness across 1024 ids
+ context round-trip.
[](url)