### PR TITLE
feat(mcp): add Embedder status on diagnostics

### DIFF
--- a/commands/claude/status.md
+++ b/commands/claude/status.md
@@ -35,7 +35,7 @@ System Health:
   [check] Agent DEK     : loaded / not loaded
   [check] Scribe        : ready / not initialized
   [check] Retriever     : ready / not initialized
-  [check] Embedder      : <status> (model: <model>, dim=<vector_dim>, uptime: <human>, requests: <n>)
+  [check] Embedder      : <status> (model: <model>, dim: <vector_dim>, uptime: <human>, requests: <n>)
                           socket: <socket_path>
                           info error:   <info_error>    (only when present)
                           health error: <health_error>  (only when present)
@@ -52,7 +52,7 @@ Use checkmarks for healthy items, X marks for issues.
 - X mark when `status` is `LOADING` / `DEGRADED` / `SHUTTING_DOWN` / `UNSPECIFIED`, or when any error field is populated
 - Show `socket_path` always when populated - it's the only way users can tell which runed instance they're talking to. Recall: runed is a shared singleton across sessions, so divergent socket paths between teammates indicate a misconfiguration.
 - Format `uptime_seconds` as a human-readable duration (e.g. `8h8m`, `37s`)
-- Omit `model` / `dim` rows when the embedder is not initialized (i.e. `model` empty AND `socket_path` empty — pre-boot)
+- Omit the entire `(model: ..., dim: ...)` parenthetical when the embedder is not initialized (i.e. `model` empty AND `socket_path` empty — pre-boot). In that case render just `Embedder : not initialized`.
 
 **Dormant Reason Display**: When `dormant_reason` is present in config or diagnostics, translate reason code into a user-friendly message:
 - `vault_unreachable`: "Vault server could not be reached. Check if it's running and the endpoint is correct."

--- a/commands/claude/status.md
+++ b/commands/claude/status.md
@@ -39,7 +39,6 @@ System Health:
                           socket: <socket_path>
                           info error:   <info_error>    (only when present)
                           health error: <health_error>  (only when present)
-  [check] LLM Provider  : <provider or "none">
   [check] enVector Cloud: reachable (<latency>ms) / unreachable
 
 Recommendations:

--- a/commands/claude/status.md
+++ b/commands/claude/status.md
@@ -35,6 +35,10 @@ System Health:
   [check] Agent DEK     : loaded / not loaded
   [check] Scribe        : ready / not initialized
   [check] Retriever     : ready / not initialized
+  [check] Embedder      : <status> (model: <model>, dim=<vector_dim>, uptime: <human>, requests: <n>)
+                          socket: <socket_path>
+                          info error:   <info_error>    (only when present)
+                          health error: <health_error>  (only when present)
   [check] LLM Provider  : <provider or "none">
   [check] enVector Cloud: reachable (<latency>ms) / unreachable
 
@@ -43,6 +47,13 @@ Recommendations:
 ```
 
 Use checkmarks for healthy items, X marks for issues.
+
+**Embedder rendering rules** (from diagnostics `embedding` section):
+- Check when `status == "OK"` and neither `info_error` nor `health_error` is set
+- X mark when `status` is `LOADING` / `DEGRADED` / `SHUTTING_DOWN` / `UNSPECIFIED`, or when any error field is populated
+- Show `socket_path` always when populated - it's the only way users can tell which runed instance they're talking to. Recall: runed is a shared singleton across sessions, so divergent socket paths between teammates indicate a misconfiguration.
+- Format `uptime_seconds` as a human-readable duration (e.g. `8h8m`, `37s`)
+- Omit `model` / `dim` rows when the embedder is not initialized (i.e. `model` empty AND `socket_path` empty — pre-boot)
 
 **Dormant Reason Display**: When `dormant_reason` is present in config or diagnostics, translate reason code into a user-friendly message:
 - `vault_unreachable`: "Vault server could not be reached. Check if it's running and the endpoint is correct."

--- a/internal/adapters/embedder/client.go
+++ b/internal/adapters/embedder/client.go
@@ -51,6 +51,7 @@ type Client interface {
 	EmbedBatch(ctx context.Context, texts []string) ([][]float32, error)
 	Info(ctx context.Context) (InfoSnapshot, error)
 	Health(ctx context.Context) (HealthSnapshot, error)
+	SocketPath() string
 	Close() error
 }
 
@@ -153,6 +154,8 @@ func (c *client) embedBatchOnce(ctx context.Context, texts []string) ([][]float3
 }
 
 func (c *client) Info(ctx context.Context) (InfoSnapshot, error) { return c.info.Get(ctx) }
+
+func (c *client) SocketPath() string { return c.sockPath }
 
 // Health issues a Health RPC. Status maps proto enum (STATUS_OK / STATUS_LOADING /
 // STATUS_DEGRADED / STATUS_SHUTTING_DOWN / STATUS_UNSPECIFIED) to the

--- a/internal/service/lifecycle.go
+++ b/internal/service/lifecycle.go
@@ -133,11 +133,10 @@ type KeysInfo struct {
 	AgentDEKLoaded bool   `json:"agent_dek_loaded"`
 }
 
-// PipelinesInfo — scribe/retriever init + active provider.
+// PipelinesInfo — scribe/retriever init state.
 type PipelinesInfo struct {
-	ScribeInitialized    bool   `json:"scribe_initialized"`
-	RetrieverInitialized bool   `json:"retriever_initialized"`
-	ActiveLLMProvider    string `json:"active_llm_provider,omitempty"` // always empty (Go agent-delegated)
+	ScribeInitialized    bool `json:"scribe_initialized"`
+	RetrieverInitialized bool `json:"retriever_initialized"`
 }
 
 // EmbeddingInfo — external embedder info snapshot

--- a/internal/service/lifecycle.go
+++ b/internal/service/lifecycle.go
@@ -252,10 +252,9 @@ func (s *LifecycleService) collectEmbedding(ctx context.Context, timeout time.Du
 	}
 	info.SocketPath = s.Embedder.SocketPath()
 
-	ctx2, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	if snap, err := s.Embedder.Info(ctx2); err != nil {
+	infoCtx, cancelInfo := context.WithTimeout(ctx, timeout)
+	defer cancelInfo()
+	if snap, err := s.Embedder.Info(infoCtx); err != nil {
 		info.InfoError = err.Error()
 	} else {
 		info.Model = snap.ModelIdentity
@@ -263,7 +262,9 @@ func (s *LifecycleService) collectEmbedding(ctx context.Context, timeout time.Du
 		info.DaemonVersion = snap.DaemonVersion
 	}
 
-	if health, err := s.Embedder.Health(ctx2); err != nil {
+	healthCtx, cancelHealth := context.WithTimeout(ctx, timeout)
+	defer cancelHealth()
+	if health, err := s.Embedder.Health(healthCtx); err != nil {
 		info.HealthError = err.Error()
 	} else {
 		info.Status = health.Status

--- a/internal/service/lifecycle.go
+++ b/internal/service/lifecycle.go
@@ -146,6 +146,12 @@ type EmbeddingInfo struct {
 	Mode          string `json:"mode"` // "external gRPC"
 	VectorDim     int    `json:"vector_dim,omitempty"`
 	DaemonVersion string `json:"daemon_version,omitempty"`
+	SocketPath    string `json:"socket_path,omitempty"`
+	Status        string `json:"status,omitempty"` // Health: OK / LOADING / DEGRADED / SHUTTING_DOWN
+	UptimeSeconds int64  `json:"uptime_seconds,omitempty"`
+	TotalRequests int64  `json:"total_requests,omitempty"`
+	InfoError     string `json:"info_error,omitempty"`
+	HealthError   string `json:"health_error,omitempty"`
 }
 
 // EnvectorInfo — reachability probe
@@ -245,18 +251,26 @@ func (s *LifecycleService) collectEmbedding(ctx context.Context, timeout time.Du
 	if s.Embedder == nil {
 		return info
 	}
+	info.SocketPath = s.Embedder.SocketPath()
 
 	ctx2, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	snap, err := s.Embedder.Info(ctx2)
-	if err != nil {
-		return info
+	if snap, err := s.Embedder.Info(ctx2); err != nil {
+		info.InfoError = err.Error()
+	} else {
+		info.Model = snap.ModelIdentity
+		info.VectorDim = snap.VectorDim
+		info.DaemonVersion = snap.DaemonVersion
 	}
 
-	info.Model = snap.ModelIdentity
-	info.VectorDim = snap.VectorDim
-	info.DaemonVersion = snap.DaemonVersion
+	if health, err := s.Embedder.Health(ctx2); err != nil {
+		info.HealthError = err.Error()
+	} else {
+		info.Status = health.Status
+		info.UptimeSeconds = health.UptimeSeconds
+		info.TotalRequests = health.TotalRequests
+	}
 
 	return info
 }


### PR DESCRIPTION
## Summary

- What changed: User can check embedder status with `/rune:status`, remove unused field
- Why:
- Scope:

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [ ] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [ ] No agent-specific script duplicates bootstrap/setup logic
- [ ] Agent-specific scripts remain thin adapters (registration/wiring only)
- [ ] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [ ] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [ ] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any): Show connected gRPC streams, `runed.Info` shows more detailed information
