### PR TITLE
feat(command): update Claude command to use updated `rune-mcp`

### DIFF
--- a/commands/claude/activate.md
+++ b/commands/claude/activate.md
@@ -1,86 +1,134 @@
 ---
 description: Activate Rune (resume from dormant) and verify pipelines come up healthy
-allowed-tools: Read, Edit, mcp__envector__reload_pipelines, mcp__envector__diagnostics, mcp__envector__vault_status
+allowed-tools: mcp__envector__activate, mcp__envector__diagnostics, mcp__envector__vault_status
 ---
 
 # /rune:activate — Activate Plugin
 
 Resume Rune from a dormant state and verify the boot loop reaches Active.
 
-In v0.4 the MCP server is a single Go binary auto-spawned by Claude Code
-from the plugin manifest. The boot loop runs as soon as `state == "active"`
-in `~/.rune/config.json`, so `/rune:activate`'s job is to flip state to
-active, ask the server to re-run the boot loop, and confirm health.
+The MCP server is a Go binary auto-spawned by Claude Code from the plugin
+manifest. `mcp__envector__activate` runs the prereq checks server-side
+(config presence + runed socket) and only triggers the boot loop if both
+prereqs pass - so this skill is now a single tool call plus result
+rendering.
 
 ## Steps
 
-1. Read `~/.rune/config.json`.
-   - Not found: respond "Not configured. Run `/rune:configure` first." and stop.
+### 1. Call `mcp__envector__activate`
 
-2. Verify required fields:
-   - `vault.endpoint` and `vault.token` must be present.
-   - Missing: report which fields are missing and suggest `/rune:configure`.
-   - enVector credentials are delivered via the Vault bundle at runtime —
-     they are not stored locally.
+That's it - no Read, no Edit, no manual state inspection. The MCP tool
+performs:
 
-3. If `state` is already `"active"`, skip to Step 5 (just verify health).
+- `config.Load()`: if missing or vault block empty, returns
+  `status: "configure_required"` without touching the boot loop
+- `os.Stat(~/.runed/embedding.sock)`: if absent, returns
+  `status: "install_pending"`
+- `Health` probe to runed: if it reports `STATUS_LOADING` (runed is
+  self-bootstrapping - fetching llama-server / downloading the model),
+  returns `status: "waiting_for_bootstrap"` with progress detail on
+  `.bootstrap` and skips the boot loop
+- Otherwise calls `reload_pipelines` and mirrors its result on `.reload`
 
-4. If `state` is `"dormant"`, update the config:
-   - Set `state` to `"active"`.
-   - Remove any `dormant_reason` and `dormant_since` fields.
-   - Update `metadata.lastUpdated` to the current ISO timestamp.
+The response shape:
 
-5. Call `mcp__envector__reload_pipelines`. This re-spawns the boot loop:
-   - Dial Vault → `GetAgentManifest` → persist `EncKey` to disk
-   - Dial runed → connect to enVector → open the team index
-   - Transition state to Active
+```jsonc
+{
+  "ok": true,
+  "status": "configure_required" | "install_pending" |
+            "waiting_for_bootstrap" |
+            "active" | "waiting_for_vault" | "dormant",
+  "hint": "<actionable string when status is not active>",
+  "bootstrap": {                              // only when status == "waiting_for_bootstrap"
+    "phase": "FETCHING_LLAMA_SERVER" | "FETCHING_MODEL" | "STARTING_LLAMA_SERVER",
+    "bytes_done":  <int64>,
+    "bytes_total": <int64>,                   // 0 when total not yet known
+    "message":     "<free-text detail>"
+  },
+  "reload": { ...ReloadPipelinesResult... }   // only when status reached the boot loop
+}
+```
 
-6. Call `mcp__envector__diagnostics` (fall back to `vault_status` if
-   diagnostics is unavailable) and render a per-subsystem report:
+### 2. Branch on `status`
 
-   ```
-   Infrastructure Validation
-   =========================
-   - Vault           : reachable (<endpoint>)
-   - Encryption Key  : loaded (key_id: <id>)
-   - Embedder        : ready
-   - enVector Cloud  : reachable (<latency>ms)
-   - Pipeline State  : Active
-   ```
-   Use a check mark for healthy items, "x" for failures with the specific
-   message on the same line.
+**`configure_required`** - Vault credentials missing.
+- Render: `"Rune is not yet configured. Run /rune:configure to set Vault credentials."`
+- Use the `hint` verbatim - it already names the exact next step.
+- Stop. Do NOT call `mcp__envector__diagnostics`; the agent already has the answer.
 
-7. If the boot loop succeeded (`vault.last_boot_error` absent and all
-   subsystems healthy):
-   - Respond: "Rune activated. Organizational memory is now online."
+**`install_pending`** — runed daemon not installed or not running.
+- Render: `"runed daemon not reachable. Run `rune install` (and ensure the daemon is running), then re-run /rune:activate."`
+- The `hint` field carries the exact socket path that was probed.
+- Stop. Don't call diagnostics.
 
-8. **If boot failed (`vault.last_boot_error` present)** — fast-fail. Note this
-   is keyed off `last_boot_error`, not `state`: a transient failure (e.g.
-   unreachable Vault) leaves the persisted `state` at `"active"` while the boot
-   loop retries, so `state` alone would miss it.
-   - Read `diagnostics.vault.last_boot_error`. It contains the boot loop's
-     classified root cause + a user-actionable hint.
-   - Render the recovery in **one block** — relay the `hint` verbatim and stop:
-     ```
-     Activation failed — <kind>
-     <hint>
+**`waiting_for_bootstrap`** - runed is up but still self-bootstrapping.
+This is expected on the very first activate after a fresh install: runed
+downloads llama-server (~25 MB) and the embedding model (~340 MB) before
+it can serve embeddings.
+- Render a single line summarizing `.bootstrap`. Pick the phrasing from `.bootstrap.phase`:
+  - `FETCHING_LLAMA_SERVER`: "runed is downloading llama-server"
+  - `FETCHING_MODEL`: "runed is downloading the embedding model"
+  - `STARTING_LLAMA_SERVER`: "runed is starting llama-server"
+- If `.bootstrap.bytes_total > 0`, append the progress in MB:
+  `"<phrase> (<done_mb> MB / <total_mb> MB)"`. Otherwise just the phrase
+- Append `.bootstrap.message` verbatim on a second line when non-empty
+- Tell the user: **no further action is needed.** The MCP server has
+  already started a background watcher that polls runed's health and
+  will complete activation.
+  Suggest:
+  - To check progress (optional): invoke `/rune:diagnostics`
+    and check `embedding.phase` / `embedding.bytes_done` /
+    `embedding.bytes_total`. The bootstrap fields are populated there
+    while runed is `LOADING`; once they go to zero and `embedding.status`
+    is `OK`, activation has auto-completed.
+  - To start using Rune as soon as it's ready: just invoke
+    `/rune:recall` or `/rune:capture` - they will succeed once the
+    watcher has reached Active
+- Stop. DO NOT poll automatically; DO NOT re-run `/rune:activate`.
 
-     Details: <detail>   (only when kind == "unknown" or hint is generic)
-     Attempts: <attempts> (only when > 1)
-     ```
-   - The `hint` is authoritative — it already names the specific fix. Relay it
-     verbatim, then suggest the matching re-run: `/rune:configure` when
-     credentials must change (auth / token / endpoint / TLS), otherwise
-     `/rune:activate` once the user applies the hint (`embedder_unreachable`
-     needs the `runed` daemon started first). The full per-`kind` table is in
-     `commands/claude/configure.md` §5 for the rare case the hint needs
-     supplementation.
-   - DO NOT retry `reload_pipelines` automatically. DO NOT probe with shell
-     tools. The classifier has already inspected the underlying error.
-   - If `last_boot_error` is unexpectedly missing (older rune-mcp binary), fall
-     back to the diagnostics `vault.error` / `embedding.health_error` /
-     `envector.error` fields and surface those.
+**`active`** — happy path. Pipelines initialized, ready to capture/recall.
+- Optionally call `mcp__envector__diagnostics` ONCE to render the
+  per-subsystem summary below. Skip if you only need to confirm activation;
+  `response.reload.state == "active"` is authoritative.
 
-**Note**: This is a session-local resume — the MCP server stays the same
-process. There is no Claude Code restart required (Task #28 wired the
-reload to re-spawn the boot loop on dormant terminals).
+**`waiting_for_vault`** or **`dormant`** - boot loop ran but didn't reach Active.
+- Fast-fail. Look at `response.reload.last_boot_error` — the boot loop has
+  already classified the root cause.
+- Render the recovery as **one block**: the `hint` from
+  `last_boot_error.hint` verbatim, then a single re-run suggestion
+  (`/rune:configure` for credential issues, `/rune:activate` after fixing
+  substrate). Do NOT retry, do NOT shell-probe with openssl/nc/etc.
+- Per-`kind` reference table lives in `commands/claude/configure.md` §5
+  for the rare case the hint needs supplementation.
+
+### 3. Render success snapshot (active path only)
+
+When `status == "active"`, call `mcp__envector__diagnostics` once and
+render the per-subsystem report (use ✓ for healthy, ✗ for failures with
+the specific error on the same line):
+
+```
+Infrastructure Validation
+=========================
+  Vault           : ✓ reachable (<endpoint>)
+  Encryption Key  : ✓ loaded (key_id: <id>)
+  Agent DEK       : ✓ loaded
+  Scribe          : ✓ initialized
+  Retriever       : ✓ initialized
+  Embedder        : ✓ <model> (dim=<vector_dim>)
+  enVector Cloud  : ✓ reachable (<latency>ms)
+  Pipeline State  : Active
+```
+
+Then: `"Rune activated. Organizational memory is now online."`
+
+---
+
+**Notes:**
+- This is a session-local resume - the MCP server stays the same process.
+  No Claude Code restart required (the reload handler re-spawns the boot
+  loop on dormant to active transitions).
+- For an older rune-mcp binary without the `activate` tool, fall back to
+  the legacy flow: Read config, call `reload_pipelines` directly, and branch
+  on `diagnostics.vault.last_boot_error`. The SDK will surface a
+  `method-not-found` error to signal the missing tool.

--- a/commands/claude/configure.md
+++ b/commands/claude/configure.md
@@ -1,32 +1,33 @@
 ---
-description: Configure Rune — collect Vault credentials and write ~/.rune/config.json (Go v0.4)
-allowed-tools: Bash(mkdir:*), Bash(chmod:*), Bash(cp:*), Bash(test:*), Read, Write, AskUserQuestion, Edit, mcp__envector__reload_pipelines, mcp__envector__diagnostics
+description: Configure Rune — collect Vault credentials and write ~/.rune/config.json
+allowed-tools: Bash(cp:*), Read, AskUserQuestion, mcp__envector__configure, mcp__envector__activate, mcp__envector__diagnostics
 ---
 
 # /rune:configure — Setup & Configuration
 
 Single entry after `claude plugin install rune`. Collects Vault credentials,
-writes `~/.rune/config.json`, and triggers `reload_pipelines` to bring Rune
-online.
+calls `mcp__envector__configure` (atomic 0600 write + soft Vault probe), and
+hands off to `mcp__envector__activate` to bring pipelines online.
 
-In v0.4 the MCP server is a single Go binary
-(`${CLAUDE_PLUGIN_ROOT}/bin/rune-mcp`) that Claude Code auto-spawns from the
-plugin manifest. There is no Python venv, no install script, and no separate
-`claude mcp add` step.
+The MCP server is a Go binary fetched by `rune install` (or auto-spawned
+by Claude Code from the plugin manifest, depending on the deployment).
+There is no Python venv, no install script, and no separate `claude mcp add`
+step.
 
 ## Quick Update Mode
 
 If $ARGUMENTS contains any of: `--vault-token`, `--vault-endpoint`:
 
-1. Read existing `~/.rune/config.json`.
-   - If not found: respond "Not configured yet. Run `/rune:configure` without arguments first." and stop.
-2. Update only the specified field(s):
-   - `--vault-token <value>` → `vault.token`
-   - `--vault-endpoint <value>` → `vault.endpoint` (auto-prepend `tcp://` if no scheme)
-3. Write back to `~/.rune/config.json` with `chmod 600`.
-4. Update `metadata.lastUpdated` to current ISO timestamp.
-5. Call `reload_pipelines` to apply.
-6. Show: "Updated [field]. Use `/rune:status` to verify."
+1. `Read ~/.rune/config.json`.
+   - Not found: respond `"Not configured yet. Run /rune:configure without arguments first."` and stop.
+2. Merge the partial update into the existing values:
+   - `--vault-token <value>`: use as the new `token`, keep existing `endpoint`/`ca_cert`/`tls_disable`.
+   - `--vault-endpoint <value>`: auto-prepend `tcp://` if no scheme, keep existing `token`/`ca_cert`/`tls_disable`.
+3. Call `mcp__envector__configure` with the merged values. Server-side
+   handles atomic write + 0600 perms + `metadata.lastUpdated` refresh +
+   the soft Vault probe.
+4. Call `mcp__envector__activate` to apply.
+5. Render: `"Updated [field]. Use /rune:status to verify."`
 
 Skip all steps below.
 
@@ -34,126 +35,119 @@ Skip all steps below.
 
 ## Full Setup Steps
 
-**Turn budget**: 4 main turns total. Aggressively batch into **single
-AskUserQuestion calls** and **parallel tool_use blocks** to keep wall-clock
-+ token cost low. Concrete plan below.
+**Turn budget**: ~3-4 turns total. Bundle questions into a single
+`AskUserQuestion` call and pair the configure + activate calls when safe
+to do so.
 
 ### 1. Probe existing state (one turn)
 
-In a single turn, run `Read` on `~/.rune/config.json` (if it exists).
-This serves two purposes at once:
+`Read ~/.rune/config.json`:
 
-- Detect whether the user is re-configuring (existing values) or fresh-setup.
-- Satisfy the `Write` tool's "must Read before Write" requirement so Step 3
-  does NOT need a separate defensive Read turn later. If the file does
-  not exist, the Read fails harmlessly — skip and proceed.
-
-If the existing config has all credentials and the user does not say they
-want to reconfigure: skip to Step 4 (reload only). Otherwise continue.
+- File missing: fresh setup. Continue to Step 2.
+- File present: mask the token (first 8 chars + "***") and show the
+  current `endpoint`, `ca_cert`, `tls_disable`, `state`, masked token.
+  Then issue a single `AskUserQuestion("Reconfigure these values?")`:
+    - User declines: call `mcp__envector__activate` and stop (just bring
+      the existing config online).
+    - User confirms: continue to Step 2 with the existing values as
+      defaults the user can override.
 
 ### 2. Collect credentials — **one AskUserQuestion call, three questions** (one turn)
 
-Issue a SINGLE `AskUserQuestion` with three bundled questions, not three
-separate calls. The tool accepts 1–4 questions per call; using one call
-saves 2 turns (each separate call costs ~5s wall + an extra round-trip of
-~50k cache_read tokens).
+Issue a SINGLE `AskUserQuestion` with three bundled questions. The tool
+accepts 1–4 questions per call; bundling saves 2 turns + ~50k cache_read
+tokens per separated call.
 
-Questions to bundle:
+Questions:
 
 1. **Vault Endpoint** (required, format: `tcp://<host>:50051`).
-   Auto-prepend `tcp://` when the user value omits the scheme.
+   Auto-prepend `tcp://` if the user omits the scheme.
 2. **Vault Token** (required, format: `evt_xxx...`).
 3. **TLS Mode**:
    - `self-signed` — team uses a self-signed CA (Recommended).
-   - `public_ca` — Let's Encrypt etc., system CA pool handles verification.
+   - `public_ca` — Let's Encrypt etc.; system CA pool handles verification.
    - `no_tls` — local dev only; Vault must also be running with
      `server.grpc.tls.disable: true`. Warn if selected.
 
-**If `self-signed` was chosen**: issue a single follow-up `AskUserQuestion`
-asking only "Path to CA certificate PEM file:" (one question, one turn).
-Otherwise skip the follow-up entirely.
+**If `self-signed` was chosen**: follow-up `AskUserQuestion` with the
+single question "Path to CA certificate PEM file:" (one question, one turn).
+Otherwise skip the follow-up.
 
-Resulting config mapping:
+Resulting argument mapping for the configure call:
 
-| TLS mode    | ca_cert                    | tls_disable |
-|-------------|----------------------------|-------------|
-| self-signed | `<HOME>/.rune/certs/ca.pem`| false       |
-| public_ca   | ""                         | false       |
-| no_tls      | ""                         | true        |
+| TLS mode    | ca_cert_path                | tls_disable |
+|-------------|-----------------------------|-------------|
+| self-signed | `<HOME>/.rune/certs/ca.pem` | false       |
+| public_ca   | ""                          | false       |
+| no_tls      | ""                          | true        |
 
-### 3. Provision and write — **parallel tool_use in one turn**
+### 3. (self-signed only) Copy the CA cert into place
 
-Emit BOTH tool calls in the same turn (parallel `tool_use` blocks). Anthropic
-runs them in parallel and returns both `tool_result`s in the next user
-message:
+When `tls_mode == self-signed`, run a single `Bash` command to copy the
+user's CA into `~/.rune/certs/ca.pem`. The MCP tool doesn't move files
+itself — the agent provides the final path to `ca_cert_path`:
 
-- **`Bash`** — only when `tls_mode == self-signed`. Sets up the cert dir
-  and copies the user-supplied CA in one command (so a partial failure
-  leaves nothing half-written):
-  ```bash
-  mkdir -p ~/.rune/certs && chmod 700 ~/.rune && \
-    cp <user_ca_path> ~/.rune/certs/ca.pem && \
-    chmod 600 ~/.rune/certs/ca.pem
-  ```
-  If `cp` fails (file not found / permission denied): surface the error
-  and ask the user for a readable path (one more `AskUserQuestion`).
-- **`Write`** — `~/.rune/config.json` with the JSON below.
-  ```json
-  {
-    "vault": {
-      "endpoint": "<vault_endpoint>",
-      "token": "<vault_token>",
-      "ca_cert": "<ca_cert_path or empty>",
-      "tls_disable": <true|false>
-    },
-    "state": "active",
-    "metadata": {
-      "configVersion": "2.0",
-      "lastUpdated": "<ISO timestamp>"
-    }
-  }
-  ```
+```bash
+mkdir -p ~/.rune/certs && cp <user_ca_path> ~/.rune/certs/ca.pem && chmod 600 ~/.rune/certs/ca.pem
+```
 
-Note: enVector credentials (endpoint, API key, EvalKey, SecKey) are not
-stored locally — Vault delivers them via the agent manifest on first
-connection.
+If `cp` fails (file not found / permission denied), surface the error
+and ask the user for a readable path (one more `AskUserQuestion`). Common
+recovery: `sudo cp /opt/runevault/certs/ca.pem ~/.rune/ca.pem && sudo chown $USER ~/.rune/ca.pem`.
 
-### 4. Lock down + trigger boot — **parallel tool_use in one turn**
+### 4. Call `mcp__envector__configure`
 
-Again emit both tool calls in the same turn:
+```jsonc
+{
+  "endpoint": "<vault_endpoint>",
+  "token": "<vault_token>",
+  "ca_cert_path": "<HOME>/.rune/certs/ca.pem"  // or "" if not self-signed
+  "tls_disable": false                          // true only if no_tls
+}
+```
 
-- **`Bash`** — `chmod 600 ~/.rune/config.json` (config file may contain the
-  vault token; ensure owner-only readable).
-- **`mcp__envector__reload_pipelines`** — kicks the boot loop. Returns
-  after up to 5s while the loop attempts to reach Active, so the response
-  may already contain `last_boot_error` on failure (see Step 5).
+Server-side does:
+- Atomic write to `~/.rune/config.json` with 0600 perms
+- Sets `state: "active"`, clears any prior `dormant_reason` / `dormant_since`
+- Refreshes `metadata.lastUpdated`
+- Runs a best-effort 5s Vault dial + HealthCheck
 
-The two are independent: the chmod doesn't affect the boot loop's read,
-and the boot loop will have already loaded the config before chmod
-finishes most of the time. Running them in parallel is safe and saves
-one round-trip.
+Response:
 
-### 5. Read the response — **fast-fail on `last_boot_error`**
+```jsonc
+{
+  "ok": true,
+  "path": "/home/.../.rune/config.json",
+  "state": "active",
+  "configured_at": "<ISO timestamp>",
+  "next_step": "Run /rune:activate to apply the new credentials." | "Vault unreachable from this host - verify endpoint/token, then run /rune:activate to retry with backoff.",
+  "vault_reachable": true | false,
+  "probe_error": "<dial / health error if vault_reachable=false>"
+}
+```
 
-Inspect the `reload_pipelines` response from Step 4 first:
+### 5. Decide what to do next based on the probe
 
-- **`state == "active"` AND no `last_boot_error`** → success path. Optionally
-  call `mcp__envector__diagnostics` ONCE for the rich per-subsystem snapshot
-  used in Step 6's completion summary. (You can skip diagnostics if you only
-  need to confirm activation — `reload_pipelines.state` is authoritative.)
+**`vault_reachable: true`** - credentials look good. Call
+`mcp__envector__activate` to bring pipelines up. Proceed to Step 6.
 
-- **`last_boot_error` is populated** → fast-fail. Use it directly; do NOT
-  call diagnostics, do NOT retry. The boot loop has already classified the
-  root cause.
+**`vault_reachable: false`** - early warning. The file IS written and
+`state` IS active, but the probe couldn't dial Vault. Two ways to proceed:
 
-- **`state != "active"` AND `last_boot_error` is absent** → boot loop is
-  still in flight (rare; only when the 5s wait window expired without an
-  error). Call `mcp__envector__diagnostics` ONCE — its
-  `vault.last_boot_error` will likely be populated by now (the boot loop
-  keeps running in the background).
+  - **Common case (transient / first-time):** still call
+    `mcp__envector__activate`. The boot loop has retries with backoff,
+    and the classified `last_boot_error` it produces will be richer than
+    the probe error.
+  - **Obvious typo case** (`probe_error` contains "no such host" /
+    "connection refused" with a hostname the user can read and recognize
+    as wrong): show the `probe_error` verbatim + suggest re-running
+    `/rune:configure` with the corrected value, instead of activating.
 
-**Do NOT** retry `reload_pipelines`, poll `diagnostics`, or probe with shell
-commands. The `last_boot_error` field is the boot loop's structured verdict.
+If you do call `activate`, branch on its response - same logic as
+`/rune:activate`'s skill. The full per-`kind` table is in §6 below for
+the rare case `last_boot_error.hint` needs supplementation.
+
+### 6. `last_boot_error.kind` table (reference)
 
 Render based on `last_boot_error.kind`:
 
@@ -166,39 +160,26 @@ Render based on `last_boot_error.kind`:
 | `vault_permission`    | Token lacks role. Show `hint`. Re-issue with correct role. |
 | `vault_network`       | Endpoint unreachable. Show `hint`. User should verify TCP connectivity (e.g., `nc -vz host port`). |
 | `vault_dns`           | Hostname doesn't resolve. Show `hint`. Likely a typo in endpoint. |
-| `vault_timeout`       | Vault didn't respond in time. Could be network or server overload — show `hint`. |
+| `vault_timeout`       | Vault didn't respond in time — show `hint`. |
 | `vault_manifest`      | Vault connected but no manifest for this token. Token probably not provisioned for an agent. |
 | `vault_rate_limit`    | Token throttled. Show `hint`. Wait and retry. |
 | `vault_bad_endpoint`  | Endpoint syntax invalid. Show `hint`. Re-run `/rune:configure` with corrected format. |
-| `embedder_unreachable`| `runed` daemon not running. Show `hint`. User should run `runed start`. |
+| `embedder_unreachable`| `runed` daemon not running. Show `hint`. User should run `rune install` (and start the daemon). |
 | `envector_init` / `envector_index` | Envector side. Show `hint` + `detail`. |
 | `key_save` / `local_io` | Local FS issue. Show `hint` + suggest checking `~/.rune/` permissions. |
 | anything else (incl. `unknown`) | Show `kind`, `hint`, and `detail`. Suggest user share the detail with their Vault admin. |
 
 The agent-facing output for a fast-fail case should be **one block**: the
-matched explanation above + the hint string verbatim + a single next-action
-suggestion. Do NOT loop on `reload_pipelines`. Do NOT call shell tools to
-verify (`openssl`, `nc`, etc.) unless the user explicitly asks — the
+matched explanation above + the `hint` string verbatim + a single
+next-action suggestion. Do NOT loop on `activate`. Do NOT call shell tools
+to verify (`openssl`, `nc`, etc.) unless the user explicitly asks — the
 classifier has already done that work server-side.
 
-**If no `last_boot_error` (success path):** proceed to Step 6.
+### 7. Completion Summary (success path)
 
-The diagnostics result has these sections (only render the ones with
-meaningful content) — used for the success summary in Step 6:
-
-- `state` + `dormant_reason` + `dormant_since`
-- `vault.healthy` + `vault.endpoint` (+ `vault.error` if unhealthy)
-- `vault.last_boot_error` (whenever present — see fast-fail above)
-- `keys.enc_key_loaded` + `keys.key_id` + `keys.agent_dek_loaded`
-- `pipelines.scribe_initialized` + `pipelines.retriever_initialized`
-- `embedding.model` + `embedding.mode` + `embedding.vector_dim` (+ `embedding.daemon_version` if present)
-- `envector.reachable` + `envector.latency_ms` (+ `envector.error` / `envector.hint` if not)
-
-### 6. Completion Summary
-
-Render the snapshot in this layout (use ✓ for healthy, ✗ for failures
-with the specific error on the same line; omit a row when the field
-isn't populated):
+When `activate.status == "active"`, optionally call
+`mcp__envector__diagnostics` once for the rich per-subsystem snapshot and
+render:
 
 ```
 Rune Configuration Complete


### PR DESCRIPTION
## Summary

- What changed: Claude commands description
- Why: Fit to updated `rune-mcp`
- Scope:

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [ ] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [ ] No agent-specific script duplicates bootstrap/setup logic
- [ ] Agent-specific scripts remain thin adapters (registration/wiring only)
- [ ] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [ ] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [ ] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas: This PR **MUST BE** merged after [rune-mcp](https://github.com/CryptoLabInc/rune-mcp/pull/1) is released
- Backward compatibility impact:
- Follow-up work (if any):
