### PR TITLE
feat(mcp): recovering enVector connection on failure

### DIFF
--- a/cmd/rune-mcp/main.go
+++ b/cmd/rune-mcp/main.go
@@ -145,6 +145,9 @@ func buildDeps() *mcp.Deps {
 	cap.State = mgr
 	cap.CaptureLog = captureLog
 
+	rec := service.NewRecallService()
+	rec.State = mgr
+
 	life := service.NewLifecycleService()
 	life.State = mgr
 	life.ConfigDir = runeDir
@@ -152,7 +155,7 @@ func buildDeps() *mcp.Deps {
 	return &mcp.Deps{
 		State:     mgr,
 		Capture:   cap,
-		Recall:    service.NewRecallService(),
+		Recall:    rec,
 		Lifecycle: life,
 	}
 }

--- a/internal/adapters/envector/errors.go
+++ b/internal/adapters/envector/errors.go
@@ -29,6 +29,16 @@ func (e *Error) Error() string {
 // Unwrap allows errors.Is / errors.As to inspect the cause.
 func (e *Error) Unwrap() error { return e.Cause }
 
+func IsAdapterError(err error) bool {
+	var e *Error
+	return errors.As(err, &e)
+}
+
+func IsRetryable(err error) bool {
+	var e *Error
+	return errors.As(err, &e) && e.Retryable
+}
+
 // Sentinel errors — spec §에러 처리.
 var (
 	// Connection / transport.

--- a/internal/lifecycle/boot.go
+++ b/internal/lifecycle/boot.go
@@ -103,25 +103,24 @@ func (m *Manager) SetReloadFunc(f func()) {
 	m.onReload.Store(f)
 }
 
-// Retrigger respawns the boot loop only if no loop is currently running.
-//
-// Concretely it fires only when state is Dormant — the boot loop returns
-// after a terminal Dormant (config missing / not_configured /
-// vault_unconfigured / user_deactivated), so its goroutine has exited and
-// a re-spawn is safe. While state is Starting / WaitingForVault / Active
-// a goroutine is still active (retrying or already succeeded), so firing
-// would race; Retrigger silently no-ops in those cases — the existing
-// loop's progress is what the caller will observe via state polling.
+// Retrigger respawns the boot loop only if no loop is currently running and
+// only one caller wins when called concurrently
+// Transitioning Active to Starting (or Dormant to Starting) atomically claims
+// right to spawn RunBootLoop
 func (m *Manager) Retrigger() {
-	if m.Current() != StateDormant {
-		return
-	}
 	v := m.onReload.Load()
 	if v == nil {
 		return
 	}
+
 	f, ok := v.(func())
 	if !ok || f == nil {
+		return
+	}
+
+	// Atomically claim the right to spawn. Losers fall through and return.
+	if !m.state.CompareAndSwap(int32(StateActive), int32(StateStarting)) &&
+		!m.state.CompareAndSwap(int32(StateDormant), int32(StateStarting)) {
 		return
 	}
 	f()

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -18,6 +18,9 @@ package mcp
 
 import (
 	"fmt"
+	"io"
+	"log/slog"
+	"time"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -46,7 +49,10 @@ type Deps struct {
 	Lifecycle *service.LifecycleService
 }
 
+const staleClientCloseTime = 5 * time.Second
+
 func (d *Deps) InjectVault(client vault.Client) {
+	prev := d.Vault
 	d.Vault = client
 	if d.Capture != nil {
 		d.Capture.Vault = client
@@ -57,9 +63,11 @@ func (d *Deps) InjectVault(client vault.Client) {
 	if d.Lifecycle != nil {
 		d.Lifecycle.Vault = client
 	}
+	closeAfterInterval("vault", prev, client)
 }
 
 func (d *Deps) InjectEmbedder(client embedder.Client) {
+	prev := d.Embedder
 	d.Embedder = client
 	if d.Capture != nil {
 		d.Capture.Embedder = client
@@ -70,9 +78,11 @@ func (d *Deps) InjectEmbedder(client embedder.Client) {
 	if d.Lifecycle != nil {
 		d.Lifecycle.Embedder = client
 	}
+	closeAfterInterval("embedder", prev, client)
 }
 
 func (d *Deps) InjectEnvector(client envector.Client) {
+	prev := d.Envector
 	d.Envector = client
 	if d.Capture != nil {
 		d.Capture.Envector = client
@@ -83,6 +93,22 @@ func (d *Deps) InjectEnvector(client envector.Client) {
 	if d.Lifecycle != nil {
 		d.Lifecycle.Envector = client
 	}
+	closeAfterInterval("envector", prev, client)
+}
+
+// Reserve Close() on a replaced client after a period to drain concurrent
+// in-flight gRPCs against the old connection
+func closeAfterInterval(name string, prev, next io.Closer) {
+	if prev == nil || prev == next {
+		return
+	}
+
+	go func() {
+		time.Sleep(staleClientCloseTime)
+		if err := prev.Close(); err != nil {
+			slog.Warn("close replaced adapter client", "name", name, "err", err)
+		}
+	}()
 }
 
 // ApplyVaultBundle propagates per-bundle metadata (AgentID / AgentDEK /

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -98,6 +98,9 @@ func (d *Deps) InjectEnvector(client envector.Client) {
 
 // Reserve Close() on a replaced client after a period to drain concurrent
 // in-flight gRPCs against the old connection
+//
+// TODO: A proper fix would track every calls on the old client via refcount or
+// sync.WaitGroup and Close()
 func closeAfterInterval(name string, prev, next io.Closer) {
 	if prev == nil || prev == next {
 		return

--- a/internal/service/capture.go
+++ b/internal/service/capture.go
@@ -143,7 +143,10 @@ func (s *CaptureService) Handle(ctx context.Context, req *domain.CaptureRequest)
 		Vectors:  vectors,
 		Metadata: envelopes,
 	}
-	insertResult, err := s.Envector.Insert(ctx, insertReq)
+	insertResult, err := withEnvectorRetry(ctx, s.State, "insert",
+		func() (*envector.InsertResult, error) {
+			return s.Envector.Insert(ctx, insertReq)
+		})
 	if err != nil {
 		return nil, fmt.Errorf("envector insert: %w", err)
 	}
@@ -269,7 +272,10 @@ func (s *CaptureService) runNoveltyCheck(ctx context.Context, embeddingText stri
 		return &domain.NoveltyInfo{Score: 1.0, Class: "novel"}, nil, nil
 	}
 
-	blobs, err := s.Envector.Score(ctx, vec)
+	blobs, err := withEnvectorRetry(ctx, s.State, "score (novelty)",
+		func() ([][]byte, error) {
+			return s.Envector.Score(ctx, vec)
+		})
 	if err != nil || len(blobs) == 0 {
 		slog.Warn("novelty check: score failed (non-fatal)", "err", err)
 		return &domain.NoveltyInfo{Score: 1.0, Class: "novel"}, nil, nil

--- a/internal/service/diagnostics_classify.go
+++ b/internal/service/diagnostics_classify.go
@@ -41,12 +41,12 @@ func ClassifyEnvectorError(err error, elapsed time.Duration) (EnvectorErrorType,
 
 	switch st.Code() {
 	case codes.Unavailable:
-		return EnvErrConnectionRefused, "Check that the enVector endpoint is correct and reachable from this machine"
+		return EnvErrConnectionRefused, "enVector cluster appears unreachable from this host - check network connectivity"
 	case codes.Unauthenticated:
-		return EnvErrAuthFailure, "enVector API key may be invalid or expired"
+		return EnvErrAuthFailure, "enVector API key was rejected - contact your Vault administrator"
 	case codes.DeadlineExceeded:
-		return EnvErrDeadlineExceeded, "The enVector gRPC deadline was exceeded. Run /rune:activate to pre-warm, then retry /rune:status"
+		return EnvErrDeadlineExceeded, "enVector gRPC deadline exceeded - check network latency to the cluster"
 	default:
-		return EnvErrUnknown, "Run /rune:activate to reinitialize the connection, or check network connectivity"
+		return EnvErrUnknown, "enVector probe failed after recovery attempt - check network connectivity"
 	}
 }

--- a/internal/service/lifecycle.go
+++ b/internal/service/lifecycle.go
@@ -274,7 +274,7 @@ func (s *LifecycleService) collectEnvector(ctx context.Context, timeout time.Dur
 	if err == nil {
 		return info
 	}
-	if s.State == nil || !isEnvectorAdapterErr(err) {
+	if s.State == nil || !envector.IsAdapterError(err) {
 		return info
 	}
 

--- a/internal/service/lifecycle.go
+++ b/internal/service/lifecycle.go
@@ -261,54 +261,73 @@ func (s *LifecycleService) collectEmbedding(ctx context.Context, timeout time.Du
 	return info
 }
 
-// collectEnvector wraps GetIndexList under timeout + ClassifyEnvectorError
+// collectEnvector probes envector, and on any envector adapter error
+// re-triggers the boot loop and probes once more before reporting
+// This is because the user only configures Vault credentails; the enVector
+// endpoint and keys arrive via Vault (recovery is system's job)
 func (s *LifecycleService) collectEnvector(ctx context.Context, timeout time.Duration) EnvectorInfo {
 	if s.Envector == nil {
 		return EnvectorInfo{}
 	}
 
-	type result struct {
-		err error
+	info, err := s.probeEnvector(ctx, timeout)
+	if err == nil {
+		return info
+	}
+	if s.State == nil || !isEnvectorAdapterErr(err) {
+		return info
 	}
 
+	slog.Warn("diagnostics: envector probe failed - re-bootstrapping", "err", err)
+	s.State.Retrigger()
+	if !waitForActiveAfterRetrigger(ctx, s.State, retriggerSettleTimeout) {
+		slog.Warn("diagnostics: re-boot did not settle to active")
+		return info
+	}
+
+	info2, _ := s.probeEnvector(ctx, timeout)
+	return info2
+}
+
+// Decide whether to attemp recovery or not
+func (s *LifecycleService) probeEnvector(ctx context.Context, timeout time.Duration) (EnvectorInfo, error) {
 	ctx2, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	ch := make(chan result, 1)
+	ch := make(chan error, 1)
 	t0 := time.Now()
 
 	go func() {
 		_, err := s.Envector.GetIndexList(ctx2)
-		ch <- result{err: err}
+		ch <- err
 	}()
 
 	select {
-	case res := <-ch:
+	case probeErr := <-ch:
 		elapsed := time.Since(t0)
-		if res.err != nil {
-			errType, hint := ClassifyEnvectorError(res.err, elapsed)
+		if probeErr == nil {
 			return EnvectorInfo{
-				Error:     res.err.Error(),
-				ErrorType: string(errType),
-				Hint:      hint,
-				ElapsedMs: float64(elapsed.Milliseconds()),
-			}
+				Reachable: true,
+				LatencyMs: float64(elapsed.Milliseconds()),
+			}, nil
 		}
+		errType, hint := ClassifyEnvectorError(probeErr, elapsed)
 		return EnvectorInfo{
-			Reachable: true,
-			LatencyMs: float64(elapsed.Milliseconds()),
-		}
+			Error:     probeErr.Error(),
+			ErrorType: string(errType),
+			Hint:      hint,
+			ElapsedMs: float64(elapsed.Milliseconds()),
+		}, probeErr
 	case <-ctx2.Done():
 		elapsed := time.Since(t0)
 		return EnvectorInfo{
 			Error: fmt.Sprintf(
-				"Health check timed out after %.0fs (elapsed: %.1fms). "+
-					"Run /rune:activate to pre-warm the connection, then retry /rune:status.",
+				"Health check timed out after %.0fs (elapsed: %.1fms).",
 				timeout.Seconds(), float64(elapsed.Milliseconds()),
 			),
 			ErrorType: string(EnvErrTimeout),
 			ElapsedMs: float64(elapsed.Milliseconds()),
-		}
+		}, ctx2.Err()
 	}
 }
 
@@ -498,8 +517,8 @@ const WarmupTimeout = 60 * time.Second
 // at boot, then user ran /rune:configure) reaches Active via this path.
 // No process restart is required.
 func (s *LifecycleService) ReloadPipelines(ctx context.Context) (*ReloadPipelinesResult, error) {
-  // Always re-trigger so config changes such as new vault endpoint and rotated token are picked
-  // without restarting MCP
+	// Always re-trigger so config changes such as new vault endpoint and rotated token are picked
+	// without restarting MCP
 	s.State.Retrigger()
 	s.waitForBootProgress(ctx, 5*time.Second)
 

--- a/internal/service/lifecycle.go
+++ b/internal/service/lifecycle.go
@@ -498,15 +498,10 @@ const WarmupTimeout = 60 * time.Second
 // at boot, then user ran /rune:configure) reaches Active via this path.
 // No process restart is required.
 func (s *LifecycleService) ReloadPipelines(ctx context.Context) (*ReloadPipelinesResult, error) {
-	// Dormant terminal: the boot loop has exited. Ask Manager to spawn a
-	// fresh attempt (Manager.Retrigger silently no-ops on non-dormant
-	// states, so this is also safe to call unconditionally if we ever
-	// expand the trigger surface). Then poll for up to 5s so the response
-	// reflects the new state instead of the stale dormant snapshot.
-	if s.State.Current() == lifecycle.StateDormant {
-		s.State.Retrigger()
-		s.waitForBootProgress(ctx, 5*time.Second)
-	}
+  // Always re-trigger so config changes such as new vault endpoint and rotated token are picked
+  // without restarting MCP
+	s.State.Retrigger()
+	s.waitForBootProgress(ctx, 5*time.Second)
 
 	result := &ReloadPipelinesResult{
 		OK:    true,

--- a/internal/service/recall.go
+++ b/internal/service/recall.go
@@ -184,14 +184,19 @@ func (s *RecallService) searchWithExpansions(
 // breadcrumb, since callers used to see only "no results" with no signal
 // as to where the pipeline shed rows.
 func (s *RecallService) searchSingle(ctx context.Context, vec []float32, topk int) ([]domain.SearchHit, error) {
-	// Score
-	scoreCtx, cancel := context.WithTimeout(ctx, envectorScoreTimeout)
-	blobs, err := s.Envector.Score(scoreCtx, vec)
-	cancel()
+  // Score
+  // Re-trigger boot and retry once with updated enVector client
+	blobs, err := withEnvectorRetry(ctx, s.State, "score",
+		func() ([][]byte, error) {
+			scoreCtx, cancel := context.WithTimeout(ctx, envectorScoreTimeout)
+			defer cancel()
+			return s.Envector.Score(scoreCtx, vec)
+		})
 	if err != nil {
 		slog.Warn("recall: envector score failed", "err", err)
 		return nil, fmt.Errorf("envector score: %w", err)
 	}
+
 	slog.Info("recall: envector score returned",
 		"blobs", len(blobs),
 		"first_blob_bytes", firstBlobLen(blobs),
@@ -225,13 +230,19 @@ func (s *RecallService) searchSingle(ctx context.Context, vec []float32, topk in
 	for i, e := range entries {
 		refs[i] = envector.MetadataRef{ShardIdx: uint64(e.ShardIdx), RowIdx: uint64(e.RowIdx)}
 	}
-	metaCtx, cancel := context.WithTimeout(ctx, envectorMetadataTimeout)
-	metaEntries, err := s.Envector.GetMetadata(metaCtx, refs, []string{"metadata"})
-	cancel()
+
+  // Re-trigger boot and retry once with updated enVector client
+	metaEntries, err := withEnvectorRetry(ctx, s.State, "get_metadata",
+		func() ([]envector.MetadataEntry, error) {
+			metaCtx, cancel := context.WithTimeout(ctx, envectorMetadataTimeout)
+			defer cancel()
+			return s.Envector.GetMetadata(metaCtx, refs, []string{"metadata"})
+		})
 	if err != nil {
 		slog.Warn("recall: envector get_metadata failed", "err", err, "refs", len(refs))
 		return nil, fmt.Errorf("envector get_metadata: %w", err)
 	}
+
 	slog.Info("recall: envector get_metadata returned",
 		"metaEntries", len(metaEntries),
 		"refs", len(refs),

--- a/internal/service/recall.go
+++ b/internal/service/recall.go
@@ -184,8 +184,8 @@ func (s *RecallService) searchWithExpansions(
 // breadcrumb, since callers used to see only "no results" with no signal
 // as to where the pipeline shed rows.
 func (s *RecallService) searchSingle(ctx context.Context, vec []float32, topk int) ([]domain.SearchHit, error) {
-  // Score
-  // Re-trigger boot and retry once with updated enVector client
+	// Score
+	// Re-trigger boot and retry once with updated enVector client
 	blobs, err := withEnvectorRetry(ctx, s.State, "score",
 		func() ([][]byte, error) {
 			scoreCtx, cancel := context.WithTimeout(ctx, envectorScoreTimeout)
@@ -231,7 +231,7 @@ func (s *RecallService) searchSingle(ctx context.Context, vec []float32, topk in
 		refs[i] = envector.MetadataRef{ShardIdx: uint64(e.ShardIdx), RowIdx: uint64(e.RowIdx)}
 	}
 
-  // Re-trigger boot and retry once with updated enVector client
+	// Re-trigger boot and retry once with updated enVector client
 	metaEntries, err := withEnvectorRetry(ctx, s.State, "get_metadata",
 		func() ([]envector.MetadataEntry, error) {
 			metaCtx, cancel := context.WithTimeout(ctx, envectorMetadataTimeout)

--- a/internal/service/retry.go
+++ b/internal/service/retry.go
@@ -26,6 +26,11 @@ func IsEnvectorRetryable(err error) bool {
 	return e.Retryable
 }
 
+func isEnvectorAdapterErr(err error) bool {
+	var e *envector.Error
+	return errors.As(err, &e)
+}
+
 // Re-trigger boot loop if enVector connection failure occurred since it might be
 // caused by outdated configurations
 func withEnvectorRetry[T any](

--- a/internal/service/retry.go
+++ b/internal/service/retry.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/envector/rune-go/internal/adapters/envector"
+	"github.com/envector/rune-go/internal/lifecycle"
+)
+
+const retriggerSettleTimeout = 30 * time.Second
+
+func IsEnvectorRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var e *envector.Error
+	if !errors.As(err, &e) {
+		return false
+	}
+
+	return e.Retryable
+}
+
+// Re-trigger boot loop if enVector connection failure occurred since it might be
+// caused by outdated configurations
+func withEnvectorRetry[T any](
+	ctx context.Context,
+	mgr *lifecycle.Manager,
+	op string,
+	fn func() (T, error),
+) (T, error) {
+	out, err := fn()
+	if err == nil {
+		return out, nil
+	}
+	if mgr == nil || !IsEnvectorRetryable(err) {
+		return out, err
+	}
+
+	slog.Warn("envector call failed with retryable error — re-bootstrapping",
+		"op", op,
+		"err", err)
+
+	mgr.Retrigger()
+	if !waitForActiveAfterRetrigger(ctx, mgr, retriggerSettleTimeout) {
+		var zero T
+		return zero, fmt.Errorf("envector %s: re-boot did not settle to active: %w", op, err)
+	}
+
+	return fn()
+}
+
+func waitForActiveAfterRetrigger(ctx context.Context, mgr *lifecycle.Manager, timeout time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		switch mgr.Current() {
+		case lifecycle.StateActive:
+			return true
+		case lifecycle.StateDormant:
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	return false
+}

--- a/internal/service/retry.go
+++ b/internal/service/retry.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -12,24 +11,6 @@ import (
 )
 
 const retriggerSettleTimeout = 30 * time.Second
-
-func IsEnvectorRetryable(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	var e *envector.Error
-	if !errors.As(err, &e) {
-		return false
-	}
-
-	return e.Retryable
-}
-
-func isEnvectorAdapterErr(err error) bool {
-	var e *envector.Error
-	return errors.As(err, &e)
-}
 
 // Re-trigger boot loop if enVector connection failure occurred since it might be
 // caused by outdated configurations
@@ -43,7 +24,7 @@ func withEnvectorRetry[T any](
 	if err == nil {
 		return out, nil
 	}
-	if mgr == nil || !IsEnvectorRetryable(err) {
+	if mgr == nil || !envector.IsRetryable(err) {
 		return out, err
 	}
 


### PR DESCRIPTION
## Summary

- What changed: Connection to enVector will be recovered automatically without user interaction
- Why: Since Rune retrieve enVector endpoint and key from the Vault, connection to enVector without user's manipulation should be preserved automatically
- Scope: mcp

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [ ] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [ ] No agent-specific script duplicates bootstrap/setup logic
- [ ] Agent-specific scripts remain thin adapters (registration/wiring only)
- [ ] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [ ] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [ ] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
