### PR TITLE
feat: fast-fail /rune:configure via classified boot errors

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -114,10 +114,11 @@ If in Active state but operations fail:
 5. Call the `reload_pipelines` MCP tool. The MCP server's boot loop
    dials Vault, fetches the agent manifest (EncKey + envector
    creds), connects to enVector, and transitions to Active.
-6. Confirm health by calling `diagnostics` and showing the per-
-   subsystem snapshot. If the boot loop landed in Dormant, surface
-   the `dormant_reason` (e.g. `vault_unreachable`,
-   `vault_token_invalid`) with the recovery action.
+6. Confirm health by calling `diagnostics` and applying the
+   **Boot Failure — Fast-Fail Rule** (see section below). If
+   `state == "active"`, render the per-subsystem snapshot. If
+   not, surface `vault.last_boot_error.hint` verbatim and stop —
+   do not retry, do not probe with shell tools.
 
 ### `/rune:status`
 (or `$rune status` for Codex CLI)
@@ -209,11 +210,12 @@ Recommendations:
    `dormant_reason` / `dormant_since` fields.
 4. Call the `reload_pipelines` MCP tool. From a terminal Dormant the
    boot loop is re-spawned; from Active it is a no-op.
-5. Call `diagnostics` and render the per-subsystem snapshot.
-6. If any subsystem failed: keep state as `"active"` (the boot loop
-   will retry transient failures), surface the dormant_reason if the
-   loop fell back to Dormant, and suggest `/rune:status` for the full
-   snapshot.
+5. Call `diagnostics` and apply the **Boot Failure — Fast-Fail Rule**
+   (section below).
+6. If `state == "active"`: render the per-subsystem snapshot. If not:
+   surface `vault.last_boot_error.hint` verbatim, suggest the matching
+   recovery action, and stop. Do NOT loop on `reload_pipelines` or probe
+   with shell tools — the classifier has already done that work.
 
 ### `/rune:reset`
 (or `$rune reset` for Codex CLI)
@@ -225,6 +227,35 @@ Recommendations:
 2. Delete `~/.rune/config.json` (the MCP server stays alive; it transitions
    to Dormant on the next reload because no config means no Vault dial)
 3. Show reconfiguration instructions
+
+## Boot Failure — Fast-Fail Rule
+
+When `diagnostics.state != "active"` AND `diagnostics.vault.last_boot_error`
+is present, that field is the boot loop's authoritative root-cause verdict
+(produced from the underlying gRPC/TLS/DNS error). Treat it as ground truth.
+
+**Do this and stop:**
+1. Show `vault.last_boot_error.hint` to the user **verbatim** — it already
+   names the specific cause and the fix.
+2. Suggest one next action keyed off `kind`:
+   - `config_*`, `vault_*` (TLS, auth, endpoint, manifest, etc.) → re-run
+     `/rune:configure` after applying the hint's fix.
+   - `user_deactivated` → `/rune:activate`.
+   - `embedder_unreachable` → start `runed` (`runed start`), then `/rune:status`.
+   - `envector_*` → share `detail` with the Vault admin.
+   - `unknown` → show `kind` + `detail`, suggest sharing with admin.
+
+**Do NOT:** retry `reload_pipelines`, poll `diagnostics` in a loop, or run
+shell probes (`openssl`, `nc`, `curl`, `dig`, etc.). The classifier already
+inspected the underlying error server-side — manual probing only burns
+tokens without changing the conclusion. The per-`kind` reference table
+lives in `commands/claude/configure.md` for the rare case the hint string
+needs supplementation.
+
+**Fallback** (older rune-mcp binary without `last_boot_error`): use
+`vault.error`, `embedding.health_error`, `envector.error`, and the
+`dormant_reason` translation in `/rune:status`. Still: do not investigate
+further, surface what you have and stop.
 
 ## Automatic Behavior (When Active)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -116,9 +116,9 @@ If in Active state but operations fail:
    creds), connects to enVector, and transitions to Active.
 6. Confirm health by calling `diagnostics` and applying the
    **Boot Failure — Fast-Fail Rule** (see section below). If
-   `state == "active"`, render the per-subsystem snapshot. If
-   not, surface `vault.last_boot_error.hint` verbatim and stop —
-   do not retry, do not probe with shell tools.
+   `vault.last_boot_error` is present, surface its `hint` verbatim
+   and stop — do not retry, do not probe with shell tools. Otherwise
+   render the per-subsystem snapshot.
 
 ### `/rune:status`
 (or `$rune status` for Codex CLI)
@@ -212,10 +212,10 @@ Recommendations:
    boot loop is re-spawned; from Active it is a no-op.
 5. Call `diagnostics` and apply the **Boot Failure — Fast-Fail Rule**
    (section below).
-6. If `state == "active"`: render the per-subsystem snapshot. If not:
-   surface `vault.last_boot_error.hint` verbatim, suggest the matching
-   recovery action, and stop. Do NOT loop on `reload_pipelines` or probe
-   with shell tools — the classifier has already done that work.
+6. If `vault.last_boot_error` is present: surface its `hint` verbatim,
+   suggest the matching recovery action, and stop. Do NOT loop on
+   `reload_pipelines` or probe with shell tools — the classifier has
+   already done that work. Otherwise render the per-subsystem snapshot.
 
 ### `/rune:reset`
 (or `$rune reset` for Codex CLI)
@@ -230,9 +230,13 @@ Recommendations:
 
 ## Boot Failure — Fast-Fail Rule
 
-When `diagnostics.state != "active"` AND `diagnostics.vault.last_boot_error`
-is present, that field is the boot loop's authoritative root-cause verdict
-(produced from the underlying gRPC/TLS/DNS error). Treat it as ground truth.
+When `diagnostics.vault.last_boot_error` is present, that field is the boot
+loop's authoritative root-cause verdict (produced from the underlying
+gRPC/TLS/DNS error). It is set on every failed boot attempt and cleared only
+on success, so its presence — regardless of `state` — means boot is currently
+failing. (`state` is the persisted config value; it stays `"active"` through
+transient retries like an unreachable Vault, so it is not a reliable failure
+signal on its own.) Treat `last_boot_error` as ground truth.
 
 **Do this and stop:**
 1. Show `vault.last_boot_error.hint` to the user **verbatim** — it already

--- a/cmd/rune-mcp/main.go
+++ b/cmd/rune-mcp/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/envector/rune-go/internal/adapters/config"
 	"github.com/envector/rune-go/internal/adapters/logio"
+	"github.com/envector/rune-go/internal/bootstrap"
 	"github.com/envector/rune-go/internal/lifecycle"
 	"github.com/envector/rune-go/internal/mcp"
 	"github.com/envector/rune-go/internal/obs"
@@ -140,6 +141,17 @@ func buildDeps() *mcp.Deps {
 		runeDir = filepath.Join(home, ".rune")
 	}
 	captureLog := logio.New(filepath.Join(runeDir, logio.DefaultFilename))
+
+	// Boot-failure log under the RUNE_HOME-aware root (bootstrap.Paths, #138)
+	// so it follows the same root override as the rest of rune-mcp state.
+	// Best-effort: if path resolution fails, leave the logger unset and the
+	// boot loop keeps in-memory LastBootError only.
+	if paths, perr := bootstrap.Resolve(); perr == nil {
+		bootLogPath := filepath.Join(paths.RuneHome, "logs", "boot.log")
+		mgr.SetBootLog(lifecycle.NewBootLogger(bootLogPath, lifecycle.DefaultBootLogMaxBytes))
+	} else {
+		slog.Warn("boot_log: path resolve failed — disk persistence disabled", "err", perr)
+	}
 
 	cap := service.NewCaptureService()
 	cap.State = mgr

--- a/commands/claude/activate.md
+++ b/commands/claude/activate.md
@@ -50,17 +50,37 @@ active, ask the server to re-run the boot loop, and confirm health.
    Use a check mark for healthy items, "x" for failures with the specific
    message on the same line.
 
-7. If the boot loop succeeded:
+7. If the boot loop succeeded (`state == "active"` and all subsystems healthy):
    - Respond: "Rune activated. Organizational memory is now online."
 
-8. If any subsystem failed:
-   - Show the full validation report.
-   - Surface the specific recovery action per failure:
-     - Vault unreachable: "Verify the Vault server is running and the endpoint is correct."
-     - Vault token rejected: "Token may be expired — run `/rune:configure` to update."
-     - runed not running: "Start the embedding daemon."
-     - enVector unreachable: "Check the cluster's external connectivity from this host."
-   - Suggest `/rune:status` for the full health snapshot.
+8. **If boot failed (state != active)** — fast-fail on `vault.last_boot_error`:
+   - Read `diagnostics.vault.last_boot_error`. If present, it already contains
+     the boot loop's classified root cause + a user-actionable hint.
+   - Render the recovery in **one block** — relay the `hint` verbatim and stop:
+     ```
+     Activation failed — <kind>
+     <hint>
+
+     Details: <detail>   (only when kind == "unknown" or hint is generic)
+     Attempts: <attempts> (only when > 1)
+     ```
+   - Common `kind` mapping for the suggestion line:
+     - `vault_tls_handshake` / `vault_tls_hostname` / `vault_ca_file` → user must
+       fix the CA cert and re-run `/rune:activate`.
+     - `vault_auth` / `vault_permission` → re-issue token with correct role,
+       then `/rune:configure`.
+     - `vault_network` / `vault_dns` → verify endpoint reachability (firewall,
+       DNS), then re-run `/rune:activate`.
+     - `embedder_unreachable` → start the `runed` daemon (`runed start`).
+     - `envector_init` / `envector_index` → contact Vault admin to verify
+       the envector endpoint / index provisioning.
+     - `vault_manifest` → token is not provisioned for an active agent. Ask
+       admin to bind the token to an agent.
+   - DO NOT retry `reload_pipelines` automatically. DO NOT probe with shell
+     tools. The classifier has already inspected the underlying error.
+   - If `last_boot_error` is unexpectedly missing (older rune-mcp binary), fall
+     back to the diagnostics `vault.error` / `embedding.health_error` /
+     `envector.error` fields and surface those.
 
 **Note**: This is a session-local resume — the MCP server stays the same
 process. There is no Claude Code restart required (Task #28 wired the

--- a/commands/claude/activate.md
+++ b/commands/claude/activate.md
@@ -68,18 +68,13 @@ active, ask the server to re-run the boot loop, and confirm health.
      Details: <detail>   (only when kind == "unknown" or hint is generic)
      Attempts: <attempts> (only when > 1)
      ```
-   - Common `kind` mapping for the suggestion line:
-     - `vault_tls_handshake` / `vault_tls_hostname` / `vault_ca_file` → user must
-       fix the CA cert and re-run `/rune:activate`.
-     - `vault_auth` / `vault_permission` → re-issue token with correct role,
-       then `/rune:configure`.
-     - `vault_network` / `vault_dns` → verify endpoint reachability (firewall,
-       DNS), then re-run `/rune:activate`.
-     - `embedder_unreachable` → start the `runed` daemon (`runed start`).
-     - `envector_init` / `envector_index` → contact Vault admin to verify
-       the envector endpoint / index provisioning.
-     - `vault_manifest` → token is not provisioned for an active agent. Ask
-       admin to bind the token to an agent.
+   - The `hint` is authoritative — it already names the specific fix. Relay it
+     verbatim, then suggest the matching re-run: `/rune:configure` when
+     credentials must change (auth / token / endpoint / TLS), otherwise
+     `/rune:activate` once the user applies the hint (`embedder_unreachable`
+     needs the `runed` daemon started first). The full per-`kind` table is in
+     `commands/claude/configure.md` §5 for the rare case the hint needs
+     supplementation.
    - DO NOT retry `reload_pipelines` automatically. DO NOT probe with shell
      tools. The classifier has already inspected the underlying error.
    - If `last_boot_error` is unexpectedly missing (older rune-mcp binary), fall

--- a/commands/claude/activate.md
+++ b/commands/claude/activate.md
@@ -50,12 +50,16 @@ active, ask the server to re-run the boot loop, and confirm health.
    Use a check mark for healthy items, "x" for failures with the specific
    message on the same line.
 
-7. If the boot loop succeeded (`state == "active"` and all subsystems healthy):
+7. If the boot loop succeeded (`vault.last_boot_error` absent and all
+   subsystems healthy):
    - Respond: "Rune activated. Organizational memory is now online."
 
-8. **If boot failed (state != active)** — fast-fail on `vault.last_boot_error`:
-   - Read `diagnostics.vault.last_boot_error`. If present, it already contains
-     the boot loop's classified root cause + a user-actionable hint.
+8. **If boot failed (`vault.last_boot_error` present)** — fast-fail. Note this
+   is keyed off `last_boot_error`, not `state`: a transient failure (e.g.
+   unreachable Vault) leaves the persisted `state` at `"active"` while the boot
+   loop retries, so `state` alone would miss it.
+   - Read `diagnostics.vault.last_boot_error`. It contains the boot loop's
+     classified root cause + a user-actionable hint.
    - Render the recovery in **one block** — relay the `hint` verbatim and stop:
      ```
      Activation failed — <kind>

--- a/commands/claude/configure.md
+++ b/commands/claude/configure.md
@@ -110,29 +110,59 @@ Call `mcp__envector__reload_pipelines`. This re-runs the boot loop:
 4. Connect to enVector cluster using the bundle endpoint + API key.
 5. Open the team index.
 
-If `reload_pipelines` returns an error or state stays dormant:
-- Surface the message — it is the boot loop's `LastError`.
-- Common causes:
-  - Vault unreachable — verify `endpoint` reachable from this host.
-  - Token invalid / role lacks permission — re-issue with
-    `runevault token issue --user <name> --role member`.
-  - runed not running — start the embedding daemon.
-  - enVector cluster unreachable — check the cluster's external
-    connectivity from this host.
-- Suggest `/rune:status` for the full health snapshot.
+`reload_pipelines` is **non-blocking** — it kicks the boot loop and returns
+immediately with the current state (typically `waiting_for_vault` while
+the dial is in flight). Do NOT interpret the immediate response as the
+final result. Go to Step 5 to read the actual outcome.
 
-### 5. Verify Health (call diagnostics)
+### 5. Verify Health (call diagnostics — **fast-fail on `last_boot_error`**)
 
-After `reload_pipelines` returns, call `mcp__envector__diagnostics` to
-get a real-time per-subsystem health snapshot. This is what the
-completion summary renders — `reload_pipelines` is the trigger,
-`diagnostics` is the ground-truth probe.
+Call `mcp__envector__diagnostics` ONCE after `reload_pipelines`.
+This returns a per-subsystem health snapshot — the ground-truth probe.
+
+**Fast-fail rule (do this FIRST, before rendering anything else):**
+
+If `diagnostics.state != "active"` AND
+`diagnostics.vault.last_boot_error` is present →
+**immediately surface the error to the user and stop**. Do NOT retry
+`reload_pipelines`, do NOT poll `diagnostics`, do NOT probe with shell
+commands. The `last_boot_error` field is the boot loop's structured
+verdict — it has already classified the root cause.
+
+Render based on `last_boot_error.kind`:
+
+| kind | what to tell the user |
+|---|---|
+| `vault_tls_handshake` | CA cert mismatch. Show `hint` verbatim. Ask user to re-fetch the current CA from the Vault admin and replace `~/.rune/certs/ca.pem`, then re-run `/rune:configure`. |
+| `vault_tls_hostname`  | Server cert doesn't cover the endpoint hostname. Show `hint`. |
+| `vault_ca_file`       | CA file path unreadable. Show `hint` — likely a typo or permissions. |
+| `vault_auth`          | Token rejected. Show `hint`. Suggest `runevault token issue --user <name> --role member`. |
+| `vault_permission`    | Token lacks role. Show `hint`. Re-issue with correct role. |
+| `vault_network`       | Endpoint unreachable. Show `hint`. User should verify TCP connectivity (e.g., `nc -vz host port`). |
+| `vault_dns`           | Hostname doesn't resolve. Show `hint`. Likely a typo in endpoint. |
+| `vault_timeout`       | Vault didn't respond in time. Could be network or server overload — show `hint`. |
+| `vault_manifest`      | Vault connected but no manifest for this token. Token probably not provisioned for an agent. |
+| `vault_rate_limit`    | Token throttled. Show `hint`. Wait and retry. |
+| `vault_bad_endpoint`  | Endpoint syntax invalid. Show `hint`. Re-run `/rune:configure` with corrected format. |
+| `embedder_unreachable`| `runed` daemon not running. Show `hint`. User should run `runed start`. |
+| `envector_init` / `envector_index` | Envector side. Show `hint` + `detail`. |
+| `key_save` / `local_io` | Local FS issue. Show `hint` + suggest checking `~/.rune/` permissions. |
+| anything else (incl. `unknown`) | Show `kind`, `hint`, and `detail`. Suggest user share the detail with their Vault admin. |
+
+The agent-facing output for a fast-fail case should be **one block**: the
+matched explanation above + the hint string verbatim + a single next-action
+suggestion. Do NOT loop on `reload_pipelines`. Do NOT call shell tools to
+verify (`openssl`, `nc`, etc.) unless the user explicitly asks — the
+classifier has already done that work server-side.
+
+**If `state == "active"` (success path):** proceed to Step 6.
 
 The diagnostics result has these sections (only render the ones with
-meaningful content):
+meaningful content) — used for the success summary in Step 6:
 
 - `state` + `dormant_reason` + `dormant_since`
 - `vault.healthy` + `vault.endpoint` (+ `vault.error` if unhealthy)
+- `vault.last_boot_error` (only when state != active — see fast-fail above)
 - `keys.enc_key_loaded` + `keys.key_id` + `keys.agent_dek_loaded`
 - `pipelines.scribe_initialized` + `pipelines.retriever_initialized`
 - `embedding.model` + `embedding.mode` + `embedding.vector_dim` (+ `embedding.daemon_version` if present)

--- a/commands/claude/configure.md
+++ b/commands/claude/configure.md
@@ -34,100 +34,126 @@ Skip all steps below.
 
 ## Full Setup Steps
 
-### 1. Collect Credentials (conversational, via AskUserQuestion)
+**Turn budget**: 4 main turns total. Aggressively batch into **single
+AskUserQuestion calls** and **parallel tool_use blocks** to keep wall-clock
++ token cost low. Concrete plan below.
 
-If `~/.rune/config.json` already exists, show current values (mask token), ask
-if the user wants to reconfigure. If they decline, skip to Step 4 (reload only).
+### 1. Probe existing state (one turn)
 
-Ask each credential one at a time:
+In a single turn, run `Read` on `~/.rune/config.json` (if it exists).
+This serves two purposes at once:
 
-- **Vault Endpoint** (required, format: `tcp://<host>:50051`).
-  Auto-prepend `tcp://` when the user enters a value without a scheme prefix.
-  Example: `vault.example.com:50051` → `tcp://vault.example.com:50051`
-- **Vault Token** (required, format: `evt_xxx...`).
+- Detect whether the user is re-configuring (existing values) or fresh-setup.
+- Satisfy the `Write` tool's "must Read before Write" requirement so Step 3
+  does NOT need a separate defensive Read turn later. If the file does
+  not exist, the Read fails harmlessly — skip and proceed.
 
-### 2. TLS Choice
+If the existing config has all credentials and the user does not say they
+want to reconfigure: skip to Step 4 (reload only). Otherwise continue.
 
-Ask: "How does your Vault server handle TLS?"
+### 2. Collect credentials — **one AskUserQuestion call, three questions** (one turn)
 
-1. **Self-signed certificate** (Recommended) — team uses a self-signed CA.
-   - Follow-up: "Path to CA certificate PEM file:" (support `~` expansion).
-   - Copy via:
-     ```bash
-     mkdir -p ~/.rune/certs && chmod 700 ~/.rune
-     cp <user_path> ~/.rune/certs/ca.pem
-     chmod 600 ~/.rune/certs/ca.pem
-     ```
-   - If the cp fails (file not found, permission denied), surface the error
-     and ask for a path the current user can read. Common fix:
-     `sudo cp /opt/runevault/certs/ca.pem ~/.rune/ca.pem && sudo chown $USER ~/.rune/ca.pem`.
-   - → config: `ca_cert: "<HOME>/.rune/certs/ca.pem"`, `tls_disable: false`
-2. **Public CA** (Let's Encrypt etc.) — system CA pool handles verification.
-   - → config: `ca_cert: ""`, `tls_disable: false`
-3. **No TLS** — local dev only. Vault must also be running with
-   `server.grpc.tls.disable: true` — `install-dev.sh`'s default does NOT do
-   this, so this option only works when the user has explicitly disabled TLS
-   on the Vault side.
-   - Warn: "Plaintext gRPC. Make sure your Vault server has tls.disable: true."
-   - → config: `ca_cert: ""`, `tls_disable: true`
+Issue a SINGLE `AskUserQuestion` with three bundled questions, not three
+separate calls. The tool accepts 1–4 questions per call; using one call
+saves 2 turns (each separate call costs ~5s wall + an extra round-trip of
+~50k cache_read tokens).
 
-### 3. Write ~/.rune/config.json
+Questions to bundle:
 
-```bash
-mkdir -p ~/.rune && chmod 700 ~/.rune
-```
+1. **Vault Endpoint** (required, format: `tcp://<host>:50051`).
+   Auto-prepend `tcp://` when the user value omits the scheme.
+2. **Vault Token** (required, format: `evt_xxx...`).
+3. **TLS Mode**:
+   - `self-signed` — team uses a self-signed CA (Recommended).
+   - `public_ca` — Let's Encrypt etc., system CA pool handles verification.
+   - `no_tls` — local dev only; Vault must also be running with
+     `server.grpc.tls.disable: true`. Warn if selected.
 
-Write:
-```json
-{
-  "vault": {
-    "endpoint": "<vault_endpoint>",
-    "token": "<vault_token>",
-    "ca_cert": "<ca_cert_path or empty>",
-    "tls_disable": <true|false>
-  },
-  "state": "active",
-  "metadata": {
-    "configVersion": "2.0",
-    "lastUpdated": "<ISO timestamp>"
+**If `self-signed` was chosen**: issue a single follow-up `AskUserQuestion`
+asking only "Path to CA certificate PEM file:" (one question, one turn).
+Otherwise skip the follow-up entirely.
+
+Resulting config mapping:
+
+| TLS mode    | ca_cert                    | tls_disable |
+|-------------|----------------------------|-------------|
+| self-signed | `<HOME>/.rune/certs/ca.pem`| false       |
+| public_ca   | ""                         | false       |
+| no_tls      | ""                         | true        |
+
+### 3. Provision and write — **parallel tool_use in one turn**
+
+Emit BOTH tool calls in the same turn (parallel `tool_use` blocks). Anthropic
+runs them in parallel and returns both `tool_result`s in the next user
+message:
+
+- **`Bash`** — only when `tls_mode == self-signed`. Sets up the cert dir
+  and copies the user-supplied CA in one command (so a partial failure
+  leaves nothing half-written):
+  ```bash
+  mkdir -p ~/.rune/certs && chmod 700 ~/.rune && \
+    cp <user_ca_path> ~/.rune/certs/ca.pem && \
+    chmod 600 ~/.rune/certs/ca.pem
+  ```
+  If `cp` fails (file not found / permission denied): surface the error
+  and ask the user for a readable path (one more `AskUserQuestion`).
+- **`Write`** — `~/.rune/config.json` with the JSON below.
+  ```json
+  {
+    "vault": {
+      "endpoint": "<vault_endpoint>",
+      "token": "<vault_token>",
+      "ca_cert": "<ca_cert_path or empty>",
+      "tls_disable": <true|false>
+    },
+    "state": "active",
+    "metadata": {
+      "configVersion": "2.0",
+      "lastUpdated": "<ISO timestamp>"
+    }
   }
-}
-```
-
-Then `chmod 600 ~/.rune/config.json`.
+  ```
 
 Note: enVector credentials (endpoint, API key, EvalKey, SecKey) are not
 stored locally — Vault delivers them via the agent manifest on first
 connection.
 
-### 4. Trigger Boot Loop
+### 4. Lock down + trigger boot — **parallel tool_use in one turn**
 
-Call `mcp__envector__reload_pipelines`. This re-runs the boot loop:
+Again emit both tool calls in the same turn:
 
-1. Dial Vault (TLS or plaintext per config) and call `GetAgentManifest`.
-2. Persist the returned `EncKey` to `~/.rune/keys/<keyID>/EncKey.json`.
-3. Dial runed at `~/.runed/embedding.sock` (or `RUNE_EMBEDDER_SOCKET`).
-4. Connect to enVector cluster using the bundle endpoint + API key.
-5. Open the team index.
+- **`Bash`** — `chmod 600 ~/.rune/config.json` (config file may contain the
+  vault token; ensure owner-only readable).
+- **`mcp__envector__reload_pipelines`** — kicks the boot loop. Returns
+  after up to 5s while the loop attempts to reach Active, so the response
+  may already contain `last_boot_error` on failure (see Step 5).
 
-`reload_pipelines` is **non-blocking** — it kicks the boot loop and returns
-immediately with the current state (typically `waiting_for_vault` while
-the dial is in flight). Do NOT interpret the immediate response as the
-final result. Go to Step 5 to read the actual outcome.
+The two are independent: the chmod doesn't affect the boot loop's read,
+and the boot loop will have already loaded the config before chmod
+finishes most of the time. Running them in parallel is safe and saves
+one round-trip.
 
-### 5. Verify Health (call diagnostics — **fast-fail on `last_boot_error`**)
+### 5. Read the response — **fast-fail on `last_boot_error`**
 
-Call `mcp__envector__diagnostics` ONCE after `reload_pipelines`.
-This returns a per-subsystem health snapshot — the ground-truth probe.
+Inspect the `reload_pipelines` response from Step 4 first:
 
-**Fast-fail rule (do this FIRST, before rendering anything else):**
+- **`state == "active"` AND no `last_boot_error`** → success path. Optionally
+  call `mcp__envector__diagnostics` ONCE for the rich per-subsystem snapshot
+  used in Step 6's completion summary. (You can skip diagnostics if you only
+  need to confirm activation — `reload_pipelines.state` is authoritative.)
 
-If `diagnostics.state != "active"` AND
-`diagnostics.vault.last_boot_error` is present →
-**immediately surface the error to the user and stop**. Do NOT retry
-`reload_pipelines`, do NOT poll `diagnostics`, do NOT probe with shell
-commands. The `last_boot_error` field is the boot loop's structured
-verdict — it has already classified the root cause.
+- **`last_boot_error` is populated** → fast-fail. Use it directly; do NOT
+  call diagnostics, do NOT retry. The boot loop has already classified the
+  root cause.
+
+- **`state != "active"` AND `last_boot_error` is absent** → boot loop is
+  still in flight (rare; only when the 5s wait window expired without an
+  error). Call `mcp__envector__diagnostics` ONCE — its
+  `vault.last_boot_error` will likely be populated by now (the boot loop
+  keeps running in the background).
+
+**Do NOT** retry `reload_pipelines`, poll `diagnostics`, or probe with shell
+commands. The `last_boot_error` field is the boot loop's structured verdict.
 
 Render based on `last_boot_error.kind`:
 

--- a/commands/claude/configure.md
+++ b/commands/claude/configure.md
@@ -181,14 +181,14 @@ suggestion. Do NOT loop on `reload_pipelines`. Do NOT call shell tools to
 verify (`openssl`, `nc`, etc.) unless the user explicitly asks — the
 classifier has already done that work server-side.
 
-**If `state == "active"` (success path):** proceed to Step 6.
+**If no `last_boot_error` (success path):** proceed to Step 6.
 
 The diagnostics result has these sections (only render the ones with
 meaningful content) — used for the success summary in Step 6:
 
 - `state` + `dormant_reason` + `dormant_since`
 - `vault.healthy` + `vault.endpoint` (+ `vault.error` if unhealthy)
-- `vault.last_boot_error` (only when state != active — see fast-fail above)
+- `vault.last_boot_error` (whenever present — see fast-fail above)
 - `keys.enc_key_loaded` + `keys.key_id` + `keys.agent_dek_loaded`
 - `pipelines.scribe_initialized` + `pipelines.retriever_initialized`
 - `embedding.model` + `embedding.mode` + `embedding.vector_dim` (+ `embedding.daemon_version` if present)

--- a/commands/claude/status.md
+++ b/commands/claude/status.md
@@ -64,3 +64,36 @@ Use checkmarks for healthy items, X marks for issues.
 - `user_deactivated`: "Manually deactivated by user via `/rune:deactivate`."
 - Other/unknown: show raw reason string with "Run `/rune:activate` to retry."
 
+**Boot Error Display** (`vault.last_boot_error`): When `state != "active"` AND
+`diagnostics.vault.last_boot_error` is set, render its `hint` field
+prominently in the **Recommendations** section. The boot loop has already
+classified the root cause — relay it verbatim instead of guessing.
+
+Render shape (one-block, no extra investigation):
+
+```
+Recommendations:
+  Boot failure (<kind>):
+    <hint>
+
+  Details: <detail>  (only when the hint is generic / kind is "unknown")
+  Attempts: <attempts>  (only when > 1, to show retry was tried)
+```
+
+Examples:
+- `kind=vault_tls_handshake` → "CA cert at … does not verify the server cert.
+  The CA was likely regenerated on the server side. Re-fetch from your
+  Vault admin and replace `~/.rune/certs/ca.pem`."
+- `kind=vault_auth` → "Vault rejected the token. Re-issue with
+  `runevault token issue --user <name> --role member`."
+- `kind=vault_network` → "Vault endpoint `<endpoint>` is not reachable.
+  Verify the host/port and your network/firewall."
+- `kind=embedder_unreachable` → "Embedder daemon (`runed`) is not running on
+  its UDS socket. Start it with `runed start`."
+- `kind=unknown` → show both `hint` and `detail` and suggest sharing with admin.
+
+DO NOT call shell tools (`openssl`, `nc`, `curl`, etc.) to "verify" the
+classifier's verdict. The classifier already inspected the underlying gRPC /
+TLS / DNS error; manual probing only adds turns + cost without changing the
+recommendation. The user can decide to manually verify later if they want.
+

--- a/commands/claude/status.md
+++ b/commands/claude/status.md
@@ -64,10 +64,12 @@ Use checkmarks for healthy items, X marks for issues.
 - `user_deactivated`: "Manually deactivated by user via `/rune:deactivate`."
 - Other/unknown: show raw reason string with "Run `/rune:activate` to retry."
 
-**Boot Error Display** (`vault.last_boot_error`): When `state != "active"` AND
-`diagnostics.vault.last_boot_error` is set, render its `hint` field
-prominently in the **Recommendations** section. The boot loop has already
-classified the root cause — relay it verbatim instead of guessing.
+**Boot Error Display** (`vault.last_boot_error`): When
+`diagnostics.vault.last_boot_error` is set (regardless of `state` — a transient
+failure keeps the persisted `state` at `"active"` while the boot loop retries),
+render its `hint` field prominently in the **Recommendations** section. The boot
+loop has already classified the root cause — relay it verbatim instead of
+guessing.
 
 Render shape (one-block, no extra investigation):
 

--- a/internal/domain/boot_error.go
+++ b/internal/domain/boot_error.go
@@ -1,0 +1,131 @@
+package domain
+
+// BootError — structured failure surfaced by the boot loop, exposed via
+// diagnostics so agents (and humans) can fast-fail with a specific kind +
+// hint instead of probing the system manually.
+//
+// Spec rationale: rune-mcp's boot loop currently logs errors and stores a
+// free-form string in lifecycle.Manager.LastError(). Callers (diagnostics,
+// SKILL.md flows) need a stable enum to branch on. See
+// docs/v04/decisions/D??-boot-error-surface.md (planned).
+//
+// Leaf type: imports stdlib only. Classifier lives in internal/lifecycle.
+
+import "time"
+
+// BootErrorKind — stable enum string for agent/UI branching.
+// Add new values only at the end to preserve schema compatibility.
+type BootErrorKind string
+
+const (
+	// Catch-all for unrecognized failures. Detail contains the raw message;
+	// SKILL.md should ask the user to share it with an admin.
+	BootErrUnknown BootErrorKind = "unknown"
+
+	// ── Config-side (terminal Dormant) ───────────────────────────────
+	BootErrConfigMissing      BootErrorKind = "config_missing"       // ~/.rune/config.json absent
+	BootErrConfigInvalid      BootErrorKind = "config_invalid"       // state=unknown / parse fail
+	BootErrConfigParse        BootErrorKind = "config_parse"         // JSON parse fail
+	BootErrUserDeactivated    BootErrorKind = "user_deactivated"     // state=dormant by /rune:deactivate
+	BootErrVaultNotConfigured BootErrorKind = "vault_not_configured" // endpoint/token empty
+
+	// ── Vault dial / NewClient (sync, before any RPC) ────────────────
+	BootErrVaultBadEndpoint BootErrorKind = "vault_bad_endpoint" // ParseEndpoint failed
+	BootErrVaultCAFile      BootErrorKind = "vault_ca_file"      // CA cert path unreadable / not PEM
+	BootErrVaultDialOpts    BootErrorKind = "vault_dial_opts"    // grpc.NewClient rejected options
+
+	// ── Vault RPC (GetAgentManifest path) ────────────────────────────
+	BootErrVaultTLSHandshake BootErrorKind = "vault_tls_handshake" // x509: signed by unknown authority / expired / etc.
+	BootErrVaultTLSHostname  BootErrorKind = "vault_tls_hostname"  // cert SAN does not match endpoint host
+	BootErrVaultDNS          BootErrorKind = "vault_dns"           // hostname resolution failed
+	BootErrVaultNetwork      BootErrorKind = "vault_network"       // TCP unreachable / refused / reset
+	BootErrVaultTimeout      BootErrorKind = "vault_timeout"       // gRPC DeadlineExceeded
+	BootErrVaultAuth         BootErrorKind = "vault_auth"          // gRPC Unauthenticated (bad token)
+	BootErrVaultPermission   BootErrorKind = "vault_permission"    // gRPC PermissionDenied (role lacks scope)
+	BootErrVaultRateLimit    BootErrorKind = "vault_rate_limit"    // gRPC ResourceExhausted
+	BootErrVaultInvalidInput BootErrorKind = "vault_invalid_input" // gRPC InvalidArgument
+	BootErrVaultManifest     BootErrorKind = "vault_manifest"      // Vault responded but manifest empty/invalid/unparseable
+	BootErrVaultInternal     BootErrorKind = "vault_internal"      // gRPC Internal / other server-side
+
+	// ── Post-Vault adapters ──────────────────────────────────────────
+	BootErrEmbedderUnreachable BootErrorKind = "embedder_unreachable" // UDS socket missing / runed down
+	BootErrEnvectorInit        BootErrorKind = "envector_init"        // envector.NewClient failed
+	BootErrEnvectorIndex       BootErrorKind = "envector_index"       // OpenIndex failed
+	BootErrKeySave             BootErrorKind = "key_save"             // SaveEncKey / KeyDir filesystem failure
+	BootErrLocalIO             BootErrorKind = "local_io"             // generic local FS / permissions
+)
+
+// BootPhase — which step of the boot sequence produced the error.
+// Useful for distinguishing same-kind errors at different phases.
+type BootPhase string
+
+const (
+	BootPhaseConfigLoad    BootPhase = "config_load"
+	BootPhaseConfigCheck   BootPhase = "config_check"
+	BootPhaseVaultDial     BootPhase = "vault_dial"
+	BootPhaseVaultManifest BootPhase = "vault_manifest"
+	BootPhaseKeySave       BootPhase = "key_save"
+	BootPhaseEmbedderDial  BootPhase = "embedder_dial"
+	BootPhaseEnvectorInit  BootPhase = "envector_init"
+	BootPhaseEnvectorIndex BootPhase = "envector_index"
+)
+
+// BootError — surfaced via diagnostics.vault.last_boot_error.
+//
+// JSON shape (stable contract for SKILL.md / agents):
+//
+//	{
+//	  "kind":     "vault_tls_handshake",
+//	  "detail":   "rpc error: code = Unavailable desc = ... x509: ...",
+//	  "hint":     "CA cert at /Users/.../ca.pem does not verify server cert from tcp://X. Re-fetch the current CA from your Vault admin.",
+//	  "phase":    "vault_manifest",
+//	  "at":       "2026-05-16T10:09:23Z",
+//	  "attempts": 4
+//	}
+//
+// Hint is interpolated with concrete values (endpoint, ca path) so the agent
+// can relay it to the user verbatim. Detail is raw text for human debugging
+// and the unknown-kind fallback path.
+type BootError struct {
+	Kind     BootErrorKind `json:"kind"`
+	Detail   string        `json:"detail"`
+	Hint     string        `json:"hint,omitempty"`
+	Phase    BootPhase     `json:"phase,omitempty"`
+	At       time.Time     `json:"at"`
+	Attempts int           `json:"attempts,omitempty"`
+}
+
+// Retryable — true when blind retry (no user action) has a reasonable chance
+// of succeeding. False when the user must change something first (re-issue
+// token, fix CA cert, edit config, etc.).
+//
+// The boot loop itself may still retry on bootRetry results regardless of
+// this flag — Retryable is for SKILL.md / UI to decide whether to suggest
+// "wait + recheck" vs "fix the underlying issue before recheck."
+func (e *BootError) Retryable() bool {
+	if e == nil {
+		return false
+	}
+	switch e.Kind {
+	// Won't self-heal without user action.
+	case BootErrConfigMissing,
+		BootErrConfigInvalid,
+		BootErrConfigParse,
+		BootErrUserDeactivated,
+		BootErrVaultNotConfigured,
+		BootErrVaultBadEndpoint,
+		BootErrVaultCAFile,
+		BootErrVaultDialOpts,
+		BootErrVaultTLSHandshake,
+		BootErrVaultTLSHostname,
+		BootErrVaultAuth,
+		BootErrVaultPermission,
+		BootErrVaultInvalidInput,
+		BootErrVaultManifest:
+		return false
+	default:
+		// Transient: network blips, DNS, timeouts, rate limits, daemon down
+		// while restarting, etc.
+		return true
+	}
+}

--- a/internal/lifecycle/boot.go
+++ b/internal/lifecycle/boot.go
@@ -30,6 +30,7 @@ import (
 	"github.com/envector/rune-go/internal/adapters/envector"
 	"github.com/envector/rune-go/internal/adapters/keymanager"
 	"github.com/envector/rune-go/internal/adapters/vault"
+	"github.com/envector/rune-go/internal/domain"
 	"github.com/envector/rune-go/internal/recovery"
 )
 
@@ -70,16 +71,21 @@ func (s State) String() string {
 
 // Manager — atomic state + Vault boot loop control.
 type Manager struct {
-	state     atomic.Int32
-	lastError atomic.Value // string
-	attempts  atomic.Int32
-	onReload  atomic.Value // func()
+	state       atomic.Int32
+	lastError   atomic.Value // string — free-form, kept for slog parity
+	lastBootErr atomic.Value // *domain.BootError — structured, surfaced via diagnostics
+	attempts    atomic.Int32
+	onReload    atomic.Value // func()
 }
 
 // NewManager — initial state = Starting.
 func NewManager() *Manager {
 	m := &Manager{}
 	m.state.Store(int32(StateStarting))
+	// Seed lastBootErr with a typed nil so atomic.Value.Load returns a
+	// consistent type after the first SetBootError call (atomic.Value
+	// requires all stored values to be the same concrete type).
+	m.lastBootErr.Store((*domain.BootError)(nil))
 	return m
 }
 
@@ -168,6 +174,43 @@ func (m *Manager) WaitForActive(ctx context.Context, timeout time.Duration) bool
 	return false
 }
 
+// LastBootError reports the structured boot error from the most recent boot
+// attempt (nil when boot is currently active / has not yet been attempted /
+// has explicitly been cleared on success). Surfaced via
+// service.LifecycleService.Diagnostics so agents can fast-fail on a stable
+// Kind + Hint instead of pattern-matching LastError() strings.
+func (m *Manager) LastBootError() *domain.BootError {
+	v := m.lastBootErr.Load()
+	if v == nil {
+		return nil
+	}
+	be, _ := v.(*domain.BootError)
+	return be
+}
+
+// SetBootError stores a classified boot error in atomic state AND appends
+// it to the on-disk boot log (~/.rune/logs/boot.log). nil is treated as
+// "clear" — atomic is reset, log is left intact (past attempts remain
+// inspectable).
+func (m *Manager) SetBootError(be *domain.BootError) {
+	// atomic.Value requires consistent concrete type — store typed nil
+	// rather than an untyped nil interface{} for the clear case.
+	if be == nil {
+		m.lastBootErr.Store((*domain.BootError)(nil))
+		return
+	}
+	m.lastBootErr.Store(be)
+	// Best-effort persist. PersistBootError swallows file errors so this
+	// can never break the boot loop.
+	PersistBootError(be)
+}
+
+// Attempts reports the cumulative retry count from the most recent boot run
+// (reset to 0 each time RunBootLoop starts). Exposed for diagnostics.
+func (m *Manager) Attempts() int {
+	return int(m.attempts.Load())
+}
+
 // BootBackoffs — Python server.py Vault retry schedule.
 // Total to cap: 1s → 2s → 5s → 15s → 30s → 60s (then loop at 60s).
 var BootBackoffs = []time.Duration{
@@ -226,23 +269,29 @@ const (
 // gRPC connections do not leak across retries.
 func RunBootLoop(ctx context.Context, m *Manager, deps BootAdapterInjector) {
 	m.SetState(StateStarting)
+	m.attempts.Store(0)
+	// Don't clear lastBootErr here — keep the previous run's error visible
+	// until this run produces a new outcome. That way a manual /rune:status
+	// during the first ~second of a Retrigger still shows context.
 
 	attempt := 0
 	for {
 		if ctx.Err() != nil {
 			return
 		}
+		m.attempts.Store(int32(attempt))
 
-		switch bootOnce(ctx, m, deps) {
+		switch bootOnce(ctx, m, deps, attempt) {
 		case bootActive:
 			m.SetState(StateActive)
 			m.lastError.Store("")
+			m.SetBootError(nil)
 			m.attempts.Store(int32(attempt))
 			slog.Info("boot: pipelines initialized and active")
 			return
 
 		case bootDormant:
-			// State + lastError already set inside bootOnce.
+			// State + lastError + lastBootErr already set inside bootOnce.
 			m.attempts.Store(int32(attempt))
 			slog.Info("boot: dormant — awaiting /rune:configure or /rune:reload_pipelines",
 				"reason", m.LastError())
@@ -265,10 +314,10 @@ func RunBootLoop(ctx context.Context, m *Manager, deps BootAdapterInjector) {
 //   - bootDormant on terminal config-side failures (caller should not retry)
 //   - bootRetry   on transient failures (caller backs off and retries)
 //
-// On any failure path, state + lastError are updated.
+// On any failure path, state + lastError + lastBootErr are updated.
 //
-// Adapter injection is per-component, not all-or-nothing
-func bootOnce(ctx context.Context, m *Manager, deps BootAdapterInjector) bootResult {
+// Adapter injection is per-component, not all-or-nothing.
+func bootOnce(ctx context.Context, m *Manager, deps BootAdapterInjector, attempt int) bootResult {
 	cfg, err := config.Load()
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -278,6 +327,7 @@ func bootOnce(ctx context.Context, m *Manager, deps BootAdapterInjector) bootRes
 			// (Python parity: server.py _set_dormant_with_reason).
 			m.SetState(StateDormant)
 			m.lastError.Store("config.json not found — run /rune:configure to set up")
+			m.SetBootError(ClassifyDormantReason("not_configured"))
 			if dErr := config.MarkDormant("not_configured"); dErr != nil {
 				slog.Warn("boot: failed to persist dormant state to config.json", "err", dErr)
 			}
@@ -288,6 +338,10 @@ func bootOnce(ctx context.Context, m *Manager, deps BootAdapterInjector) bootRes
 		// Other config errors (JSON parse, permission denied, etc.) — could be
 		// transient (user editing the file). Retry.
 		m.lastError.Store(fmt.Sprintf("config load: %v", err))
+		m.SetBootError(ClassifyBootError(err, BootErrCtx{
+			Phase:    domain.BootPhaseConfigLoad,
+			Attempts: attempt,
+		}))
 		slog.Error("boot: failed to load config", "err", err)
 		return bootRetry
 	}
@@ -319,6 +373,7 @@ func bootOnce(ctx context.Context, m *Manager, deps BootAdapterInjector) bootRes
 		}
 
 		m.lastError.Store("dormant: " + reason)
+		m.SetBootError(ClassifyDormantReason(reason))
 		if dErr := config.MarkDormant(reason); dErr != nil {
 			slog.Warn("boot: failed to persist dormant state to config.json", "err", dErr)
 		}
@@ -334,12 +389,25 @@ func bootOnce(ctx context.Context, m *Manager, deps BootAdapterInjector) bootRes
 		// so the next boot picks up the same dormant_reason.
 		m.SetState(StateDormant)
 		m.lastError.Store("vault endpoint or token missing in config — run /rune:configure")
+		m.SetBootError(ClassifyDormantReason("vault_unconfigured"))
 		if dErr := config.MarkDormant("vault_unconfigured"); dErr != nil {
 			slog.Warn("boot: failed to persist dormant state to config.json", "err", dErr)
 		}
 		slog.Warn("boot: vault endpoint/token missing — entering dormant",
 			"hint", "run /rune:configure")
 		return bootDormant
+	}
+
+	// classify — helper closure that classifies an error with the current
+	// phase + interpolates the user's endpoint/CA path into the hint. Pulled
+	// out so each error site stays a single readable line.
+	classify := func(err error, phase domain.BootPhase) *domain.BootError {
+		return ClassifyBootError(err, BootErrCtx{
+			Phase:         phase,
+			VaultEndpoint: cfg.Vault.Endpoint,
+			VaultCAPath:   cfg.Vault.CACert,
+			Attempts:      attempt,
+		})
 	}
 
 	vaultClient, err := vault.NewClient(cfg.Vault.Endpoint, cfg.Vault.Token, vault.ClientOpts{
@@ -352,6 +420,7 @@ func bootOnce(ctx context.Context, m *Manager, deps BootAdapterInjector) bootRes
 	if err != nil {
 		m.SetState(StateWaitingForVault)
 		m.lastError.Store(fmt.Sprintf("vault dial: %v", err))
+		m.SetBootError(classify(err, domain.BootPhaseVaultDial))
 		slog.Error("boot: failed to connect to vault", "err", err)
 		return bootRetry
 	}
@@ -360,6 +429,7 @@ func bootOnce(ctx context.Context, m *Manager, deps BootAdapterInjector) bootRes
 	if err != nil {
 		m.SetState(StateWaitingForVault)
 		m.lastError.Store(fmt.Sprintf("vault get manifest: %v", err))
+		m.SetBootError(classify(err, domain.BootPhaseVaultManifest))
 		slog.Warn("boot: waiting for vault...", "err", err)
 		_ = vaultClient.Close()
 		return bootRetry
@@ -367,6 +437,7 @@ func bootOnce(ctx context.Context, m *Manager, deps BootAdapterInjector) bootRes
 
 	if err := keymanager.SaveEncKey(bundle.KeyID, bundle.EncKey); err != nil {
 		m.lastError.Store(fmt.Sprintf("save EncKey: %v", err))
+		m.SetBootError(classify(err, domain.BootPhaseKeySave))
 		slog.Error("boot: failed to save keys to disk", "err", err)
 		_ = vaultClient.Close()
 		return bootRetry
@@ -375,6 +446,7 @@ func bootOnce(ctx context.Context, m *Manager, deps BootAdapterInjector) bootRes
 	keyDir, err := keymanager.KeyDir(bundle.KeyID)
 	if err != nil {
 		m.lastError.Store(fmt.Sprintf("resolve key dir: %v", err))
+		m.SetBootError(classify(err, domain.BootPhaseKeySave))
 		slog.Error("boot: failed to resolve key dir", "err", err)
 		return bootRetry
 	}
@@ -389,6 +461,7 @@ func bootOnce(ctx context.Context, m *Manager, deps BootAdapterInjector) bootRes
 	})
 	if err != nil {
 		m.lastError.Store(fmt.Sprintf("embedder dial: %v", err))
+		m.SetBootError(classify(err, domain.BootPhaseEmbedderDial))
 		slog.Error("boot: failed to connect to embedder", "err", err)
 		return bootRetry
 	}
@@ -407,12 +480,14 @@ func bootOnce(ctx context.Context, m *Manager, deps BootAdapterInjector) bootRes
 	})
 	if err != nil {
 		m.lastError.Store(fmt.Sprintf("envector new client: %v", err))
+		m.SetBootError(classify(err, domain.BootPhaseEnvectorInit))
 		slog.Error("boot: failed to connect to envector", "err", err)
 		return bootRetry
 	}
 
 	if err := envectorClient.OpenIndex(ctx); err != nil {
 		m.lastError.Store(fmt.Sprintf("envector open index: %v", err))
+		m.SetBootError(classify(err, domain.BootPhaseEnvectorIndex))
 		slog.Error("boot: envector index activation failed", "err", err)
 		_ = envectorClient.Close()
 		return bootRetry

--- a/internal/lifecycle/boot.go
+++ b/internal/lifecycle/boot.go
@@ -76,6 +76,7 @@ type Manager struct {
 	lastBootErr atomic.Value // *domain.BootError — structured, surfaced via diagnostics
 	attempts    atomic.Int32
 	onReload    atomic.Value // func()
+	bootLog     *BootLogger  // on-disk failure log; nil = disabled (no-op)
 }
 
 // NewManager — initial state = Starting.
@@ -88,6 +89,15 @@ func NewManager() *Manager {
 	m.lastBootErr.Store((*domain.BootError)(nil))
 	return m
 }
+
+// SetBootLog injects the on-disk boot-failure logger. Called once during wiring
+// (cmd/rune-mcp). Leave unset (nil) to disable disk persistence — SetBootError
+// then only updates in-memory state. Not safe to call concurrently with boot.
+func (m *Manager) SetBootLog(bl *BootLogger) { m.bootLog = bl }
+
+// BootLog returns the injected logger (nil when disabled). Exposed so the
+// shutdown path can add it to the Closer list.
+func (m *Manager) BootLog() *BootLogger { return m.bootLog }
 
 // Current — atomic load.
 func (m *Manager) Current() State {
@@ -200,9 +210,9 @@ func (m *Manager) SetBootError(be *domain.BootError) {
 		return
 	}
 	m.lastBootErr.Store(be)
-	// Best-effort persist. PersistBootError swallows file errors so this
-	// can never break the boot loop.
-	PersistBootError(be)
+	// Best-effort persist. Persist is nil-safe and swallows file errors so
+	// this can never break the boot loop.
+	m.bootLog.Persist(be)
 }
 
 // Attempts reports the cumulative retry count from the most recent boot run

--- a/internal/lifecycle/boot_classify.go
+++ b/internal/lifecycle/boot_classify.go
@@ -1,0 +1,351 @@
+package lifecycle
+
+// boot_classify.go — translate raw boot errors into structured domain.BootError
+// so diagnostics (and downstream agents) can branch on a stable enum instead
+// of pattern-matching free-form strings.
+//
+// Each error site in boot.go calls ClassifyBootError(err, ctx) with the phase
+// it was in. The classifier walks the wrap chain via errors.As, checks
+// known sentinels (vault.Error, net.OpError, x509.UnknownAuthorityError,
+// gRPC status), and falls through to a phase-specific fallback so every
+// failure produces a non-empty Kind + Hint.
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/envector/rune-go/internal/adapters/vault"
+	"github.com/envector/rune-go/internal/domain"
+)
+
+// BootErrCtx — context the boot loop hands to the classifier so hints can
+// be interpolated with concrete values (endpoint, ca path) the user can act on.
+type BootErrCtx struct {
+	Phase         domain.BootPhase
+	VaultEndpoint string
+	VaultCAPath   string
+	Attempts      int
+}
+
+// ClassifyBootError maps any error from the boot sequence to a BootError.
+// Returns nil if err is nil. Always returns a non-nil BootError otherwise,
+// with Kind defaulting to BootErrUnknown only when nothing matched.
+func ClassifyBootError(err error, c BootErrCtx) *domain.BootError {
+	if err == nil {
+		return nil
+	}
+
+	be := &domain.BootError{
+		Kind:     domain.BootErrUnknown,
+		Detail:   err.Error(),
+		Phase:    c.Phase,
+		At:       time.Now().UTC(),
+		Attempts: c.Attempts,
+	}
+
+	// Order matters: more specific checks first. Each branch fills Kind+Hint
+	// and returns. The phase-aware fallback at the bottom catches anything
+	// that didn't match a structured sentinel.
+
+	if classifyConfigErr(err, be, c) {
+		return be
+	}
+	if classifyTLSErr(err, be, c) {
+		return be
+	}
+	if classifyVaultSentinel(err, be, c) {
+		return be
+	}
+	if classifyNetErr(err, be, c) {
+		return be
+	}
+	if classifyGRPCStatus(err, be, c) {
+		return be
+	}
+
+	// Last resort: phase-aware fallback.
+	applyPhaseFallback(be, c)
+	return be
+}
+
+// ClassifyDormantReason maps a Dormant return's reason string to a BootError.
+// These are terminal — the boot loop has stopped retrying. SKILL.md uses
+// this to tell the user what action will move out of dormant.
+func ClassifyDormantReason(reason string) *domain.BootError {
+	be := &domain.BootError{
+		Detail: "dormant: " + reason,
+		At:     time.Now().UTC(),
+	}
+	switch reason {
+	case "not_configured":
+		be.Kind = domain.BootErrConfigMissing
+		be.Hint = "~/.rune/config.json is missing. Run /rune:configure to set up Vault credentials."
+	case "vault_unconfigured":
+		be.Kind = domain.BootErrVaultNotConfigured
+		be.Hint = "Vault endpoint or token is empty in ~/.rune/config.json. Run /rune:configure."
+	case "user_deactivated":
+		be.Kind = domain.BootErrUserDeactivated
+		be.Hint = "Rune is dormant by user choice. Run /rune:activate to resume."
+	case "invalid_state":
+		be.Kind = domain.BootErrConfigInvalid
+		be.Hint = "config.json has an unknown state value. Edit it or re-run /rune:configure."
+	case "":
+		be.Kind = domain.BootErrConfigInvalid
+		be.Hint = "Dormant for unknown reason. Run /rune:configure to reset."
+	default:
+		be.Kind = domain.BootErrConfigInvalid
+		be.Hint = "Dormant: " + reason
+	}
+	return be
+}
+
+// ── individual classifiers ────────────────────────────────────────────────
+
+// classifyConfigErr — fs.ErrNotExist, JSON parse errors at config_load phase.
+func classifyConfigErr(err error, be *domain.BootError, c BootErrCtx) bool {
+	if errors.Is(err, fs.ErrNotExist) && c.Phase == domain.BootPhaseConfigLoad {
+		be.Kind = domain.BootErrConfigMissing
+		be.Hint = "~/.rune/config.json not found. Run /rune:configure to set up."
+		return true
+	}
+	// JSON parse during config load
+	var syntaxErr *strings.Reader // placeholder; real check below
+	_ = syntaxErr
+	if c.Phase == domain.BootPhaseConfigLoad && strings.Contains(strings.ToLower(err.Error()), "unmarshal") {
+		be.Kind = domain.BootErrConfigParse
+		be.Hint = "~/.rune/config.json is not valid JSON. Edit or re-run /rune:configure."
+		return true
+	}
+	return false
+}
+
+// classifyTLSErr — x509 typed errors + TLS message patterns (for cases where
+// gRPC wraps the typed error in plain string).
+func classifyTLSErr(err error, be *domain.BootError, c BootErrCtx) bool {
+	// 1) CA cert file load failure — surfaces as fs.PathError wrapped by vault.NewClient.
+	var pathErr *fs.PathError
+	if errors.As(err, &pathErr) && strings.Contains(strings.ToLower(err.Error()), "ca cert") {
+		be.Kind = domain.BootErrVaultCAFile
+		be.Hint = fmt.Sprintf("CA cert file %q could not be opened. Check the path in ~/.rune/config.json.", c.VaultCAPath)
+		return true
+	}
+	// 2) Typed x509 errors (may be wrapped by gRPC).
+	var unknownAuth x509.UnknownAuthorityError
+	if errors.As(err, &unknownAuth) {
+		be.Kind = domain.BootErrVaultTLSHandshake
+		be.Hint = tlsCAMismatchHint(c)
+		return true
+	}
+	var hostnameErr x509.HostnameError
+	if errors.As(err, &hostnameErr) {
+		be.Kind = domain.BootErrVaultTLSHostname
+		be.Hint = fmt.Sprintf("Vault server cert does not include %q in its SAN. Use an endpoint that matches the cert, or re-issue the cert with the right SAN.", c.VaultEndpoint)
+		return true
+	}
+	var certInvalid x509.CertificateInvalidError
+	if errors.As(err, &certInvalid) {
+		be.Kind = domain.BootErrVaultTLSHandshake
+		be.Hint = "Vault server cert is not valid (expired, not yet valid, or malformed). Re-issue the cert."
+		return true
+	}
+
+	// 3) String fallback — gRPC sometimes wraps x509 errors as plain strings
+	// without preserving the typed error. Catch the common phrases.
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "tls:") || strings.Contains(msg, "x509:") ||
+		strings.Contains(msg, "authentication handshake failed") {
+		switch {
+		case strings.Contains(msg, "signed by unknown authority"),
+			strings.Contains(msg, "unable to verify"),
+			strings.Contains(msg, "unknown ca"):
+			be.Kind = domain.BootErrVaultTLSHandshake
+			be.Hint = tlsCAMismatchHint(c)
+			return true
+		case strings.Contains(msg, "is valid for"),
+			strings.Contains(msg, "not valid for"),
+			strings.Contains(msg, "doesn't contain any ip sans"),
+			strings.Contains(msg, "san"):
+			be.Kind = domain.BootErrVaultTLSHostname
+			be.Hint = fmt.Sprintf("Vault server cert does not match the endpoint %q. Either use a different endpoint or re-issue the cert with the right SAN.", c.VaultEndpoint)
+			return true
+		case strings.Contains(msg, "expired"),
+			strings.Contains(msg, "not yet valid"):
+			be.Kind = domain.BootErrVaultTLSHandshake
+			be.Hint = "Vault server cert is expired or not yet valid. Re-issue the cert."
+			return true
+		default:
+			be.Kind = domain.BootErrVaultTLSHandshake
+			be.Hint = "TLS handshake with Vault failed. Detail field contains specifics — share with your Vault admin."
+			return true
+		}
+	}
+	return false
+}
+
+// classifyVaultSentinel — vault.Error (already categorized by MapGRPCError).
+func classifyVaultSentinel(err error, be *domain.BootError, c BootErrCtx) bool {
+	var ve *vault.Error
+	if !errors.As(err, &ve) {
+		return false
+	}
+	switch ve.Code {
+	case vault.ErrVaultAuthFailed.Code:
+		be.Kind = domain.BootErrVaultAuth
+		be.Hint = "Vault rejected the token. Check the token in ~/.rune/config.json — it may be wrong or revoked. Re-issue with `runevault token issue` if needed."
+	case vault.ErrVaultPermissionDenied.Code:
+		be.Kind = domain.BootErrVaultPermission
+		be.Hint = "Token authenticated but lacks the required role/scope. Re-issue the token with the correct role."
+	case vault.ErrVaultRateLimited.Code:
+		be.Kind = domain.BootErrVaultRateLimit
+		be.Hint = "Vault rate-limited this token. Wait and retry, or check token quota."
+	case vault.ErrVaultTimeout.Code:
+		be.Kind = domain.BootErrVaultTimeout
+		be.Hint = fmt.Sprintf("Vault did not respond within the timeout (endpoint %s). Network latency or server overload.", c.VaultEndpoint)
+	case vault.ErrVaultUnavailable.Code:
+		// Could be TLS or pure network — classifyTLSErr ran first, so if we
+		// got here it's most likely network. But fall through to a network
+		// hint that's still helpful if it WAS TLS.
+		be.Kind = domain.BootErrVaultNetwork
+		be.Hint = fmt.Sprintf("Vault endpoint %s is not reachable. Verify TCP connectivity (e.g., `nc -vz host port`) and firewall, and confirm the server is running.", c.VaultEndpoint)
+	case vault.ErrVaultKeyNotFound.Code:
+		be.Kind = domain.BootErrVaultManifest
+		be.Hint = "Vault returned NotFound for this token's manifest. Confirm the token is provisioned for an active agent."
+	case vault.ErrVaultInvalidInput.Code:
+		be.Kind = domain.BootErrVaultInvalidInput
+		be.Hint = "Vault rejected the request as invalid input. Likely a malformed token or endpoint."
+	case vault.ErrVaultInternal.Code:
+		be.Kind = domain.BootErrVaultInternal
+		be.Hint = "Vault server returned an internal error. Share the detail field with your Vault admin."
+	default:
+		be.Kind = domain.BootErrVaultInternal
+		be.Hint = "Vault returned an unrecognized error."
+	}
+	return true
+}
+
+// classifyNetErr — net.DNSError, net.OpError for non-gRPC-wrapped failures.
+func classifyNetErr(err error, be *domain.BootError, c BootErrCtx) bool {
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		be.Kind = domain.BootErrVaultDNS
+		be.Hint = fmt.Sprintf("Cannot resolve hostname for %s: %s. Check the endpoint spelling and DNS.", c.VaultEndpoint, dnsErr.Err)
+		return true
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		be.Kind = domain.BootErrVaultNetwork
+		be.Hint = fmt.Sprintf("Network error contacting %s during %s: %s.", c.VaultEndpoint, opErr.Op, opErr.Err)
+		return true
+	}
+	// URL parse errors during ParseEndpoint
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		be.Kind = domain.BootErrVaultBadEndpoint
+		be.Hint = fmt.Sprintf("Endpoint %q could not be parsed: %s. Format: host:port or tcp://host:port.", c.VaultEndpoint, urlErr.Err)
+		return true
+	}
+	return false
+}
+
+// classifyGRPCStatus — bare gRPC status (when not wrapped in vault.Error).
+func classifyGRPCStatus(err error, be *domain.BootError, c BootErrCtx) bool {
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	switch st.Code() {
+	case codes.Unauthenticated:
+		be.Kind = domain.BootErrVaultAuth
+		be.Hint = "Vault rejected the token (gRPC Unauthenticated)."
+	case codes.PermissionDenied:
+		be.Kind = domain.BootErrVaultPermission
+		be.Hint = "Token authenticated but lacks required role (gRPC PermissionDenied)."
+	case codes.ResourceExhausted:
+		be.Kind = domain.BootErrVaultRateLimit
+		be.Hint = "Vault rate-limited this token (gRPC ResourceExhausted)."
+	case codes.Unavailable:
+		be.Kind = domain.BootErrVaultNetwork
+		be.Hint = fmt.Sprintf("Vault endpoint %s is not reachable (gRPC Unavailable).", c.VaultEndpoint)
+	case codes.DeadlineExceeded:
+		be.Kind = domain.BootErrVaultTimeout
+		be.Hint = "Vault did not respond within the deadline."
+	case codes.NotFound:
+		be.Kind = domain.BootErrVaultManifest
+		be.Hint = "Vault returned NotFound — manifest may not exist for this token."
+	case codes.InvalidArgument:
+		be.Kind = domain.BootErrVaultInvalidInput
+		be.Hint = "Vault rejected the request as invalid input."
+	case codes.OK:
+		return false // not actually an error
+	default:
+		be.Kind = domain.BootErrVaultInternal
+		be.Hint = fmt.Sprintf("Vault returned gRPC %s.", st.Code())
+	}
+	return true
+}
+
+// applyPhaseFallback — when no structured classifier matched, infer kind+hint
+// from which boot phase we were in. Guarantees every BootError has a useful
+// hint even for unknown wrappers.
+func applyPhaseFallback(be *domain.BootError, c BootErrCtx) {
+	if be.Hint != "" && be.Kind != domain.BootErrUnknown {
+		return
+	}
+	switch c.Phase {
+	case domain.BootPhaseConfigLoad:
+		be.Kind = domain.BootErrConfigInvalid
+		be.Hint = "Failed to load ~/.rune/config.json. Check the file is valid JSON with the expected schema."
+	case domain.BootPhaseConfigCheck:
+		be.Kind = domain.BootErrConfigInvalid
+		be.Hint = "Config loaded but has invalid values."
+	case domain.BootPhaseVaultDial:
+		be.Kind = domain.BootErrVaultDialOpts
+		be.Hint = "Could not initialize the Vault gRPC client (endpoint, CA, or dial options rejected)."
+	case domain.BootPhaseVaultManifest:
+		be.Kind = domain.BootErrVaultManifest
+		be.Hint = "Vault responded but the agent manifest could not be parsed or was empty."
+	case domain.BootPhaseKeySave:
+		be.Kind = domain.BootErrKeySave
+		be.Hint = "Could not save key material to ~/.rune/. Check filesystem permissions."
+	case domain.BootPhaseEmbedderDial:
+		be.Kind = domain.BootErrEmbedderUnreachable
+		be.Hint = "Embedder daemon (runed) is not reachable on its UDS socket. Start it with `runed start`."
+	case domain.BootPhaseEnvectorInit:
+		be.Kind = domain.BootErrEnvectorInit
+		be.Hint = "Envector client could not be initialized — check the manifest's envector_endpoint and api_key."
+	case domain.BootPhaseEnvectorIndex:
+		be.Kind = domain.BootErrEnvectorIndex
+		be.Hint = "Envector index could not be opened. The index may be missing on the server, or auth failed."
+	default:
+		be.Kind = domain.BootErrUnknown
+		be.Hint = "Unrecognized boot failure. Detail field has the raw error — share with your Vault admin."
+	}
+}
+
+// tlsCAMismatchHint — interpolated CA-mismatch hint used both by typed x509
+// detection and string fallback so the wording stays consistent.
+func tlsCAMismatchHint(c BootErrCtx) string {
+	caPath := c.VaultCAPath
+	if caPath == "" {
+		caPath = "(no CA cert configured)"
+	}
+	endpoint := c.VaultEndpoint
+	if endpoint == "" {
+		endpoint = "the Vault server"
+	}
+	return fmt.Sprintf(
+		"Vault server's certificate is not signed by the CA at %s. "+
+			"The CA may have been regenerated on the server side (same CN, different keypair) "+
+			"and the local CA is stale. Re-fetch the current CA from %s admin and replace ~/.rune/certs/ca.pem.",
+		caPath, endpoint,
+	)
+}

--- a/internal/lifecycle/boot_classify_test.go
+++ b/internal/lifecycle/boot_classify_test.go
@@ -1,0 +1,220 @@
+package lifecycle
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/envector/rune-go/internal/adapters/vault"
+	"github.com/envector/rune-go/internal/domain"
+)
+
+func TestClassifyBootError_NilReturnsNil(t *testing.T) {
+	if got := ClassifyBootError(nil, BootErrCtx{}); got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+func TestClassifyBootError_ConfigMissing(t *testing.T) {
+	be := ClassifyBootError(fs.ErrNotExist, BootErrCtx{Phase: domain.BootPhaseConfigLoad})
+	if be.Kind != domain.BootErrConfigMissing {
+		t.Fatalf("kind: got %q want %q", be.Kind, domain.BootErrConfigMissing)
+	}
+	if !strings.Contains(be.Hint, "/rune:configure") {
+		t.Errorf("hint should mention /rune:configure: %q", be.Hint)
+	}
+	if be.Retryable() {
+		t.Error("config missing should not be retryable")
+	}
+}
+
+func TestClassifyBootError_TypedX509UnknownAuthority(t *testing.T) {
+	// x509.UnknownAuthorityError zero value is fine — we only check the type.
+	err := x509.UnknownAuthorityError{}
+	be := ClassifyBootError(err, BootErrCtx{
+		Phase:         domain.BootPhaseVaultManifest,
+		VaultEndpoint: "tcp://vault.example:50051",
+		VaultCAPath:   "/home/user/.rune/certs/ca.pem",
+		Attempts:      3,
+	})
+	if be.Kind != domain.BootErrVaultTLSHandshake {
+		t.Fatalf("kind: got %q want %q", be.Kind, domain.BootErrVaultTLSHandshake)
+	}
+	if !strings.Contains(be.Hint, "/home/user/.rune/certs/ca.pem") {
+		t.Errorf("hint should mention CA path: %q", be.Hint)
+	}
+	if be.Retryable() {
+		t.Error("TLS handshake should not be retryable (won't fix on retry)")
+	}
+}
+
+func TestClassifyBootError_TLSStringFallback(t *testing.T) {
+	// gRPC commonly returns errors like this where the typed x509 error is
+	// lost in string-wrapping. The classifier needs to recover via substring.
+	err := errors.New(
+		"rpc error: code = Unavailable desc = connection error: " +
+			"desc = \"transport: authentication handshake failed: " +
+			"tls: failed to verify certificate: x509: certificate signed by unknown authority\"",
+	)
+	be := ClassifyBootError(err, BootErrCtx{
+		Phase:         domain.BootPhaseVaultManifest,
+		VaultEndpoint: "tcp://158.180.87.178:50051",
+		VaultCAPath:   "/u/.rune/certs/ca.pem",
+	})
+	if be.Kind != domain.BootErrVaultTLSHandshake {
+		t.Fatalf("kind: got %q want %q\ndetail: %s", be.Kind, domain.BootErrVaultTLSHandshake, be.Detail)
+	}
+	if !strings.Contains(be.Hint, "stale") && !strings.Contains(be.Hint, "regenerated") {
+		t.Errorf("hint should mention CA regeneration: %q", be.Hint)
+	}
+}
+
+func TestClassifyBootError_VaultAuth(t *testing.T) {
+	// MapGRPCError converts gRPC Unauthenticated → vault.ErrVaultAuthFailed.
+	authErr := status.Error(codes.Unauthenticated, "token validation failed")
+	mapped := vault.MapGRPCError(authErr)
+	be := ClassifyBootError(mapped, BootErrCtx{
+		Phase:         domain.BootPhaseVaultManifest,
+		VaultEndpoint: "tcp://x:50051",
+	})
+	if be.Kind != domain.BootErrVaultAuth {
+		t.Fatalf("kind: got %q want %q", be.Kind, domain.BootErrVaultAuth)
+	}
+	if be.Retryable() {
+		t.Error("auth failure should not be retryable (won't fix on retry)")
+	}
+	if !strings.Contains(strings.ToLower(be.Hint), "token") {
+		t.Errorf("hint should mention token: %q", be.Hint)
+	}
+}
+
+func TestClassifyBootError_VaultNetworkViaUnavailable(t *testing.T) {
+	netErr := status.Error(codes.Unavailable, "name resolver error: produced zero addresses")
+	mapped := vault.MapGRPCError(netErr)
+	be := ClassifyBootError(mapped, BootErrCtx{
+		Phase:         domain.BootPhaseVaultManifest,
+		VaultEndpoint: "tcp://does-not-resolve:50051",
+	})
+	if be.Kind != domain.BootErrVaultNetwork {
+		t.Fatalf("kind: got %q want %q", be.Kind, domain.BootErrVaultNetwork)
+	}
+	if !be.Retryable() {
+		t.Error("network failure should be retryable")
+	}
+}
+
+func TestClassifyBootError_DNSError(t *testing.T) {
+	dnsErr := &net.DNSError{Name: "vault.invalid", Err: "no such host"}
+	be := ClassifyBootError(dnsErr, BootErrCtx{
+		Phase:         domain.BootPhaseVaultManifest,
+		VaultEndpoint: "tcp://vault.invalid:50051",
+	})
+	if be.Kind != domain.BootErrVaultDNS {
+		t.Fatalf("kind: got %q want %q", be.Kind, domain.BootErrVaultDNS)
+	}
+}
+
+func TestClassifyBootError_GRPCDeadlineExceeded(t *testing.T) {
+	be := ClassifyBootError(
+		status.Error(codes.DeadlineExceeded, "deadline exceeded"),
+		BootErrCtx{Phase: domain.BootPhaseVaultManifest, VaultEndpoint: "x"},
+	)
+	if be.Kind != domain.BootErrVaultTimeout {
+		t.Fatalf("kind: got %q want %q", be.Kind, domain.BootErrVaultTimeout)
+	}
+}
+
+func TestClassifyBootError_PhaseFallback_EmbedderDial(t *testing.T) {
+	// Unrecognized error in embedder_dial phase falls back to embedder_unreachable.
+	be := ClassifyBootError(
+		fmt.Errorf("some-totally-unknown-embedder-error"),
+		BootErrCtx{Phase: domain.BootPhaseEmbedderDial},
+	)
+	if be.Kind != domain.BootErrEmbedderUnreachable {
+		t.Fatalf("kind: got %q want %q", be.Kind, domain.BootErrEmbedderUnreachable)
+	}
+	if !strings.Contains(be.Hint, "runed") {
+		t.Errorf("hint should mention runed daemon: %q", be.Hint)
+	}
+}
+
+func TestClassifyBootError_PhaseFallback_EnvectorIndex(t *testing.T) {
+	be := ClassifyBootError(
+		fmt.Errorf("unknown index error"),
+		BootErrCtx{Phase: domain.BootPhaseEnvectorIndex},
+	)
+	if be.Kind != domain.BootErrEnvectorIndex {
+		t.Fatalf("kind: got %q want %q", be.Kind, domain.BootErrEnvectorIndex)
+	}
+}
+
+func TestClassifyBootError_FullyUnknown(t *testing.T) {
+	be := ClassifyBootError(
+		fmt.Errorf("totally novel error"),
+		BootErrCtx{}, // no phase, no context
+	)
+	if be.Kind != domain.BootErrUnknown {
+		t.Fatalf("kind: got %q want %q", be.Kind, domain.BootErrUnknown)
+	}
+	if be.Detail == "" {
+		t.Error("detail should always be populated")
+	}
+}
+
+func TestClassifyDormantReason(t *testing.T) {
+	cases := []struct {
+		reason   string
+		wantKind domain.BootErrorKind
+	}{
+		{"not_configured", domain.BootErrConfigMissing},
+		{"vault_unconfigured", domain.BootErrVaultNotConfigured},
+		{"user_deactivated", domain.BootErrUserDeactivated},
+		{"invalid_state", domain.BootErrConfigInvalid},
+		{"", domain.BootErrConfigInvalid},
+		{"some_unknown_reason", domain.BootErrConfigInvalid},
+	}
+	for _, c := range cases {
+		t.Run(c.reason, func(t *testing.T) {
+			be := ClassifyDormantReason(c.reason)
+			if be.Kind != c.wantKind {
+				t.Errorf("reason %q: kind=%q want=%q", c.reason, be.Kind, c.wantKind)
+			}
+			if be.Hint == "" {
+				t.Errorf("reason %q: hint is empty", c.reason)
+			}
+		})
+	}
+}
+
+func TestBootError_RetryableTLS(t *testing.T) {
+	// TLS handshake: NOT retryable (won't fix on retry without user action).
+	be := &domain.BootError{Kind: domain.BootErrVaultTLSHandshake}
+	if be.Retryable() {
+		t.Error("TLS handshake should be non-retryable")
+	}
+
+	// Network: IS retryable.
+	be = &domain.BootError{Kind: domain.BootErrVaultNetwork}
+	if !be.Retryable() {
+		t.Error("network should be retryable")
+	}
+
+	// Unknown: be conservative and allow retry.
+	be = &domain.BootError{Kind: domain.BootErrUnknown}
+	if !be.Retryable() {
+		t.Error("unknown should be retryable (conservative)")
+	}
+
+	// Nil: not retryable (nothing to retry).
+	var nilBe *domain.BootError
+	if nilBe.Retryable() {
+		t.Error("nil BootError should not be retryable")
+	}
+}

--- a/internal/lifecycle/boot_log.go
+++ b/internal/lifecycle/boot_log.go
@@ -1,0 +1,149 @@
+package lifecycle
+
+// boot_log.go — append-only JSON log of boot failures to ~/.rune/logs/boot.log.
+// Complementary to lifecycle.Manager.LastBootError() (in-memory, latest only)
+// and slog (stderr / handler chain). The on-disk log is the fallback for
+// cases the structured classifier didn't fully describe — humans / admins
+// can grep across attempts.
+//
+// Design:
+//   - One JSON object per line ({ "time": ..., "kind": ..., ... })
+//   - Append-only — never truncates. Log rotation deferred (manual or
+//     external logrotate); typical session writes a few dozen lines max.
+//   - Best-effort: open/write errors do NOT propagate (logging must not
+//     take down the boot loop).
+//   - Sensitive substrings in `detail` are redacted via obs.Redact before
+//     writing — same patterns the slog handler uses.
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/envector/rune-go/internal/domain"
+	"github.com/envector/rune-go/internal/obs"
+)
+
+// bootLogState — package-scope state for the on-disk boot log. Guarded by mu
+// because the boot loop (one goroutine) and graceful shutdown (another) may
+// touch the file concurrently.
+var bootLog = struct {
+	mu   sync.Mutex
+	file *os.File
+	path string
+	// resolved tracks whether we've tried to open at least once — failures
+	// after that switch to silent (avoid spamming slog with the same error).
+	resolved bool
+}{}
+
+// bootLogEntry is the JSON shape written per line. Pinned schema so admins
+// can write scripts against it without worrying about field renames.
+type bootLogEntry struct {
+	Time     time.Time            `json:"time"`
+	Kind     domain.BootErrorKind `json:"kind"`
+	Phase    domain.BootPhase     `json:"phase,omitempty"`
+	Detail   string               `json:"detail"`
+	Hint     string               `json:"hint,omitempty"`
+	Attempts int                  `json:"attempts,omitempty"`
+}
+
+// PersistBootError appends a JSON line describing the boot error to
+// ~/.rune/logs/boot.log. No-op when be is nil. Failures are swallowed
+// (logged once via slog, then silent) so the log writer can't break the
+// boot loop.
+func PersistBootError(be *domain.BootError) {
+	if be == nil {
+		return
+	}
+	bootLog.mu.Lock()
+	defer bootLog.mu.Unlock()
+
+	if bootLog.file == nil {
+		if err := openBootLogLocked(); err != nil {
+			if !bootLog.resolved {
+				slog.Warn("boot_log: file open failed — boot errors will not be persisted",
+					"err", err, "path", bootLog.path)
+			}
+			bootLog.resolved = true
+			return
+		}
+	}
+
+	entry := bootLogEntry{
+		Time:     be.At,
+		Kind:     be.Kind,
+		Phase:    be.Phase,
+		Detail:   obs.Redact(be.Detail),
+		Hint:     be.Hint, // hint never contains secrets by construction
+		Attempts: be.Attempts,
+	}
+	line, err := json.Marshal(entry)
+	if err != nil {
+		// json.Marshal failing on these stdlib types should be impossible,
+		// but be defensive.
+		slog.Warn("boot_log: marshal failed", "err", err)
+		return
+	}
+	line = append(line, '\n')
+	if _, err := bootLog.file.Write(line); err != nil {
+		slog.Warn("boot_log: write failed", "err", err)
+	}
+}
+
+// CloseBootLog closes the underlying file. Called from graceful shutdown
+// so the OS flushes the buffer. Idempotent.
+func CloseBootLog() {
+	bootLog.mu.Lock()
+	defer bootLog.mu.Unlock()
+	if bootLog.file != nil {
+		_ = bootLog.file.Close()
+		bootLog.file = nil
+	}
+}
+
+// BootLogPath returns the on-disk path the boot log writes to (resolved once
+// per process). Exposed for diagnostics tools that want to surface the path
+// to the user.
+func BootLogPath() string {
+	bootLog.mu.Lock()
+	defer bootLog.mu.Unlock()
+	if bootLog.path == "" {
+		_ = resolveBootLogPathLocked()
+	}
+	return bootLog.path
+}
+
+// resolveBootLogPathLocked computes ~/.rune/logs/boot.log and stores it
+// in bootLog.path. Caller must hold bootLog.mu.
+func resolveBootLogPathLocked() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	bootLog.path = filepath.Join(home, ".rune", "logs", "boot.log")
+	return nil
+}
+
+// openBootLogLocked mkdir -p the logs directory + opens the log file in
+// O_APPEND mode with 0600 perms (file is owner-only since detail may contain
+// internal endpoints / error strings). Caller must hold bootLog.mu.
+func openBootLogLocked() error {
+	if bootLog.path == "" {
+		if err := resolveBootLogPathLocked(); err != nil {
+			return err
+		}
+	}
+	dir := filepath.Dir(bootLog.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(bootLog.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	bootLog.file = f
+	return nil
+}

--- a/internal/lifecycle/boot_log.go
+++ b/internal/lifecycle/boot_log.go
@@ -1,6 +1,6 @@
 package lifecycle
 
-// boot_log.go — append-only JSON log of boot failures to ~/.rune/logs/boot.log.
+// boot_log.go — append-only JSON log of boot failures (e.g. ~/.rune/logs/boot.log).
 // Complementary to lifecycle.Manager.LastBootError() (in-memory, latest only)
 // and slog (stderr / handler chain). The on-disk log is the fallback for
 // cases the structured classifier didn't fully describe — humans / admins
@@ -8,12 +8,15 @@ package lifecycle
 //
 // Design:
 //   - One JSON object per line ({ "time": ..., "kind": ..., ... })
-//   - Append-only — never truncates. Log rotation deferred (manual or
-//     external logrotate); typical session writes a few dozen lines max.
+//   - Size-based rotation: when a write would exceed maxBytes, the current
+//     file is rotated to "<path>.1" (previous .1 overwritten) and a fresh
+//     file is opened. Two-file scheme, no external deps.
 //   - Best-effort: open/write errors do NOT propagate (logging must not
 //     take down the boot loop).
 //   - Sensitive substrings in `detail` are redacted via obs.Redact before
 //     writing — same patterns the slog handler uses.
+//   - The destination path is injected (see NewBootLogger) so callers control
+//     the root via bootstrap.Paths and tests can write to a temp dir.
 
 import (
 	"encoding/json"
@@ -27,17 +30,31 @@ import (
 	"github.com/envector/rune-go/internal/obs"
 )
 
-// bootLogState — package-scope state for the on-disk boot log. Guarded by mu
-// because the boot loop (one goroutine) and graceful shutdown (another) may
-// touch the file concurrently.
-var bootLog = struct {
-	mu   sync.Mutex
-	file *os.File
-	path string
+// DefaultBootLogMaxBytes — rotation threshold when none is supplied.
+const DefaultBootLogMaxBytes int64 = 1 << 20 // 1 MiB
+
+// BootLogger owns the on-disk boot-failure log. Construct with NewBootLogger
+// and inject into Manager via Manager.SetBootLog. A nil *BootLogger is a safe
+// no-op so callers (and tests) can leave it unset.
+type BootLogger struct {
+	mu       sync.Mutex
+	path     string
+	maxBytes int64
+	file     *os.File
 	// resolved tracks whether we've tried to open at least once — failures
 	// after that switch to silent (avoid spamming slog with the same error).
 	resolved bool
-}{}
+}
+
+// NewBootLogger returns a logger that appends to path, rotating at maxBytes
+// (DefaultBootLogMaxBytes when maxBytes <= 0). The file is opened lazily on
+// the first Persist call.
+func NewBootLogger(path string, maxBytes int64) *BootLogger {
+	if maxBytes <= 0 {
+		maxBytes = DefaultBootLogMaxBytes
+	}
+	return &BootLogger{path: path, maxBytes: maxBytes}
+}
 
 // bootLogEntry is the JSON shape written per line. Pinned schema so admins
 // can write scripts against it without worrying about field renames.
@@ -50,24 +67,23 @@ type bootLogEntry struct {
 	Attempts int                  `json:"attempts,omitempty"`
 }
 
-// PersistBootError appends a JSON line describing the boot error to
-// ~/.rune/logs/boot.log. No-op when be is nil. Failures are swallowed
-// (logged once via slog, then silent) so the log writer can't break the
-// boot loop.
-func PersistBootError(be *domain.BootError) {
-	if be == nil {
+// Persist appends a JSON line describing the boot error. No-op when the
+// receiver or be is nil. Failures are swallowed (logged once via slog, then
+// silent) so the log writer can't break the boot loop.
+func (bl *BootLogger) Persist(be *domain.BootError) {
+	if bl == nil || be == nil {
 		return
 	}
-	bootLog.mu.Lock()
-	defer bootLog.mu.Unlock()
+	bl.mu.Lock()
+	defer bl.mu.Unlock()
 
-	if bootLog.file == nil {
-		if err := openBootLogLocked(); err != nil {
-			if !bootLog.resolved {
+	if bl.file == nil {
+		if err := bl.openLocked(); err != nil {
+			if !bl.resolved {
 				slog.Warn("boot_log: file open failed — boot errors will not be persisted",
-					"err", err, "path", bootLog.path)
+					"err", err, "path", bl.path)
 			}
-			bootLog.resolved = true
+			bl.resolved = true
 			return
 		}
 	}
@@ -88,62 +104,80 @@ func PersistBootError(be *domain.BootError) {
 		return
 	}
 	line = append(line, '\n')
-	if _, err := bootLog.file.Write(line); err != nil {
+
+	bl.rotateIfNeededLocked(int64(len(line)))
+	if bl.file == nil {
+		return // rotation failed to reopen; openLocked already logged
+	}
+	if _, err := bl.file.Write(line); err != nil {
 		slog.Warn("boot_log: write failed", "err", err)
 	}
 }
 
-// CloseBootLog closes the underlying file. Called from graceful shutdown
-// so the OS flushes the buffer. Idempotent.
-func CloseBootLog() {
-	bootLog.mu.Lock()
-	defer bootLog.mu.Unlock()
-	if bootLog.file != nil {
-		_ = bootLog.file.Close()
-		bootLog.file = nil
+// Close closes the underlying file. Called from graceful shutdown so the OS
+// flushes the buffer. Idempotent and nil-safe; satisfies the Closer interface.
+func (bl *BootLogger) Close() error {
+	if bl == nil {
+		return nil
 	}
-}
-
-// BootLogPath returns the on-disk path the boot log writes to (resolved once
-// per process). Exposed for diagnostics tools that want to surface the path
-// to the user.
-func BootLogPath() string {
-	bootLog.mu.Lock()
-	defer bootLog.mu.Unlock()
-	if bootLog.path == "" {
-		_ = resolveBootLogPathLocked()
-	}
-	return bootLog.path
-}
-
-// resolveBootLogPathLocked computes ~/.rune/logs/boot.log and stores it
-// in bootLog.path. Caller must hold bootLog.mu.
-func resolveBootLogPathLocked() error {
-	home, err := os.UserHomeDir()
-	if err != nil {
+	bl.mu.Lock()
+	defer bl.mu.Unlock()
+	if bl.file != nil {
+		err := bl.file.Close()
+		bl.file = nil
 		return err
 	}
-	bootLog.path = filepath.Join(home, ".rune", "logs", "boot.log")
 	return nil
 }
 
-// openBootLogLocked mkdir -p the logs directory + opens the log file in
-// O_APPEND mode with 0600 perms (file is owner-only since detail may contain
-// internal endpoints / error strings). Caller must hold bootLog.mu.
-func openBootLogLocked() error {
-	if bootLog.path == "" {
-		if err := resolveBootLogPathLocked(); err != nil {
-			return err
-		}
+// Path returns the destination path. Nil-safe (returns "").
+func (bl *BootLogger) Path() string {
+	if bl == nil {
+		return ""
 	}
-	dir := filepath.Dir(bootLog.path)
+	return bl.path
+}
+
+// openLocked mkdir -p the logs directory + opens the log file in O_APPEND mode
+// with 0600 perms (file is owner-only since detail may contain internal
+// endpoints / error strings). Caller must hold bl.mu.
+func (bl *BootLogger) openLocked() error {
+	dir := filepath.Dir(bl.path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
-	f, err := os.OpenFile(bootLog.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	f, err := os.OpenFile(bl.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}
-	bootLog.file = f
+	bl.file = f
 	return nil
+}
+
+// rotateIfNeededLocked rotates the current file to "<path>.1" when appending
+// `incoming` bytes would push it past maxBytes, then reopens a fresh file. The
+// previous ".1" is overwritten (two-file scheme). Best-effort: on any error it
+// leaves bl.file as-is or nil and lets the caller skip the write. Caller must
+// hold bl.mu.
+func (bl *BootLogger) rotateIfNeededLocked(incoming int64) {
+	info, err := bl.file.Stat()
+	if err != nil {
+		return
+	}
+	if info.Size()+incoming <= bl.maxBytes {
+		return
+	}
+	_ = bl.file.Close()
+	bl.file = nil
+	// Overwrite any prior rotation; we keep exactly one generation of history.
+	if err := os.Rename(bl.path, bl.path+".1"); err != nil {
+		slog.Warn("boot_log: rotate rename failed", "err", err, "path", bl.path)
+		// Fall through and try to reopen the original so we don't lose new writes.
+	}
+	if err := bl.openLocked(); err != nil {
+		if !bl.resolved {
+			slog.Warn("boot_log: reopen after rotate failed", "err", err, "path", bl.path)
+		}
+		bl.resolved = true
+	}
 }

--- a/internal/lifecycle/boot_log.go
+++ b/internal/lifecycle/boot_log.go
@@ -1,22 +1,8 @@
 package lifecycle
 
-// boot_log.go — append-only JSON log of boot failures (e.g. ~/.rune/logs/boot.log).
-// Complementary to lifecycle.Manager.LastBootError() (in-memory, latest only)
-// and slog (stderr / handler chain). The on-disk log is the fallback for
-// cases the structured classifier didn't fully describe — humans / admins
-// can grep across attempts.
-//
-// Design:
-//   - One JSON object per line ({ "time": ..., "kind": ..., ... })
-//   - Size-based rotation: when a write would exceed maxBytes, the current
-//     file is rotated to "<path>.1" (previous .1 overwritten) and a fresh
-//     file is opened. Two-file scheme, no external deps.
-//   - Best-effort: open/write errors do NOT propagate (logging must not
-//     take down the boot loop).
-//   - Sensitive substrings in `detail` are redacted via obs.Redact before
-//     writing — same patterns the slog handler uses.
-//   - The destination path is injected (see NewBootLogger) so callers control
-//     the root via bootstrap.Paths and tests can write to a temp dir.
+// boot_log.go — append-only JSON log of boot failures, one object per line.
+// Best-effort: open/write errors never propagate to the boot loop. detail is
+// redacted via obs.Redact before writing.
 
 import (
 	"encoding/json"
@@ -30,25 +16,20 @@ import (
 	"github.com/envector/rune-go/internal/obs"
 )
 
-// DefaultBootLogMaxBytes — rotation threshold when none is supplied.
 const DefaultBootLogMaxBytes int64 = 1 << 20 // 1 MiB
 
-// BootLogger owns the on-disk boot-failure log. Construct with NewBootLogger
-// and inject into Manager via Manager.SetBootLog. A nil *BootLogger is a safe
+// BootLogger owns the on-disk boot-failure log. A nil *BootLogger is a safe
 // no-op so callers (and tests) can leave it unset.
 type BootLogger struct {
 	mu       sync.Mutex
 	path     string
 	maxBytes int64
 	file     *os.File
-	// resolved tracks whether we've tried to open at least once — failures
-	// after that switch to silent (avoid spamming slog with the same error).
-	resolved bool
+	resolved bool // tried to open at least once; gates repeated open-error logs
 }
 
-// NewBootLogger returns a logger that appends to path, rotating at maxBytes
-// (DefaultBootLogMaxBytes when maxBytes <= 0). The file is opened lazily on
-// the first Persist call.
+// NewBootLogger appends to path, rotating at maxBytes (default when <= 0).
+// The file opens lazily on first Persist.
 func NewBootLogger(path string, maxBytes int64) *BootLogger {
 	if maxBytes <= 0 {
 		maxBytes = DefaultBootLogMaxBytes
@@ -56,8 +37,7 @@ func NewBootLogger(path string, maxBytes int64) *BootLogger {
 	return &BootLogger{path: path, maxBytes: maxBytes}
 }
 
-// bootLogEntry is the JSON shape written per line. Pinned schema so admins
-// can write scripts against it without worrying about field renames.
+// bootLogEntry is the pinned JSON shape written per line.
 type bootLogEntry struct {
 	Time     time.Time            `json:"time"`
 	Kind     domain.BootErrorKind `json:"kind"`
@@ -67,9 +47,8 @@ type bootLogEntry struct {
 	Attempts int                  `json:"attempts,omitempty"`
 }
 
-// Persist appends a JSON line describing the boot error. No-op when the
-// receiver or be is nil. Failures are swallowed (logged once via slog, then
-// silent) so the log writer can't break the boot loop.
+// Persist appends one JSON line. No-op when bl or be is nil. Open failures are
+// logged once then silent so the writer can't break the boot loop.
 func (bl *BootLogger) Persist(be *domain.BootError) {
 	if bl == nil || be == nil {
 		return
@@ -98,8 +77,6 @@ func (bl *BootLogger) Persist(be *domain.BootError) {
 	}
 	line, err := json.Marshal(entry)
 	if err != nil {
-		// json.Marshal failing on these stdlib types should be impossible,
-		// but be defensive.
 		slog.Warn("boot_log: marshal failed", "err", err)
 		return
 	}
@@ -114,8 +91,7 @@ func (bl *BootLogger) Persist(be *domain.BootError) {
 	}
 }
 
-// Close closes the underlying file. Called from graceful shutdown so the OS
-// flushes the buffer. Idempotent and nil-safe; satisfies the Closer interface.
+// Close is idempotent and nil-safe; satisfies the Closer interface.
 func (bl *BootLogger) Close() error {
 	if bl == nil {
 		return nil
@@ -130,7 +106,6 @@ func (bl *BootLogger) Close() error {
 	return nil
 }
 
-// Path returns the destination path. Nil-safe (returns "").
 func (bl *BootLogger) Path() string {
 	if bl == nil {
 		return ""
@@ -138,9 +113,8 @@ func (bl *BootLogger) Path() string {
 	return bl.path
 }
 
-// openLocked mkdir -p the logs directory + opens the log file in O_APPEND mode
-// with 0600 perms (file is owner-only since detail may contain internal
-// endpoints / error strings). Caller must hold bl.mu.
+// openLocked opens the log O_APPEND with 0600 (owner-only; detail may carry
+// internal endpoints). Caller must hold bl.mu.
 func (bl *BootLogger) openLocked() error {
 	dir := filepath.Dir(bl.path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -154,10 +128,8 @@ func (bl *BootLogger) openLocked() error {
 	return nil
 }
 
-// rotateIfNeededLocked rotates the current file to "<path>.1" when appending
-// `incoming` bytes would push it past maxBytes, then reopens a fresh file. The
-// previous ".1" is overwritten (two-file scheme). Best-effort: on any error it
-// leaves bl.file as-is or nil and lets the caller skip the write. Caller must
+// rotateIfNeededLocked rotates to "<path>.1" (one generation kept) when the
+// next write would exceed maxBytes, then reopens a fresh file. Caller must
 // hold bl.mu.
 func (bl *BootLogger) rotateIfNeededLocked(incoming int64) {
 	info, err := bl.file.Stat()
@@ -169,10 +141,9 @@ func (bl *BootLogger) rotateIfNeededLocked(incoming int64) {
 	}
 	_ = bl.file.Close()
 	bl.file = nil
-	// Overwrite any prior rotation; we keep exactly one generation of history.
 	if err := os.Rename(bl.path, bl.path+".1"); err != nil {
 		slog.Warn("boot_log: rotate rename failed", "err", err, "path", bl.path)
-		// Fall through and try to reopen the original so we don't lose new writes.
+		// reopen original anyway so we don't lose new writes
 	}
 	if err := bl.openLocked(); err != nil {
 		if !bl.resolved {

--- a/internal/lifecycle/boot_log_test.go
+++ b/internal/lifecycle/boot_log_test.go
@@ -1,0 +1,131 @@
+package lifecycle
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/envector/rune-go/internal/domain"
+)
+
+func sampleBootError(detail string) *domain.BootError {
+	return &domain.BootError{
+		Kind:     domain.BootErrVaultNetwork,
+		Detail:   detail,
+		Hint:     "check the endpoint",
+		Phase:    domain.BootPhaseVaultDial,
+		At:       time.Now(),
+		Attempts: 1,
+	}
+}
+
+func TestBootLogger_PersistWritesJSONLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "logs", "boot.log")
+	bl := NewBootLogger(path, DefaultBootLogMaxBytes)
+	defer bl.Close()
+
+	bl.Persist(sampleBootError("vault unreachable"))
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read boot log: %v", err)
+	}
+	var entry bootLogEntry
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &entry); err != nil {
+		t.Fatalf("unmarshal line: %v (raw=%q)", err, data)
+	}
+	if entry.Kind != domain.BootErrVaultNetwork {
+		t.Errorf("kind: got %q, want %q", entry.Kind, domain.BootErrVaultNetwork)
+	}
+	if entry.Detail != "vault unreachable" {
+		t.Errorf("detail: got %q", entry.Detail)
+	}
+}
+
+func TestBootLogger_NilReceiverIsNoop(t *testing.T) {
+	var bl *BootLogger // nil — simulates Manager with bootLog unset
+	// None of these should panic.
+	bl.Persist(sampleBootError("x"))
+	if got := bl.Path(); got != "" {
+		t.Errorf("nil Path(): got %q, want empty", got)
+	}
+	if err := bl.Close(); err != nil {
+		t.Errorf("nil Close(): %v", err)
+	}
+}
+
+func TestBootLogger_NilErrorIsNoop(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "boot.log")
+	bl := NewBootLogger(path, DefaultBootLogMaxBytes)
+	defer bl.Close()
+
+	bl.Persist(nil)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("nil BootError should not create the file (stat err=%v)", err)
+	}
+}
+
+func TestBootLogger_CloseIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "boot.log")
+	bl := NewBootLogger(path, DefaultBootLogMaxBytes)
+	bl.Persist(sampleBootError("once"))
+
+	if err := bl.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := bl.Close(); err != nil {
+		t.Errorf("second Close should be no-op: %v", err)
+	}
+}
+
+func TestBootLogger_RotatesWhenExceedingMaxBytes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "boot.log")
+	// Tiny threshold so a couple of entries force rotation.
+	bl := NewBootLogger(path, 200)
+	defer bl.Close()
+
+	// Each entry's JSON line is ~150+ bytes, so the second/third writes cross
+	// the 200-byte threshold and rotate.
+	bl.Persist(sampleBootError("first-entry-aaaaaaaaaaaaaaaaaaaa"))
+	bl.Persist(sampleBootError("second-entry-bbbbbbbbbbbbbbbbbbbb"))
+	bl.Persist(sampleBootError("third-entry-cccccccccccccccccccc"))
+
+	// Rotation produced a ".1" sidecar holding earlier generation(s).
+	rotated := path + ".1"
+	if _, err := os.Stat(rotated); err != nil {
+		t.Fatalf("expected rotated file %s: %v", rotated, err)
+	}
+
+	// Current file holds the most recent write and is under the threshold.
+	cur, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read current: %v", err)
+	}
+	if int64(len(cur)) > 200 {
+		t.Errorf("current file size %d exceeds maxBytes 200 — rotation didn't reset", len(cur))
+	}
+	if !strings.Contains(string(cur), "third-entry") {
+		t.Errorf("current file should hold the latest entry; got %q", cur)
+	}
+
+	// Every line across both files must be valid JSON (no torn writes).
+	for _, f := range []string{rotated, path} {
+		b, _ := os.ReadFile(f)
+		sc := bufio.NewScanner(strings.NewReader(string(b)))
+		for sc.Scan() {
+			line := strings.TrimSpace(sc.Text())
+			if line == "" {
+				continue
+			}
+			var e bootLogEntry
+			if err := json.Unmarshal([]byte(line), &e); err != nil {
+				t.Errorf("%s: invalid JSON line %q: %v", f, line, err)
+			}
+		}
+	}
+}

--- a/internal/lifecycle/shutdown.go
+++ b/internal/lifecycle/shutdown.go
@@ -70,6 +70,10 @@ func GracefulShutdown(ctx context.Context, tracker *InflightTracker, closers []C
 		ZeroizeDEK(dek)
 	}
 
+	// Step 4 — flush + close the boot log file so the OS doesn't hold a
+	// stale fd after exit. Idempotent; safe to call even if never opened.
+	CloseBootLog()
+
 	return nil
 }
 

--- a/internal/lifecycle/shutdown.go
+++ b/internal/lifecycle/shutdown.go
@@ -70,10 +70,9 @@ func GracefulShutdown(ctx context.Context, tracker *InflightTracker, closers []C
 		ZeroizeDEK(dek)
 	}
 
-	// Step 4 — flush + close the boot log file so the OS doesn't hold a
-	// stale fd after exit. Idempotent; safe to call even if never opened.
-	CloseBootLog()
-
+	// The boot log file is flushed + closed via the closers list (BootLogger
+	// satisfies Closer); callers pass Manager.BootLog() alongside the adapter
+	// closers. Nothing boot-log-specific to do here.
 	return nil
 }
 

--- a/internal/obs/slog.go
+++ b/internal/obs/slog.go
@@ -55,6 +55,11 @@ func redact(s string) string {
 	return s
 }
 
+// Redact is the exported entry point for redacting a string outside the
+// slog handler path (e.g. boot log file writer, MCP tool result fields).
+// Same semantics as the internal redact used by filteringHandler.
+func Redact(s string) string { return redact(s) }
+
 // NewHandler wraps an inner slog.Handler with sensitive-data redaction.
 // Falls back to a stderr text handler at the given level when inner is
 // nil.

--- a/internal/service/lifecycle.go
+++ b/internal/service/lifecycle.go
@@ -121,11 +121,21 @@ type EnvInfo struct {
 }
 
 // VaultInfo — subset exposed in diagnostics.
+//
+// Configured = a Vault gRPC client is wired (boot loop reached Active).
+// Healthy    = the most recent HealthCheck succeeded.
+// Error      = HealthCheck error (operational, set only when Healthy=false).
+// LastBootError = structured boot failure from lifecycle.Manager. Surfaces
+//
+//	the actual reason for waiting_for_vault state — agents
+//	branch on .kind to fast-fail without manual probing. Nil
+//	when boot has succeeded or no attempt has been made yet.
 type VaultInfo struct {
-	Configured bool   `json:"configured"`
-	Healthy    bool   `json:"healthy"`
-	Endpoint   string `json:"endpoint,omitempty"`
-	Error      string `json:"error,omitempty"`
+	Configured    bool               `json:"configured"`
+	Healthy       bool               `json:"healthy"`
+	Endpoint      string             `json:"endpoint,omitempty"`
+	Error         string             `json:"error,omitempty"`
+	LastBootError *domain.BootError  `json:"last_boot_error,omitempty"`
 }
 
 // KeysInfo — memory-resident key state.
@@ -234,6 +244,17 @@ func (s *LifecycleService) Diagnostics(ctx context.Context) *DiagnosticsResult {
 
 func (s *LifecycleService) collectVault(ctx context.Context, timeout time.Duration) VaultInfo {
 	info := VaultInfo{Configured: s.Vault != nil}
+
+	// Surface the most recent boot failure regardless of client state.
+	// When the boot loop is stuck on waiting_for_vault, s.Vault is nil but
+	// LastBootError holds the actual reason — agents need this to skip
+	// expensive trial-and-error diagnosis.
+	if s.State != nil {
+		if be := s.State.LastBootError(); be != nil {
+			info.LastBootError = be
+		}
+	}
+
 	if s.Vault == nil {
 		return info
 	}
@@ -488,12 +509,18 @@ func (s *LifecycleService) DeleteCapture(ctx context.Context, args DeleteCapture
 
 // ReloadPipelinesResult.
 type ReloadPipelinesResult struct {
-	OK                   bool        `json:"ok"`
-	State                string      `json:"state"`
-	ScribeInitialized    bool        `json:"scribe_initialized"`
-	RetrieverInitialized bool        `json:"retriever_initialized"`
-	Errors               []string    `json:"errors,omitempty"`
-	EnvectorWarmup       *WarmupInfo `json:"envector_warmup,omitempty"`
+	OK                   bool              `json:"ok"`
+	State                string            `json:"state"`
+	ScribeInitialized    bool              `json:"scribe_initialized"`
+	RetrieverInitialized bool              `json:"retriever_initialized"`
+	// LastBootError mirrors VaultInfo.LastBootError so callers (agent, UI)
+	// can fast-fail on this single response — no follow-up diagnostics call
+	// needed for the common case of "reload finished, boot failed, here's
+	// why". Populated only when state != "active" AND a classified error
+	// is available; nil otherwise.
+	LastBootError  *domain.BootError `json:"last_boot_error,omitempty"`
+	Errors         []string          `json:"errors,omitempty"`
+	EnvectorWarmup *WarmupInfo       `json:"envector_warmup,omitempty"`
 }
 
 // WarmupInfo — GetIndexList probe (60s timeout).
@@ -531,6 +558,16 @@ func (s *LifecycleService) ReloadPipelines(ctx context.Context) (*ReloadPipeline
 	if s.State.Current() == lifecycle.StateActive {
 		result.ScribeInitialized = true
 		result.RetrieverInitialized = true
+	} else {
+		// Boot did not reach active within the 5s wait window. Surface the
+		// most recent classified boot error so the caller can fast-fail
+		// without needing a separate diagnostics call. May still be nil
+		// (e.g., boot loop is genuinely in-flight and hasn't recorded an
+		// error yet) — in that case the agent should follow up with
+		// diagnostics per the Fast-Fail Rule in SKILL.md.
+		if be := s.State.LastBootError(); be != nil {
+			result.LastBootError = be
+		}
 	}
 
 	if s.Envector != nil {


### PR DESCRIPTION
## 문제
`/rune:configure` 실패 시 (CA 불일치, 잘못된 토큰, endpoint 도달 불가 등) rune-mcp 가 `state: "waiting_for_vault"` 만 반환하고 원인을 노출하지 않음. agent 가 openssl/nc/source code 까지 동원해 직접 진단하다 **58 turn / $4.90 / 4분 50초 (Opus 4.7 max)** 소모 후 boot 실패로 종료합니다.

## 수정 (4-layer)

1. **분류기** (`internal/lifecycle/boot_classify.go`) — raw gRPC/TLS/DNS 에러 → `BootError{kind, hint, detail, phase, attempts}`. 24개 `kind` enum, TLS 는 typed `x509` + gRPC string-wrap fallback 2-layer.
2. **Boot loop wiring** (`boot.go`) — `bootOnce` 모든 실패 경로에서 분류기 호출 → `Manager` atomic 저장 + `~/.rune/logs/boot.log` (mode 0600, `obs.Redact` 적용) 자동 append.
3. **응답 surface** (`service/lifecycle.go`) — `diagnostics.vault.last_boot_error` + `reload_pipelines.last_boot_error`. 후자만 봐도 한 호출로 fast-fail 가능.
4. **SKILL.md / commands** — "hint verbatim + STOP" rule. 추가로 `/rune:configure` 절차도 압축 (AskUserQuestion 3개 묶기, `Bash`+`Write` / `chmod`+`reload_pipelines` parallel `tool_use`).

## 결과 (동일 TLS CA mismatch 시나리오)

| | Before | After |
|---|---:|---:|
| Turn | 58 | **7** |
| Wall clock | 4:50 | **1:36** |
| Cost (Opus 4.7 max) | $4.90 | **$0.73** |
| Model dependency | Opus 만 root cause 도달 | 모델 무관 fast-fail |

## Compatibility

- 응답 스키마 변경 없음 — `last_boot_error` 만 `omitempty` 로 추가
- 옛 rune-mcp 환경에서는 SKILL.md fallback rule 이 legacy 필드 (`vault.error`, `dormant_reason`) 활용

## Related
Complements #135 (recovery interceptor):
- #135 = transient 실패 자동 복구 (gRPC unary interceptor)
- This PR = unrecoverable 실패의 root cause surface
- 같은 boot 시나리오에서 둘 다 작동 (recovery 가 max retry 초과 → 우리 분류기가 최종 에러 분류)
- `boot.go` + `service/lifecycle.go` 에서 git-level conflict 있음 — 모두 additive (양쪽 다 적용), resolve 자명.
