### PR TITLE
fix(policy): rune-aware truncation to keep payload UTF-8 valid for embedder

### DIFF
--- a/internal/policy/pii.go
+++ b/internal/policy/pii.go
@@ -43,9 +43,7 @@ func RedactSensitive(text string) (string, string) {
 		}
 	}
 
-	if len(redacted) > MaxInputChars {
-		redacted = redacted[:MaxInputChars]
-	}
+	redacted = truncRunes(redacted, MaxInputChars)
 
 	noteStr := ""
 	if len(notes) > 0 {

--- a/internal/policy/record_builder.go
+++ b/internal/policy/record_builder.go
@@ -133,7 +133,7 @@ func buildSingleRecord(
 		Timestamp:     now.UTC(),
 		Title:         title,
 		Decision: domain.DecisionDetail{
-			What:  truncStr(cleanText, 500),
+			What:  truncRunes(cleanText, 500),
 			Who:   userWho(rawEvent),
 			Where: whereStr(rawEvent),
 		},
@@ -211,10 +211,7 @@ func buildMultiRecord(
 		}
 		recordID := domain.GenerateRecordID(now, d, phaseTitle) + suffix
 
-		decision := phase.PhaseDecision
-		if len(decision) > 500 {
-			decision = decision[:500]
-		}
+		decision := truncRunes(phase.PhaseDecision, 500)
 
 		evidence := extractEvidence(rawEvent, cleanText)
 		certainty, missingInfo := determineCertainty(evidence, phase.PhaseRationale)
@@ -295,15 +292,14 @@ func buildMultiRecord(
 
 //--- Helper ---//
 
-// Extract first sentence up to domain.MaxTitleLen chars
+// extractTitle returns the first sentence (up to first ".") capped at
+// MaxTitleLen runes. text[:idx] is safe because "." is ASCII single-byte.
 func extractTitle(text string) string {
 	firstSentence := text
 	if idx := strings.Index(text, "."); idx > 0 {
 		firstSentence = text[:idx]
 	}
-	if len(firstSentence) > domain.MaxTitleLen {
-		firstSentence = firstSentence[:domain.MaxTitleLen]
-	}
+	firstSentence = truncRunes(firstSentence, domain.MaxTitleLen)
 	firstSentence = strings.TrimSpace(firstSentence)
 	if len(firstSentence) > 10 {
 		return firstSentence
@@ -319,13 +315,9 @@ func extractEvidence(rawEvent *domain.RawEvent, text string) []domain.Evidence {
 		matches := rx.FindAllStringSubmatch(text, -1)
 		for _, m := range matches {
 			if len(m) > 1 && len(m[1]) >= 10 {
-				quote := m[1]
-				if len(quote) > 200 {
-					quote = quote[:200]
-				}
 				evidence = append(evidence, domain.Evidence{
 					Claim:  "Quoted statement from discussion",
-					Quote:  quote,
+					Quote:  truncRunes(m[1], 200),
 					Source: sourceRef,
 				})
 			}
@@ -335,8 +327,8 @@ func extractEvidence(rawEvent *domain.RawEvent, text string) []domain.Evidence {
 	// Fallback paraphrase
 	if len(evidence) == 0 && len(text) >= 20 {
 		quote := text
-		if len(quote) > 150 {
-			quote = quote[:150] + "..."
+		if truncated := truncRunes(quote, 150); truncated != quote {
+			quote = truncated + "..."
 		}
 		evidence = append(evidence, domain.Evidence{
 			Claim:  "Decision statement (paraphrased)",
@@ -453,9 +445,3 @@ func whereStr(rawEvent *domain.RawEvent) string {
 	return rawEvent.Source
 }
 
-func truncStr(s string, maxLen int) string {
-	if len(s) > maxLen {
-		return s[:maxLen]
-	}
-	return s
-}

--- a/internal/policy/utf8_safe.go
+++ b/internal/policy/utf8_safe.go
@@ -1,0 +1,23 @@
+package policy
+
+// truncRunes truncates s to maxRunes codepoints (Python s[:N] semantic).
+// Used in place of byte slicing on record fields so multi-byte UTF-8 is
+// not split mid-encoding (proto3 string-field validation rejects orphan
+// continuation bytes).
+func truncRunes(s string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	// Byte length is an upper bound on rune count.
+	if len(s) <= maxRunes {
+		return s
+	}
+	count := 0
+	for i := range s {
+		if count == maxRunes {
+			return s[:i]
+		}
+		count++
+	}
+	return s
+}

--- a/internal/policy/utf8_safe_test.go
+++ b/internal/policy/utf8_safe_test.go
@@ -1,0 +1,120 @@
+package policy
+
+import (
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/envector/rune-go/internal/domain"
+)
+
+func TestTruncRunes(t *testing.T) {
+	cases := []struct {
+		name    string
+		s       string
+		n       int
+		want    string
+		wantLen int // expected rune count
+	}{
+		{"empty input", "", 5, "", 0},
+		{"zero cap", "hello", 0, "", 0},
+		{"negative cap", "hello", -1, "", 0},
+		{"ASCII under cap", "hi", 5, "hi", 2},
+		{"ASCII at cap", "hello", 5, "hello", 5},
+		{"ASCII over cap", "hello world", 5, "hello", 5},
+		// 1 Korean char = 3 UTF-8 bytes
+		{"Korean under cap", "안녕", 5, "안녕", 2},
+		{"Korean exactly at cap", "안녕하세요", 5, "안녕하세요", 5},
+		{"Korean over cap", "안녕하세요세계", 5, "안녕하세요", 5},
+		// Mixed
+		{"mixed under cap", "안녕 hi", 10, "안녕 hi", 5},
+		{"mixed cut at korean boundary", "ab안녕cd", 3, "ab안", 3},
+		{"mixed cut at ascii boundary", "안녕ab", 3, "안녕a", 3},
+		// 1 emoji = 4 UTF-8 bytes (1 rune)
+		{"emoji over cap", "🚀🎉🌟", 2, "🚀🎉", 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := truncRunes(c.s, c.n)
+			if got != c.want {
+				t.Errorf("truncRunes(%q, %d) = %q, want %q", c.s, c.n, got, c.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("truncRunes(%q, %d) returned invalid UTF-8", c.s, c.n)
+			}
+			if utf8.RuneCountInString(got) != c.wantLen {
+				t.Errorf("truncRunes(%q, %d) rune count = %d, want %d",
+					c.s, c.n, utf8.RuneCountInString(got), c.wantLen)
+			}
+		})
+	}
+}
+
+// TestRedactSensitive_PreservesUTF8 — regression for the proto3 marshal
+// failure observed 2026-05-16. Korean text passing through
+// RedactSensitive must remain valid UTF-8 even when truncation triggers.
+func TestRedactSensitive_PreservesUTF8(t *testing.T) {
+	// Mostly-Korean text padded past MaxInputChars (12000 chars).
+	// Pre-fix the byte-level cut would land mid-codepoint.
+	korean := "안녕하세요 세계 다양한 문자열이 들어있는 입력 텍스트 입니다 "
+	long := strings.Repeat(korean, 500) // ~14000 runes, ~42000 bytes
+	out, _ := RedactSensitive(long)
+	if !utf8.ValidString(out) {
+		t.Fatalf("RedactSensitive output is invalid UTF-8 (len=%d bytes)", len(out))
+	}
+	if got := utf8.RuneCountInString(out); got > MaxInputChars {
+		t.Errorf("rune count %d exceeds cap %d", got, MaxInputChars)
+	}
+}
+
+// TestBuildPhases_KoreanTextProducesValidUTF8 — full pipeline check.
+// Korean capture text goes through extractTitle / extractEvidence /
+// truncStr; the resulting record's Payload.Text must be valid UTF-8 so
+// that downstream embedder.EmbedBatch marshaling succeeds.
+func TestBuildPhases_KoreanTextProducesValidUTF8(t *testing.T) {
+	// Real-world reproducer from session 1778902721 #17.
+	text := "/rune:configure 실패 원인을 surface 하는 4-layer 변경:  " +
+		"문제: /rune:configure 실패 시 (CA 인증서 불일치, 잘못된 토큰, " +
+		"endpoint 도달 불가 등) rune-mcp 가 state: \"waiting_for_vault\" 만 " +
+		"반환하고 실패 이유를 안 알려줌."
+
+	extractedRaw := map[string]any{
+		"domain": "rune-architecture",
+		"topic":  "boot-error-classification",
+		"kind":   "design-decision",
+		"tags":   []any{"boot", "korean", "test"},
+	}
+	detection, extraction, err := domain.ParseExtractionFromAgent(extractedRaw)
+	if err != nil {
+		t.Fatalf("ParseExtractionFromAgent: %v", err)
+	}
+
+	rawEvent := &domain.RawEvent{
+		Text:    text,
+		Source:  "claude-code:/rune:capture",
+		Channel: "rune-debug",
+		User:    "redcourage",
+	}
+
+	records, err := BuildPhases(rawEvent, detection, extraction, time.Now())
+	if err != nil {
+		t.Fatalf("BuildPhases: %v", err)
+	}
+	if len(records) == 0 {
+		t.Fatal("BuildPhases returned 0 records")
+	}
+	for i, r := range records {
+		if !utf8.ValidString(r.Title) {
+			t.Errorf("record[%d].Title is invalid UTF-8: %q", i, r.Title)
+		}
+		if !utf8.ValidString(r.Payload.Text) {
+			t.Errorf("record[%d].Payload.Text is invalid UTF-8 (%d bytes)", i, len(r.Payload.Text))
+		}
+		for j, ev := range r.Evidence {
+			if !utf8.ValidString(ev.Quote) {
+				t.Errorf("record[%d].Evidence[%d].Quote is invalid UTF-8", i, j)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 문제

  `/rune:capture` 가 한국어 (또는 multi-byte UTF-8) 텍스트로 호출되면 `runed` 의 `EmbedBatch` 에서 marshal 실패:

  ```
  embed batch: rpc error: code = Internal desc = grpc: error while marshaling:
    string field contains invalid UTF-8
```
  세션 1778902721 의 #17, #19 에서 재현 (3-byte 한국어 + ASCII 혼합 입력).

  ## Root cause

  Python 원본은 `s[:N]` 으로 **codepoint 단위** 자르기 — 결과 항상 valid UTF-8. Go port 는 같은 `s[:N]` 형태 유지했지만 Go
   의 문자열은 **byte slice**, `s[:N]` 은 byte N 에서 자름. byte N 이 multi-byte codepoint 중간이면 (CJK 3 bytes, emoji 4
  bytes) **orphan continuation byte** 가 남아 proto3 string field validation 에서 실패.

  ## 영향 받은 5개 site

  - `pii.go`: `MaxInputChars 12000` cleanText cap
  - `record_builder.go extractTitle`: `domain.MaxTitleLen 60` 자
  - `record_builder.go extractEvidence`: quote cap 200 / 150 자
  - `record_builder.go phase.PhaseDecision`: 500 자
  - `record_builder.go truncStr` (Decision.What 500 자 cap 에서 호출)

  ## Fix

  `internal/policy/utf8_safe.go` 에 `TruncRunes(s, maxRunes)` 추가:
  - single-pass codepoint walk (zero allocation on truncate path)
  - Python semantic 복원 — `s[:N]` 이 byte 가 아닌 **codepoint** 단위
  - 모든 byte-slicing 사이트 교체

  **Safe-by-design 으로 유지된 사이트**: `record_builder.go:302` 의 `text[:idx]` (idx = `strings.Index(text, ".")`). `.`
  는 ASCII single-byte (0x2E) 라 continuation byte 가 될 수 없음, 항상 rune boundary 에서 cut.

  ## 호환성

  - ASCII 입력 동작 변화 없음 (rune 수 == byte 수, fast path 로 즉시 return)
  - Storage / schema 변화 없음 (필드 의미 그대로, 단위만 byte → rune)
  - 기존 한국어 records 영향 없음 (이미 저장된 record 는 그대로)
  - Python parity 회복 — 코멘트들이 이미 "Python s[:60]" 로 약속한 동작