### PR TITLE
feat: prepare scripts for release

### DIFF
--- a/.github/workflows/release-rune-cli.yml
+++ b/.github/workflows/release-rune-cli.yml
@@ -1,0 +1,86 @@
+name: Release rune CLI
+
+on:
+  push:
+    tags:
+      - 'v*' # Trigger on version tags
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to release (e.g. v0.4.0)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Skip publishing GitHub Release'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: [self-hosted, linux]
+    steps:
+      # Setup
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building release for $VERSION"
+
+      # Build and test
+      - name: Cross-build CLI binaries
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: scripts/release-rune-cli.sh "${VERSION}"
+
+      - name: List artifacts
+        run: ls -lh dist/
+
+      - name: Smoke test with linux-amd64
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          BIN=./dist/rune-linux-amd64
+          chmod +x "$BIN"
+          OUT="$("$BIN" version)"
+          echo "$OUT"
+          case "$OUT" in
+            *"$VERSION"*) echo "smoke test passed" ;;
+            *) echo "smoke test FAILED - expected version $VERSION in output" >&2; exit 1 ;;
+          esac
+
+      # Release
+      - name: Publish GitHub Release
+        if: github.event_name != 'workflow_dispatch' || !inputs.dry_run
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          name: rune CLI ${{ steps.version.outputs.version }}
+          files: |
+            dist/rune-linux-amd64
+            dist/rune-linux-arm64
+            dist/rune-darwin-amd64
+            dist/rune-darwin-arm64
+            dist/checksums.txt
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/.github/workflows/release-rune-cli.yml
+++ b/.github/workflows/release-rune-cli.yml
@@ -1,32 +1,49 @@
 name: Release rune CLI
 
+# Workflow creates a prerelease when any `v*` tag pushed and
+# maintainer later change to release via Github
+
 on:
   push:
     tags:
-      - 'v*' # Trigger on version tags
+      - 'v*' # trigger on version tags
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag to release (e.g. v0.4.0)'
+        description: 'Existing git tag to build from (e.g. v0.4.0)'
         required: true
         type: string
       dry_run:
-        description: 'Skip publishing GitHub Release'
+        description: 'Build and smoke-test but skip publishing prerelease'
         required: false
         type: boolean
         default: false
 
 permissions:
-  contents: write
+  contents: write # softprops/action-gh-release
 
 jobs:
   release:
     runs-on: [self-hosted, linux]
     steps:
       # Setup
+      - name: Resolve version
+        id: version
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="$DISPATCH_VERSION"
+          else
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building prerelease for $VERSION"
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ steps.version.outputs.version }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -35,17 +52,6 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-
-      - name: Resolve version
-        id: version
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.version }}"
-          else
-            VERSION="${GITHUB_REF#refs/tags/}"
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Building release for $VERSION"
 
       # Build and test
       - name: Cross-build CLI binaries
@@ -69,13 +75,14 @@ jobs:
             *) echo "smoke test FAILED - expected version $VERSION in output" >&2; exit 1 ;;
           esac
 
-      # Release
-      - name: Publish GitHub Release
+      # Publish as prerelease
+      - name: Publish prerelease
         if: github.event_name != 'workflow_dispatch' || !inputs.dry_run
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: rune CLI ${{ steps.version.outputs.version }}
+          prerelease: true
           files: |
             dist/rune-linux-amd64
             dist/rune-linux-arm64

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,11 @@ __pycache__/
 # Internal Planning
 docs/planning/
 
-# Go build artifacts
-bin/
+# Go build artifacts - execept bin/rune wrapper
+bin/*
+!bin/rune
 *.test
 coverage.out
+
+# Cross-build artifacts
+dist/

--- a/bin/rune
+++ b/bin/rune
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Platform-detecting wrapper that fetches and runs the rune CLI binary
+# from GitHub Releases
+# We don't use bash installer to prevent agents from decomposing script
+# into ad-hoc steps rather than just running bash script
+
+# Usage: invoked transparently by agent or user as `rune <subcommand>`.
+set -euo pipefail
+
+RUNE_VERSION="${RUNE_VERSION:-v0.4.0}"
+
+CACHE_ROOT="$HOME/.cache/rune"
+CACHE_DIR="$CACHE_ROOT/$RUNE_VERSION"
+
+# TODO: Windows
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)   ASSET="rune-linux-amd64"  ;;
+  Linux-aarch64)  ASSET="rune-linux-arm64"  ;;
+  Darwin-x86_64)  ASSET="rune-darwin-amd64" ;;
+  Darwin-arm64)   ASSET="rune-darwin-arm64" ;;
+  *)
+    echo "rune: unsupported platform $(uname -s)-$(uname -m)" >&2
+    echo "       Supported: Linux x86_64/aarch64, macOS x86_64/arm64" >&2
+    exit 1
+    ;;
+esac
+
+BIN="$CACHE_DIR/$ASSET"
+
+if [ ! -x "$BIN" ]; then
+  mkdir -p "$CACHE_DIR"
+  RELEASE_BASE="https://github.com/CryptoLabInc/rune/releases/download/$RUNE_VERSION"
+  echo "rune: fetching $ASSET ($RUNE_VERSION)..." >&2
+
+  # Download atomically by rename to prevent partially downloaded binary
+  curl --fail --silent --show-error --location \
+    "$RELEASE_BASE/$ASSET" -o "$BIN.tmp"
+  curl --fail --silent --show-error --location \
+    "$RELEASE_BASE/checksums.txt" -o "$CACHE_DIR/checksums.txt.tmp"
+  mv "$CACHE_DIR/checksums.txt.tmp" "$CACHE_DIR/checksums.txt"
+
+  # Verify
+  EXPECTED="$(grep " $ASSET\$" "$CACHE_DIR/checksums.txt" | cut -d' ' -f1)"
+  if [ -z "$EXPECTED" ]; then
+    rm -f "$BIN.tmp"
+    echo "rune: $ASSET not listed in checksums.txt for $RUNE_VERSION" >&2
+    exit 1
+  fi
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL="$(sha256sum "$BIN.tmp" | cut -d' ' -f1)"
+  else
+    ACTUAL="$(shasum -a 256 "$BIN.tmp" | cut -d' ' -f1)"
+  fi
+
+  if [ "$ACTUAL" != "$EXPECTED" ]; then
+    rm -f "$BIN.tmp"
+    echo "rune: checksum mismatch for $ASSET" >&2
+    echo "       expected: $EXPECTED" >&2
+    echo "       actual:   $ACTUAL" >&2
+    exit 1
+  fi
+
+  chmod +x "$BIN.tmp"
+  mv "$BIN.tmp" "$BIN"
+fi
+
+exec "$BIN" "$@"

--- a/scripts/release-rune-cli.sh
+++ b/scripts/release-rune-cli.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Cross-build the rune CLI
+#
+# Output layout: dist/rune-<os>-<arch>{,.exe} + dist/checksums.txt
+#
+# Usage:
+#   scripts/release-rune-cli.sh [version]
+
+set -euo pipefail
+
+VERSION="${1:-v0.4.0-dev}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="$ROOT/dist"
+
+TARGETS=(
+  "linux  amd64  rune-linux-amd64"
+  "linux  arm64  rune-linux-arm64"
+  "darwin amd64  rune-darwin-amd64"
+  "darwin arm64  rune-darwin-arm64"
+)
+
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+# Strip debug and symbol tables, set runeVersion into cmd/rune/main.go
+LDFLAGS="-s -w -X main.runeVersion=$VERSION"
+
+for line in "${TARGETS[@]}"; do
+  read -r GOOS GOARCH ASSET <<<"$line"
+  echo "building $ASSET ($GOOS/$GOARCH)..."
+  GOOS="$GOOS" GOARCH="$GOARCH" CGO_ENABLED=0 \
+    go build -trimpath -ldflags "$LDFLAGS" \
+    -o "$OUT/$ASSET" "$ROOT/cmd/rune"
+done
+
+echo "computing checksums..."
+(cd "$OUT" && sha256sum rune-* > checksums.txt)
+
+echo
+echo "release artifacts ready in $OUT/ for $VERSION:"
+ls -lh "$OUT"


### PR DESCRIPTION
## Summary

- What changed: build script, initializing wrapper script, and release CI
- Why: Prepare release
- Scope:

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [ ] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [ ] No agent-specific script duplicates bootstrap/setup logic
- [ ] Agent-specific scripts remain thin adapters (registration/wiring only)
- [ ] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [ ] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [ ] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
