### PR TITLE
chore: v04 hardening

### DIFF
--- a/internal/adapters/vault/endpoint.go
+++ b/internal/adapters/vault/endpoint.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"net"
 	"net/url"
 	"strings"
 )
@@ -17,24 +18,65 @@ import (
 //	"host"                    → "host:50051" (default port)
 //
 // Returns normalized "host:port" suitable for grpc.NewClient.
-// TODO: full implementation with url.Parse and default port handling.
+//
+// Implementation notes:
+//   - tcp:// / http:// / https:// all flow through url.Parse so a raw IPv6
+//     literal (e.g. "tcp://[::1]:50051") is split correctly.
+//   - Schemeless inputs are treated as authority only — url.Parse can't be
+//     used directly on "host:port" since it'd interpret "host" as the
+//     scheme.
+//   - Default port (50051) is appended in exactly one place — the host
+//     never carries a port at the end of the function path means we add it.
+const defaultGRPCPort = "50051"
+
 func NormalizeEndpoint(raw string) (string, error) {
-	if strings.HasPrefix(raw, "tcp://") {
-		return strings.TrimPrefix(raw, "tcp://"), nil
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", &Error{Code: "VAULT_BAD_ENDPOINT", Message: "endpoint is empty"}
 	}
-	if strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
+
+	var host string
+	switch {
+	case strings.HasPrefix(raw, "tcp://"),
+		strings.HasPrefix(raw, "http://"),
+		strings.HasPrefix(raw, "https://"):
 		u, err := url.Parse(raw)
 		if err != nil {
-			return "", err
+			return "", &Error{Code: "VAULT_BAD_ENDPOINT", Message: "parse endpoint: " + err.Error()}
 		}
-		host := u.Host
-		if !strings.Contains(host, ":") {
-			host += ":50051"
+		host = u.Host
+	default:
+		host = raw
+	}
+
+	if host == "" {
+		return "", &Error{Code: "VAULT_BAD_ENDPOINT", Message: "endpoint missing host: " + raw}
+	}
+
+	// Append default port unless one is already present. Treat trailing
+	// `:port` on an IPv6 literal correctly: bracketed forms like "[::1]"
+	// have no `:` outside the brackets after the closing `]`.
+	//
+	// url.Parse already returns IPv6 hosts in their bracketed form
+	// ("[::1]"), so calling net.JoinHostPort on them double-brackets.
+	// Append manually in that case; otherwise JoinHostPort handles
+	// hostnames + IPv4 + un-bracketed IPv6 (which url.Parse never
+	// produces, but a direct caller might).
+	if !hasPort(host) {
+		if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+			host = host + ":" + defaultGRPCPort
+		} else {
+			host = net.JoinHostPort(host, defaultGRPCPort)
 		}
-		return host, nil
 	}
-	if !strings.Contains(raw, ":") {
-		raw += ":50051"
+	return host, nil
+}
+
+// hasPort reports whether host already carries a `:port` suffix.
+// Handles IPv6 literals: "[::1]" → false, "[::1]:50051" → true.
+func hasPort(host string) bool {
+	if strings.HasPrefix(host, "[") {
+		return strings.Contains(host[strings.Index(host, "]"):], ":")
 	}
-	return raw, nil
+	return strings.Contains(host, ":")
 }

--- a/internal/adapters/vault/endpoint_test.go
+++ b/internal/adapters/vault/endpoint_test.go
@@ -1,0 +1,69 @@
+package vault
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeEndpoint(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"tcp scheme with port", "tcp://vault.example.com:50051", "vault.example.com:50051"},
+		{"tcp scheme without port", "tcp://vault.example.com", "vault.example.com:50051"},
+		{"http scheme with port", "http://vault.example.com:8080", "vault.example.com:8080"},
+		{"http scheme without port", "http://vault.example.com", "vault.example.com:50051"},
+		{"https scheme with port and path", "https://vault.example.com:443/api", "vault.example.com:443"},
+		{"https scheme without port", "https://vault.example.com", "vault.example.com:50051"},
+		{"bare host:port", "vault.example.com:50051", "vault.example.com:50051"},
+		{"bare host without port", "vault.example.com", "vault.example.com:50051"},
+		{"loopback IPv4", "127.0.0.1:50051", "127.0.0.1:50051"},
+		{"IPv6 with port via tcp", "tcp://[::1]:50051", "[::1]:50051"},
+		{"IPv6 without port via tcp", "tcp://[::1]", "[::1]:50051"},
+		{"trims surrounding whitespace", "  tcp://vault.example.com:50051  ", "vault.example.com:50051"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := NormalizeEndpoint(c.in)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Fatalf("NormalizeEndpoint(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeEndpoint_Errors(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        string
+		wantCode  string
+		wantInMsg string
+	}{
+		{"empty", "", "VAULT_BAD_ENDPOINT", "empty"},
+		{"whitespace only", "   ", "VAULT_BAD_ENDPOINT", "empty"},
+		{"scheme only", "tcp://", "VAULT_BAD_ENDPOINT", "missing host"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := NormalizeEndpoint(c.in)
+			if err == nil {
+				t.Fatalf("expected error for %q, got nil", c.in)
+			}
+			ve, ok := err.(*Error)
+			if !ok {
+				t.Fatalf("expected *vault.Error, got %T", err)
+			}
+			if ve.Code != c.wantCode {
+				t.Fatalf("Code = %q, want %q", ve.Code, c.wantCode)
+			}
+			if !strings.Contains(ve.Message, c.wantInMsg) {
+				t.Fatalf("Message = %q, want substring %q", ve.Message, c.wantInMsg)
+			}
+		})
+	}
+}

--- a/internal/service/lifecycle.go
+++ b/internal/service/lifecycle.go
@@ -486,17 +486,17 @@ type WarmupInfo struct {
 // WarmupTimeout — Python WARMUP_TIMEOUT (server.py:L1059). 60s.
 const WarmupTimeout = 60 * time.Second
 
-// ReloadPipelines — re-init + warmup
+// ReloadPipelines — re-trigger the boot loop from Dormant + warmup envector.
 //
-// TODO: currently a no-op for state recovery — only envector warmup probe runs.
-// Full re-init requires:
-//   1. internal/lifecycle/boot.go::RunBootLoop body (Vault.GetAgentManifest + bundle setup
-//      + envector.NewClient + state=Active transition)
-//   2. wiring here to re-trigger boot logic on call (state.SetState(Starting) +
-//      RunBootLoop re-invoke, or a shared _init_pipelines helper called from both
-//      startup and this function)
-// Until both land, /rune:activate cannot recover from dormant or trigger first-time
-// pipeline init.
+// On a terminal Dormant state (boot loop's goroutine has exited), call
+// Manager.Retrigger to spawn a fresh RunBootLoop bound to the same ctx +
+// Deps; main.go wires the spawn callback at startup. Manager.Retrigger
+// is a silent no-op when state is Starting / WaitingForVault / Active —
+// safe to call unconditionally if the trigger surface ever widens.
+//
+// /rune:activate from a freshly-spawned MCP server (no ~/.rune/config.json
+// at boot, then user ran /rune:configure) reaches Active via this path.
+// No process restart is required.
 func (s *LifecycleService) ReloadPipelines(ctx context.Context) (*ReloadPipelinesResult, error) {
 	// Dormant terminal: the boot loop has exited. Ask Manager to spawn a
 	// fresh attempt (Manager.Retrigger silently no-ops on non-dormant

--- a/internal/service/recall.go
+++ b/internal/service/recall.go
@@ -36,10 +36,33 @@ func NewRecallService() *RecallService {
 	return &RecallService{Now: time.Now}
 }
 
-// Handle — Python: server.py:L910-1034 tool_recall + searcher.search().
+// External-IO call deadlines (per call, not aggregate). Each external op
+// gets a fresh context derived from the caller's; the constants are
+// upper bounds — a healthy stack returns in milliseconds. Picking these
+// values:
 //
-// TODO: External IO calls (Embedder, Envector, Vault) do not have explicit timeouts.
-// We should add context timeouts (context.WithTimeout) for these operations after we determine optimal duration
+//   - embedder: runed has typically <100ms latency on warm queries;
+//     10s tolerates first-call cold starts when ggml loads weights.
+//   - envector Score: FHE inner-product is the heaviest hop on the
+//     recall path — 30s mirrors Python's WARMUP_TIMEOUT bound.
+//   - envector GetMetadata: shard/row lookup of cipher metadata; 15s.
+//   - vault DecryptScores: FHE decrypt, also heavy; 30s.
+//   - vault DecryptMetadata: AES-only, fast even when batched; 30s
+//     bounds pathological large batches.
+//
+// These exist so a hung dependency surfaces as a typed error in seconds
+// instead of stalling the MCP request indefinitely (gRPC keepalive
+// alone won't fail an active call when the server replies but never
+// finishes).
+const (
+	embedderCallTimeout         = 10 * time.Second
+	envectorScoreTimeout        = 30 * time.Second
+	envectorMetadataTimeout     = 15 * time.Second
+	vaultDecryptScoresTimeout   = 30 * time.Second
+	vaultDecryptMetadataTimeout = 30 * time.Second
+)
+
+// Handle — Python: server.py:L910-1034 tool_recall + searcher.search().
 func (s *RecallService) Handle(ctx context.Context, args *domain.RecallArgs) (*domain.RecallResult, error) {
 	// Phase 2: parse query
 	parsed := policy.Parse(args.Query)
@@ -50,7 +73,9 @@ func (s *RecallService) Handle(ctx context.Context, args *domain.RecallArgs) (*d
 	}
 
 	// Phase 3: embed expansions
-	vectors, err := s.Embedder.EmbedBatch(ctx, expansions)
+	embedCtx, cancel := context.WithTimeout(ctx, embedderCallTimeout)
+	vectors, err := s.Embedder.EmbedBatch(embedCtx, expansions)
+	cancel()
 	if err != nil {
 		return nil, fmt.Errorf("embed expansions: %w", err)
 	}
@@ -126,7 +151,9 @@ func (s *RecallService) searchWithExpansions(
 		}
 	}
 	if !originalInExps && s.Embedder != nil {
-		vec, err := s.Embedder.EmbedSingle(ctx, original)
+		embedCtx, cancel := context.WithTimeout(ctx, embedderCallTimeout)
+		vec, err := s.Embedder.EmbedSingle(embedCtx, original)
+		cancel()
 		if err == nil {
 			hits, err := s.searchSingle(ctx, vec, topk)
 			if err == nil {
@@ -158,7 +185,9 @@ func (s *RecallService) searchWithExpansions(
 // as to where the pipeline shed rows.
 func (s *RecallService) searchSingle(ctx context.Context, vec []float32, topk int) ([]domain.SearchHit, error) {
 	// Score
-	blobs, err := s.Envector.Score(ctx, vec)
+	scoreCtx, cancel := context.WithTimeout(ctx, envectorScoreTimeout)
+	blobs, err := s.Envector.Score(scoreCtx, vec)
+	cancel()
 	if err != nil {
 		slog.Warn("recall: envector score failed", "err", err)
 		return nil, fmt.Errorf("envector score: %w", err)
@@ -179,7 +208,9 @@ func (s *RecallService) searchSingle(ctx context.Context, vec []float32, topk in
 	// proto3 string-validation path and trips
 	// "grpc: error while marshaling: string field contains invalid UTF-8".
 	encryptedBlobB64 := base64.StdEncoding.EncodeToString(blobs[0])
-	entries, err := s.Vault.DecryptScores(ctx, encryptedBlobB64, topk)
+	decCtx, cancel := context.WithTimeout(ctx, vaultDecryptScoresTimeout)
+	entries, err := s.Vault.DecryptScores(decCtx, encryptedBlobB64, topk)
+	cancel()
 	if err != nil {
 		slog.Warn("recall: vault decrypt_scores failed", "err", err)
 		return nil, fmt.Errorf("vault decrypt scores: %w", err)
@@ -194,7 +225,9 @@ func (s *RecallService) searchSingle(ctx context.Context, vec []float32, topk in
 	for i, e := range entries {
 		refs[i] = envector.MetadataRef{ShardIdx: uint64(e.ShardIdx), RowIdx: uint64(e.RowIdx)}
 	}
-	metaEntries, err := s.Envector.GetMetadata(ctx, refs, []string{"metadata"})
+	metaCtx, cancel := context.WithTimeout(ctx, envectorMetadataTimeout)
+	metaEntries, err := s.Envector.GetMetadata(metaCtx, refs, []string{"metadata"})
+	cancel()
 	if err != nil {
 		slog.Warn("recall: envector get_metadata failed", "err", err, "refs", len(refs))
 		return nil, fmt.Errorf("envector get_metadata: %w", err)
@@ -299,11 +332,15 @@ func (s *RecallService) resolveMetadata(ctx context.Context, entries []envector.
 
 	// Batch decrypt AES envelopes
 	if len(aesList) > 0 && s.Vault != nil {
-		decrypted, err := s.Vault.DecryptMetadata(ctx, aesList)
+		batchCtx, batchCancel := context.WithTimeout(ctx, vaultDecryptMetadataTimeout)
+		decrypted, err := s.Vault.DecryptMetadata(batchCtx, aesList)
+		batchCancel()
 		if err != nil {
 			slog.Warn("batch decrypt failed, trying per-entry", "err", err)
 			for j, aesIdx := range aesIndices {
-				single, singleErr := s.Vault.DecryptMetadata(ctx, []string{aesList[j]})
+				singleCtx, singleCancel := context.WithTimeout(ctx, vaultDecryptMetadataTimeout)
+				single, singleErr := s.Vault.DecryptMetadata(singleCtx, []string{aesList[j]})
+				singleCancel()
 				if singleErr == nil && len(single) > 0 {
 					var parsed map[string]any
 					if json.Unmarshal([]byte(single[0]), &parsed) == nil {
@@ -441,7 +478,9 @@ func (s *RecallService) expandPhaseChains(ctx context.Context, results []domain.
 
 	for _, g := range incomplete {
 		query := fmt.Sprintf("Group: %s", g.gid)
-		vec, err := s.Embedder.EmbedSingle(ctx, query)
+		embedCtx, cancel := context.WithTimeout(ctx, embedderCallTimeout)
+		vec, err := s.Embedder.EmbedSingle(embedCtx, query)
+		cancel()
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
a. Vault endpoint 정규화 (internal/adapters/vault/endpoint.go)

문제: NormalizeEndpoint 가 미완성. 두 edge case 가 silently broken:
- tcp://host (포트 없음) → 기본 :50051 안 붙고 그대로 반환
- tcp://[::1]:50051 (IPv6 리터럴) → 처리 경로 없음

변경:
- 세 scheme (tcp/http/https) 모두 url.Parse 통과시켜 host 추출
- 단일 defaulting step 에서 포트 없으면 :50051 추가
- IPv6 ([::1]) 의 경우 url.Parse 가 이미 brackets 채워주니 net.JoinHostPort 가 double-bracket 안 하도록 분기
- 빈 입력 / scheme-only 입력 (tcp://) → typed VAULT_BAD_ENDPOINT 에러
- 12개 happy-path + 3개 에러 case 테스트 추가

영향: Vault endpoint 입력 robustness. 사용자가 tcp://vault.cryptolab.co.kr 처럼 포트 안 적어도 동작.

b. Stale TODO 주석 정리 (internal/service/lifecycle.go:489)
변경: TODO 블록을 실제 contract 설명으로 교체.

c. Recall external-IO timeouts (internal/service/recall.go)

문제: recall 파이프라인이 8개 외부 RPC 를 호출하는데 (Embedder 3, Envector 2, Vault 3) gRPC keepalive 만 의존. keepalive 는 connection 끊김만 감지 — 서버가 ACK 보내고 stream 만 잡고 응답 안 주면 무한 hang. FHE 부하 큰 envector cluster 나 느린 Vault 호스트에서 실재 risk.

변경:
- 5개 timeout 상수 + 각 외부 호출을 context.WithTimeout 으로 감쌈
- embedder 10s, envector Score 30s, envector Metadata 15s, vault DecryptScores 30s, vault DecryptMetadata 30s
- 각 호출 직후 cancel() 로 timer resource 즉시 해제
- TODO 주석 제거