### PR TITLE
fix(mcp): support partial readiness and align embedder Info cache with real state

### DIFF
--- a/internal/adapters/embedder/cache.go
+++ b/internal/adapters/embedder/cache.go
@@ -71,3 +71,12 @@ func (ic *infoCache) Snapshot() InfoSnapshot {
 	defer ic.mu.Unlock()
 	return ic.snap
 }
+
+func (ic *infoCache) invalidate() {
+	ic.mu.Lock()
+	defer ic.mu.Unlock()
+	ic.loaded = false
+	ic.snap = InfoSnapshot{}
+	ic.lastErr = nil
+	ic.lastAttempt = time.Time{}
+}

--- a/internal/adapters/embedder/client.go
+++ b/internal/adapters/embedder/client.go
@@ -15,6 +15,7 @@ package embedder
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	runedv1 "github.com/CryptoLabInc/runed/gen/runed/v1"
@@ -56,10 +57,12 @@ type Client interface {
 }
 
 type client struct {
-	sockPath string
-	conn     *grpc.ClientConn
-	pb       runedv1.RunedServiceClient
-	info     *infoCache
+	sockPath   string
+	conn       *grpc.ClientConn
+	pb         runedv1.RunedServiceClient
+	info       *infoCache
+	lastUptime atomic.Int64 // the most recent Health uptimes seconds.
+	// (new < previous) indicates the daemon restarted
 }
 
 type Opts struct {
@@ -176,9 +179,17 @@ func (c *client) Health(ctx context.Context) (HealthSnapshot, error) {
 	if err != nil {
 		return HealthSnapshot{}, MapGRPCError(err)
 	}
+
+	// Detect daemon restart and invalidate if restarted
+	newUptime := resp.GetUptimeSeconds()
+	if prev := c.lastUptime.Load(); prev > 0 && newUptime < prev {
+		c.info.invalidate()
+	}
+	c.lastUptime.Store(newUptime)
+
 	return HealthSnapshot{
 		Status:        statusName(resp.GetStatus()),
-		UptimeSeconds: resp.GetUptimeSeconds(),
+		UptimeSeconds: newUptime,
 		TotalRequests: resp.GetTotalRequests(),
 	}, nil
 }

--- a/internal/adapters/embedder/client_test.go
+++ b/internal/adapters/embedder/client_test.go
@@ -29,7 +29,7 @@ type fakeRuned struct {
 	infoFn       func(*runedv1.InfoRequest) (*runedv1.InfoResponse, error)
 	healthFn     func(*runedv1.HealthRequest) (*runedv1.HealthResponse, error)
 
-	infoCalls       int32 // atomic — Info should be invoked exactly once across the lifetime of an infoCache
+	infoCalls       int32 // atomic — counts Info RPC attempts (success cached, error retried after cooldown)
 	embedCalls      int32 // atomic — used by retry test to count attempts
 	embedBatchCalls int32 // atomic — used by batch-split test
 }
@@ -245,11 +245,14 @@ func TestInfo_CachesAcrossCalls(t *testing.T) {
 		}
 	}
 	if got := atomic.LoadInt32(&fake.infoCalls); got != 1 {
-		t.Errorf("Info RPC calls: got %d, want 1 (sync.Once cache)", got)
+		t.Errorf("Info RPC calls: got %d, want 1", got)
 	}
 }
 
-func TestInfo_CachesError(t *testing.T) {
+func TestInfo_ErrorReturnsLastErrorWithinCooldown(t *testing.T) {
+	restore := embedder.SetInfoRetryCooldown(1 * time.Second)
+	defer restore()
+
 	fake, c := startFakeRuned(t)
 	fake.infoFn = func(*runedv1.InfoRequest) (*runedv1.InfoResponse, error) {
 		return nil, status.Error(codes.Unavailable, "down")
@@ -260,11 +263,53 @@ func TestInfo_CachesError(t *testing.T) {
 	}
 	_, err2 := c.Info(context.Background())
 	if err2 == nil {
-		t.Fatal("second Info: expected cached error")
+		t.Fatal("second Info: expected error")
 	}
-	// Both calls return the same cached error; only one RPC fires.
 	if got := atomic.LoadInt32(&fake.infoCalls); got != 1 {
-		t.Errorf("Info RPC calls: got %d, want 1 (error caches too)", got)
+		t.Errorf("Info RPC calls: got %d, want 1 (second call within cooldown)", got)
+	}
+}
+
+func TestInfo_RetriesErrorAfterCooldown(t *testing.T) {
+	restore := embedder.SetInfoRetryCooldown(5 * time.Millisecond)
+	defer restore()
+
+	fake, c := startFakeRuned(t)
+	var attempts int32
+	fake.infoFn = func(*runedv1.InfoRequest) (*runedv1.InfoResponse, error) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 2 {
+			return nil, status.Error(codes.Unavailable, "down")
+		}
+		return &runedv1.InfoResponse{
+			DaemonVersion: "0.1.0-test",
+			ModelIdentity: "qwen3-test",
+			VectorDim:     1024,
+			MaxTextLength: 8192,
+			MaxBatchSize:  4,
+		}, nil
+	}
+
+	if _, err := c.Info(context.Background()); err == nil {
+		t.Fatal("first Info: expected error")
+	}
+
+	time.Sleep(20 * time.Millisecond) // wait cooldown
+
+	snap, err := c.Info(context.Background())
+	if err != nil {
+		t.Fatalf("second Info after cooldown: %v", err)
+	}
+	if snap.ModelIdentity != "qwen3-test" {
+		t.Errorf("snap: got %+v", snap)
+	}
+
+	if _, err := c.Info(context.Background()); err != nil {
+		t.Fatalf("third Info: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&fake.infoCalls); got != 2 {
+		t.Errorf("Info RPC calls: got %d, want 2 (1 failed + 1 succeeded)", got)
 	}
 }
 

--- a/internal/adapters/embedder/client_test.go
+++ b/internal/adapters/embedder/client_test.go
@@ -313,6 +313,52 @@ func TestInfo_RetriesErrorAfterCooldown(t *testing.T) {
 	}
 }
 
+func TestHealth_UptimeRegressionInvalidatesInfoCache(t *testing.T) {
+	fake, c := startFakeRuned(t)
+
+	// Daemon A serves: model "alpha", uptime 100
+	var uptime int64 = 100
+	var modelID = "alpha"
+	fake.infoFn = func(*runedv1.InfoRequest) (*runedv1.InfoResponse, error) {
+		return &runedv1.InfoResponse{ModelIdentity: modelID, VectorDim: 1024, MaxBatchSize: 4}, nil
+	}
+	fake.healthFn = func(*runedv1.HealthRequest) (*runedv1.HealthResponse, error) {
+		return &runedv1.HealthResponse{
+			Status:        runedv1.HealthResponse_STATUS_OK,
+			UptimeSeconds: atomic.LoadInt64(&uptime),
+		}, nil
+	}
+
+	// Prime cache + uptime tracker against daemon A
+	if snap, err := c.Info(context.Background()); err != nil || snap.ModelIdentity != "alpha" {
+		t.Fatalf("priming Info: snap=%+v err=%v", snap, err)
+	}
+	if _, err := c.Health(context.Background()); err != nil {
+		t.Fatalf("priming Health: %v", err)
+	}
+
+	// Daemon B comes up: uptime resets to 5, model changes to "beta"
+	atomic.StoreInt64(&uptime, 5)
+	modelID = "beta"
+
+	// Health observes the uptime regression: invalidates cache
+	if _, err := c.Health(context.Background()); err != nil {
+		t.Fatalf("post-restart Health: %v", err)
+	}
+
+	// Info re-fetches and reflects daemon B
+	snap, err := c.Info(context.Background())
+	if err != nil {
+		t.Fatalf("post-restart Info: %v", err)
+	}
+	if snap.ModelIdentity != "beta" {
+		t.Errorf("ModelIdentity: got %q, want beta (cache should have been invalidated)", snap.ModelIdentity)
+	}
+	if got := atomic.LoadInt32(&fake.infoCalls); got != 2 {
+		t.Errorf("Info RPC calls: got %d, want 2 (initial + post-invalidation)", got)
+	}
+}
+
 func TestHealth_StatusEnumMapping(t *testing.T) {
 	cases := []struct {
 		grpcStatus runedv1.HealthResponse_Status

--- a/internal/adapters/embedder/export_test.go
+++ b/internal/adapters/embedder/export_test.go
@@ -1,0 +1,10 @@
+package embedder
+
+import "time"
+
+// Overrides infoCache retry cooldown for tests and returns restore function
+func SetInfoRetryCooldown(d time.Duration) (restore func()) {
+	prev := infoRetryCooldown
+	infoRetryCooldown = d
+	return func() { infoRetryCooldown = prev }
+}

--- a/internal/adapters/embedder/info_cache.go
+++ b/internal/adapters/embedder/info_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"time"
 
 	runedv1 "github.com/CryptoLabInc/runed/gen/runed/v1"
 )
@@ -13,44 +14,60 @@ import (
 // Spec: docs/v04/spec/components/embedder.md §Info 캐시.
 //
 // Behavior:
-//   - sync.Once ensures first Get() triggers exactly one Info RPC
-//   - subsequent Get() calls return cached snapshot (or cached error)
-//   - no TTL — embedder config changes require daemon restart
-//
-// Logs a slog.Info breadcrumb on successful load (model_identity tracking
-// for post-MVP re-embedding migration — D30). MVP scope is logging only;
-// automatic model-change detection is deferred.
+//   - Success: snapshot cached for the lifetime of the cache
+//   - Error  : NOT cached. The next Get() re-attempts the RPC. Within the cooldown
+//     window the most recent error is returned without an RPC
+
 type infoCache struct {
-	once sync.Once
-	snap InfoSnapshot
-	err  error
-	svc  runedv1.RunedServiceClient
+	mu          sync.Mutex
+	loaded      bool // sticky once true
+	snap        InfoSnapshot
+	lastErr     error
+	lastAttempt time.Time // zero means "no attempt yet"
+	svc         runedv1.RunedServiceClient
 }
 
+var infoRetryCooldown = 3 * time.Second
+
 func (ic *infoCache) Get(ctx context.Context) (InfoSnapshot, error) {
-	ic.once.Do(func() {
-		resp, err := ic.svc.Info(ctx, &runedv1.InfoRequest{})
-		if err != nil {
-			ic.err = MapGRPCError(err)
-			return
-		}
-		ic.snap = InfoSnapshot{
-			DaemonVersion: resp.GetDaemonVersion(),
-			ModelIdentity: resp.GetModelIdentity(),
-			VectorDim:     int(resp.GetVectorDim()),
-			MaxTextLength: int(resp.GetMaxTextLength()),
-			MaxBatchSize:  int(resp.GetMaxBatchSize()),
-		}
-		slog.Info("embedder info loaded",
-			"daemon_version", ic.snap.DaemonVersion,
-			"model_identity", ic.snap.ModelIdentity,
-			"vector_dim", ic.snap.VectorDim,
-			"max_batch_size", ic.snap.MaxBatchSize,
-		)
-	})
-	return ic.snap, ic.err
+	ic.mu.Lock()
+	defer ic.mu.Unlock()
+
+	if ic.loaded {
+		return ic.snap, nil
+	}
+	if !ic.lastAttempt.IsZero() && time.Since(ic.lastAttempt) < infoRetryCooldown {
+		return InfoSnapshot{}, ic.lastErr
+	}
+	ic.lastAttempt = time.Now()
+
+	resp, err := ic.svc.Info(ctx, &runedv1.InfoRequest{})
+	if err != nil {
+		ic.lastErr = err
+		return InfoSnapshot{}, err
+	}
+	ic.snap = InfoSnapshot{
+		DaemonVersion: resp.GetDaemonVersion(),
+		ModelIdentity: resp.GetModelIdentity(),
+		VectorDim:     int(resp.GetVectorDim()),
+		MaxTextLength: int(resp.GetMaxTextLength()),
+		MaxBatchSize:  int(resp.GetMaxBatchSize()),
+	}
+	ic.loaded = true
+	ic.lastErr = nil
+	slog.Info("embedder info loaded",
+		"daemon_version", ic.snap.DaemonVersion,
+		"model_identity", ic.snap.ModelIdentity,
+		"vector_dim", ic.snap.VectorDim,
+		"max_batch_size", ic.snap.MaxBatchSize,
+	)
+	return ic.snap, nil
 }
 
 // Snapshot returns the cached value without triggering load.
-// Returns zero InfoSnapshot if Get() has never been called.
-func (ic *infoCache) Snapshot() InfoSnapshot { return ic.snap }
+// Returns zero InfoSnapshot if Get() has not yet succeeded.
+func (ic *infoCache) Snapshot() InfoSnapshot {
+	ic.mu.Lock()
+	defer ic.mu.Unlock()
+	return ic.snap
+}

--- a/internal/lifecycle/boot.go
+++ b/internal/lifecycle/boot.go
@@ -185,8 +185,6 @@ var BootBackoffs = []time.Duration{
 // available end-to-end, the boot loop should source dim from there instead.
 const DefaultKeyDim = 1024
 
-const embedderBootHealthTimeout = 2 * time.Second
-
 // bootResult is the outcome of one bootOnce attempt.
 type bootResult int
 
@@ -267,9 +265,9 @@ func RunBootLoop(ctx context.Context, m *Manager, deps BootAdapterInjector) {
 //   - bootDormant on terminal config-side failures (caller should not retry)
 //   - bootRetry   on transient failures (caller backs off and retries)
 //
-// On any failure path, state + lastError are updated. On post-Vault-dial
-// failures the partially-constructed adapter conns are closed before return
-// to avoid gRPC connection leak.
+// On any failure path, state + lastError are updated.
+//
+// Adapter injection is per-component, not all-or-nothing
 func bootOnce(ctx context.Context, m *Manager, deps BootAdapterInjector) bootResult {
 	cfg, err := config.Load()
 	if err != nil {
@@ -374,6 +372,16 @@ func bootOnce(ctx context.Context, m *Manager, deps BootAdapterInjector) bootRes
 		return bootRetry
 	}
 
+	keyDir, err := keymanager.KeyDir(bundle.KeyID)
+	if err != nil {
+		m.lastError.Store(fmt.Sprintf("resolve key dir: %v", err))
+		slog.Error("boot: failed to resolve key dir", "err", err)
+		return bootRetry
+	}
+
+	deps.InjectVault(vaultClient)
+	deps.ApplyVaultBundle(bundle)
+
 	embedderClient, err := embedder.New(embedder.ResolveSocketPath(""), embedder.Opts{
 		UnaryInterceptors: []grpc.UnaryClientInterceptor{
 			recovery.UnaryRecovery("embedder", m),
@@ -382,30 +390,9 @@ func bootOnce(ctx context.Context, m *Manager, deps BootAdapterInjector) bootRes
 	if err != nil {
 		m.lastError.Store(fmt.Sprintf("embedder dial: %v", err))
 		slog.Error("boot: failed to connect to embedder", "err", err)
-		_ = vaultClient.Close()
 		return bootRetry
 	}
-
-	// Verify daemon is reachable
-	healthCtx, healthCancel := context.WithTimeout(ctx, embedderBootHealthTimeout)
-	_, herr := embedderClient.Health(healthCtx)
-	healthCancel()
-	if herr != nil {
-		m.lastError.Store(fmt.Sprintf("embedder health: %v", herr))
-		slog.Warn("boot: embedder health probe failed", "err", herr)
-		_ = vaultClient.Close()
-		_ = embedderClient.Close()
-		return bootRetry
-	}
-
-	keyDir, err := keymanager.KeyDir(bundle.KeyID)
-	if err != nil {
-		m.lastError.Store(fmt.Sprintf("resolve key dir: %v", err))
-		slog.Error("boot: failed to resolve key dir", "err", err)
-		_ = vaultClient.Close()
-		_ = embedderClient.Close()
-		return bootRetry
-	}
+	deps.InjectEmbedder(embedderClient)
 
 	envectorClient, err := envector.NewClient(envector.ClientConfig{
 		Endpoint:  bundle.EnvectorEndpoint,
@@ -421,24 +408,16 @@ func bootOnce(ctx context.Context, m *Manager, deps BootAdapterInjector) bootRes
 	if err != nil {
 		m.lastError.Store(fmt.Sprintf("envector new client: %v", err))
 		slog.Error("boot: failed to connect to envector", "err", err)
-		_ = vaultClient.Close()
-		_ = embedderClient.Close()
 		return bootRetry
 	}
 
 	if err := envectorClient.OpenIndex(ctx); err != nil {
 		m.lastError.Store(fmt.Sprintf("envector open index: %v", err))
 		slog.Error("boot: envector index activation failed", "err", err)
-		_ = vaultClient.Close()
-		_ = embedderClient.Close()
 		_ = envectorClient.Close()
 		return bootRetry
 	}
-
-	deps.InjectVault(vaultClient)
-	deps.InjectEmbedder(embedderClient)
 	deps.InjectEnvector(envectorClient)
-	deps.ApplyVaultBundle(bundle)
 
 	return bootActive
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -49,7 +49,8 @@ type Deps struct {
 	Lifecycle *service.LifecycleService
 }
 
-const staleClientCloseTime = 5 * time.Second
+// TODO: revert this to 5s once closeAfterInterval is replaced with refcount/sync.WaitGroup
+const staleClientCloseTime = 30 * time.Second
 
 func (d *Deps) InjectVault(client vault.Client) {
 	prev := d.Vault


### PR DESCRIPTION
## Summary

- What changed:
  - Boot injects each adapter as it becomes ready
  - Embedder `Info` cache stores only success
- Why:
  - `/rune:diagnostics` cannot check partial readiness with all-or-nothing approach
  - `Info` cache is never updated with `sync.Once`
- Scope:

## Validation

- [x] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [ ] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [ ] No agent-specific script duplicates bootstrap/setup logic
- [ ] Agent-specific scripts remain thin adapters (registration/wiring only)
- [ ] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [ ] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [ ] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any): `staleClientCloseTime` is changed to 30s to avoid race, but it should be reverted once `closeAfterInterval` is implemented with refcount/WaitGroup
