### PR TITLE
feat(cli): add subcommands and minor refactoring

### DIFF
--- a/cmd/rune/launch.go
+++ b/cmd/rune/launch.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func execInstalledBinary(ctx context.Context, binDir, name string, args []string, stderr io.Writer) int {
+	binPath := filepath.Join(binDir, name)
+
+	if _, err := os.Stat(binPath); err != nil {
+		fmt.Fprintf(stderr,
+			"rune: %s not installed at %s.\nRun `rune install` first (then restart your Claude session if you were trying to launch rune-mcp).\n",
+			name, binPath)
+		return 127 // not installed (missing binary)
+	}
+
+	cmd := exec.CommandContext(ctx, binPath, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode()
+		}
+		fmt.Fprintf(stderr, "rune: launching %s failed: %v\n", name, err)
+		return 1
+	}
+
+	return 0
+}

--- a/cmd/rune/launch.go
+++ b/cmd/rune/launch.go
@@ -7,7 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
+	"time"
 )
+
+const gracefulShutdownGrace = 5 * time.Second
 
 func execInstalledBinary(ctx context.Context, binDir, name string, args []string, stderr io.Writer) int {
 	binPath := filepath.Join(binDir, name)
@@ -23,6 +27,12 @@ func execInstalledBinary(ctx context.Context, binDir, name string, args []string
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	// Forward SIGTERM to the child instead of SIGKILL
+	cmd.Cancel = func() error {
+		return cmd.Process.Signal(syscall.SIGTERM)
+	}
+	cmd.WaitDelay = gracefulShutdownGrace
+
 	if err := cmd.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return exitErr.ExitCode()

--- a/cmd/rune/main.go
+++ b/cmd/rune/main.go
@@ -1,15 +1,24 @@
 // CLI installer and diagnostics tool for Rune
 //
+// `rune install` downloads two binaries from GitHub Releases and places
+// them under the home realms they belong to:
+//
+//	~/.rune/bin/rune-mcp (rune plugin realm)
+//	~/.runed/bin/runed   (runed daemon realm)
+//
 // Subcommands:
+//
 //	rune install [--force] [--json] [--manifest-url URL]
-//	    Download the runed bundle (runed daemon + llama-server) from
-//	    GitHub Releases, extract it into ~/.runed/bin/
-//      Runed handles its own model on startup
+//	    Fetch the manifest, and place the rune-mcp and runed binaries
 //
 //	rune verify [--json]
 //	    Read-only health checks
 //
 //	rune version
+//	    Print the rune CLI version and the manifest URL
+//
+//	rune mcp-server [args...]
+//      The plugin manifest's mcpServers entry uses this to spawn mcp server without absolute path in plugin.json
 
 package main
 
@@ -46,6 +55,8 @@ func main() {
 		os.Exit(runVerify(ctx, args, os.Stdout))
 	case "version":
 		os.Exit(runVersion(os.Stdout))
+	case "mcp-server":
+		os.Exit(runMCPServer(ctx, args, os.Stderr))
 	case "-h", "--help", "help":
 		printHelp(os.Stdout)
 		os.Exit(0)
@@ -61,16 +72,18 @@ func printHelp(w io.Writer) {
 
 Usage:
   rune install [--force] [--json] [--manifest-url URL]
-        download the runed bundle from GitHub releases into ~/.runed/bin/
+        download rune-mcp into ~/.rune/bin/ and runed into ~/.runed/bin/
         (next: /rune:configure + /rune:activate to finish setup)
   rune verify [--json]
-        run health checks
+        run read-only health checks
   rune version
         print version and manifest URL
+  rune mcp-server [args...]
+        forward stdio to ~/.rune/bin/rune-mcp (plugin-manifest entry point)
 
 Environment:
-  RUNE_HOME       override ~/.rune/  (rune-mcp's realm)
-  RUNED_HOME      override ~/.runed/ (runed daemon's realm)
+  RUNE_HOME       override ~/.rune/  (rune plugin realm: config + rune-mcp)
+  RUNED_HOME      override ~/.runed/ (runed daemon realm)
   RUNE_MANIFEST   override the build-baked manifest URL (mostly for tests)
 `)
 }

--- a/cmd/rune/main.go
+++ b/cmd/rune/main.go
@@ -18,7 +18,11 @@
 //	    Print the rune CLI version and the manifest URL
 //
 //	rune mcp-server [args...]
-//      The plugin manifest's mcpServers entry uses this to spawn mcp server without absolute path in plugin.json
+//      Forward stdio to ~/.rune/bin/rune-mcp. The plugin manifest's
+//      mcpServers entry uses this to spawn mcp server
+//
+//	rune runed [args...]
+//      Forward stdio + args to ~/.runed/bin/runed
 
 package main
 
@@ -57,6 +61,8 @@ func main() {
 		os.Exit(runVersion(os.Stdout))
 	case "mcp-server":
 		os.Exit(runMCPServer(ctx, args, os.Stderr))
+	case "runed":
+		os.Exit(runRuned(ctx, args, os.Stderr))
 	case "-h", "--help", "help":
 		printHelp(os.Stdout)
 		os.Exit(0)
@@ -80,6 +86,8 @@ Usage:
         print version and manifest URL
   rune mcp-server [args...]
         forward stdio to ~/.rune/bin/rune-mcp (plugin-manifest entry point)
+  rune runed [args...]
+        forward stdio + args to ~/.runed/bin/runed
 
 Environment:
   RUNE_HOME       override ~/.rune/  (rune plugin realm: config + rune-mcp)

--- a/cmd/rune/mcpserver.go
+++ b/cmd/rune/mcpserver.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/CryptoLabInc/rune-cli/internal/bootstrap"
+)
+
+func runMCPServer(ctx context.Context, args []string, stderr io.Writer) int {
+	paths, err := bootstrap.Resolve()
+	if err != nil {
+		fmt.Fprintf(stderr, "rune: cannot resolve home directories: %v\n", err)
+		return 1
+	}
+
+	return execInstalledBinary(ctx, paths.RuneBin, "rune-mcp", args, stderr)
+}

--- a/cmd/rune/runed.go
+++ b/cmd/rune/runed.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/CryptoLabInc/rune-cli/internal/bootstrap"
+)
+
+func runRuned(ctx context.Context, args []string, stderr io.Writer) int {
+	paths, err := bootstrap.Resolve()
+	if err != nil {
+		fmt.Fprintf(stderr, "rune: cannot resolve home directories: %v\n", err)
+		return 1
+	}
+	return execInstalledBinary(ctx, paths.RunedBin, "runed", args, stderr)
+}

--- a/internal/bootstrap/install.go
+++ b/internal/bootstrap/install.go
@@ -11,9 +11,9 @@ import (
 
 type InstallOptions struct {
 	ManifestURL string
-	Force bool // `rune install --force` to force re-download
-	Progress ProgressFunc
-	Log func(format string, args ...any)
+	Force       bool // `rune install --force` to force re-download
+	Progress    ProgressFunc
+	Log         func(format string, args ...any)
 }
 
 type Result struct {
@@ -32,9 +32,11 @@ type ArtifactInfo struct {
 
 const (
 	StepManifest = "manifest"
-	StepBundle   = "runed_bundle"
-	StepProbe    = "probe"
+	StepRuned    = "runed"
+	StepRuneMCP  = "rune_mcp"
 )
+
+const binaryMode = 0o755 // executable
 
 func Install(ctx context.Context, opts InstallOptions) (*Result, error) {
 	logf := opts.Log
@@ -42,7 +44,7 @@ func Install(ctx context.Context, opts InstallOptions) (*Result, error) {
 		logf = func(string, ...any) {}
 	}
 
-  // Resolve path and ensure directories
+	// Resolve paths and ensure directories
 	paths, err := Resolve()
 	if err != nil {
 		return nil, err
@@ -51,7 +53,7 @@ func Install(ctx context.Context, opts InstallOptions) (*Result, error) {
 		return nil, err
 	}
 
-  // Acquire lock for installation
+	// Acquire lock for installation
 	unlock, err := acquireInstallLock(ctx, paths.InstallLock, InstallLockTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("install: acquire lock: %w", err)
@@ -65,7 +67,7 @@ func Install(ctx context.Context, opts InstallOptions) (*Result, error) {
 	}
 
 	// Fetch manifest
-	logf("[1/2] manifest: fetching from %s", opts.ManifestURL)
+	logf("[1/3] manifest: fetching from %s", opts.ManifestURL)
 	manifest, err := FetchManifest(ctx, opts.ManifestURL)
 	if err != nil {
 		r.Failed[StepManifest] = err.Error()
@@ -73,33 +75,69 @@ func Install(ctx context.Context, opts InstallOptions) (*Result, error) {
 		return r, err
 	}
 	r.Completed = append(r.Completed, StepManifest)
-	logf("[1/2] manifest: ok (version %d, rune-mcp %s)", manifest.Version, manifest.RuneMCPVersion)
+	logf("[1/3] manifest: ok (rune-mcp %s, runed %s)", manifest.RuneMCPVersion, manifest.RunedVersion)
 
-	bundleSpec, err := manifest.BundleForCurrentPlatform()
+	artifacts, err := manifest.ArtifactsForCurrentPlatform()
 	if err != nil {
-		r.Failed[StepBundle] = err.Error()
+		r.Failed[StepRuned] = err.Error() // not exact, but just for notifying failure
 		r.Status = "partial"
 		return r, err
 	}
 
-  // Runed binaries -> `~/.runed/bin/`
-	if err := installBundle(ctx, paths, bundleSpec, opts, r, logf); err != nil {
-		r.Failed[StepBundle] = err.Error()
-		r.Status = "partial"
-		return r, err
+	// Per-artifact installation (Result.Status = "partial" on any failure)
+	type install struct {
+		step string
+		spec ArtifactSpec
+		dest string
+	}
+	installs := []install{
+		{StepRuned, artifacts.Runed, paths.RunedBinary},
+		{StepRuneMCP, artifacts.RuneMCP, paths.RuneMCPBinary},
 	}
 
-  // Probe
+	for i, in := range installs {
+		stepNum := i + 2 // starting from [2/3]
+		if !opts.Force {
+			if fileExists(in.dest) {
+				logf("[%d/3] %s: skipped (already at %s)", stepNum, in.step, in.dest)
+				r.Completed = append(r.Completed, in.step)
+				r.Skipped = append(r.Skipped, in.step)
+
+				continue
+			}
+		}
+
+		logf("[%d/3] %s (%d bytes): downloading...", stepNum, in.step, in.spec.Size)
+		if err := DownloadAndVerify(ctx, in.spec, in.dest, opts.Progress); err != nil {
+			r.Failed[in.step] = err.Error()
+			r.Status = "partial"
+			return r, err
+		}
+		if err := os.Chmod(in.dest, binaryMode); err != nil {
+			r.Failed[in.step] = err.Error()
+			r.Status = "partial"
+			return r, fmt.Errorf("install: chmod %s: %w", in.dest, err)
+		}
+
+		r.Completed = append(r.Completed, in.step)
+		if info, statErr := os.Stat(in.dest); statErr == nil {
+			r.Installed[filepath.Base(in.dest)] = ArtifactInfo{Path: in.dest, Size: info.Size()}
+		}
+		logf("[%d/3] %s: installed at %s", stepNum, in.step, in.dest)
+	}
+
+	// Probe socket
 	if probeSocket(paths.RunedSocket) {
 		logf("probe: daemon already running at %s", paths.RunedSocket)
 	} else {
-    logf("probe: daemon not running (expected: first /rune:activate will spawn it)")
+		logf("probe: daemon not running (expected: first /rune:activate will spawn it)")
 	}
 
 	r.OK = true
 	if onlySkipped(r) {
 		r.Status = "no_op"
 	}
+
 	return r, nil
 }
 
@@ -120,42 +158,6 @@ func onlySkipped(r *Result) bool {
 		}
 	}
 	return len(r.Skipped) > 0
-}
-
-func installBundle(ctx context.Context, paths *Paths, spec ArtifactSpec, opts InstallOptions, r *Result, logf func(string, ...any)) error {
-	if !opts.Force {
-		if fileExists(paths.RunedBinary) && fileExists(paths.LlamaServer) {
-			logf("[2/2] runed bundle: skipped (binaries already present at %s)", paths.RunedBin)
-			r.Completed = append(r.Completed, StepBundle)
-			r.Skipped = append(r.Skipped, StepBundle)
-			return nil
-		}
-	}
-
-	cachePath := filepath.Join(paths.Cache, "runed-bundle.tar.gz")
-	logf("[2/2] runed bundle (%d bytes): downloading...", spec.Size)
-	if err := DownloadAndVerify(ctx, spec, cachePath, opts.Progress); err != nil {
-		return err
-	}
-
-	logf("[2/2] runed bundle: extracting to %s ...", paths.RunedBin)
-	extracted, err := ExtractBundle(cachePath, paths.RunedBin)
-	if err != nil {
-		return err
-	}
-	if err := os.Remove(cachePath); err != nil && !os.IsNotExist(err) {
-		logf("warning: failed to remove cache %s: %v", cachePath, err)
-	}
-
-	r.Completed = append(r.Completed, StepBundle)
-	for _, p := range extracted {
-		if info, statErr := os.Stat(p); statErr == nil {
-			r.Installed[filepath.Base(p)] = ArtifactInfo{Path: p, Size: info.Size()}
-		}
-	}
-	logf("[2/2] runed bundle: extracted %d files", len(extracted))
-
-	return nil
 }
 
 func probeSocket(path string) bool {

--- a/internal/bootstrap/install_test.go
+++ b/internal/bootstrap/install_test.go
@@ -12,49 +12,65 @@ import (
 )
 
 type installFixture struct {
-	srv               *httptest.Server
-	bundleBody        []byte
-	bundleSHA         string
-	manifestBundleSHA string
-	bundleHits        int
+	srv      *httptest.Server
+	runed    []byte
+	runeMCP  []byte
+	runedSHA string
+	mcpSHA   string
+
+	// Override SHA in the manifest to simulate a checksum mismatch
+	mismatchStep string // "" | StepRuned | StepRuneMCP
+
+	hits map[string]int
 }
 
 func newFixture(t *testing.T) *installFixture {
 	t.Helper()
-	bundle := makeBundleTarball(t, map[string][]byte{
-		"bin/runed":        []byte("runed-binary-bytes"),
-		"bin/llama-server": []byte("llama-binary-bytes"),
-	})
 	fx := &installFixture{
-		bundleBody: bundle,
-		bundleSHA:  sha256Hex(bundle),
+		runed:   []byte("runed-binary-bytes"),
+		runeMCP: []byte("rune-mcp-binary-bytes"),
+		hits:    map[string]int{},
 	}
+	fx.runedSHA = sha256Hex(fx.runed)
+	fx.mcpSHA = sha256Hex(fx.runeMCP)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/manifest.json", func(w http.ResponseWriter, r *http.Request) {
-		bundleSHA := fx.manifestBundleSHA
-		if bundleSHA == "" {
-			bundleSHA = fx.bundleSHA
+		runedSHA := fx.runedSHA
+		mcpSHA := fx.mcpSHA
+
+		switch fx.mismatchStep {
+		case StepRuned:
+			runedSHA = "00" + runedSHA[2:]
+		case StepRuneMCP:
+			mcpSHA = "00" + mcpSHA[2:]
 		}
+
 		manifest := map[string]any{
 			"version":          1,
-			"rune_mcp_version": "v0.4.0-test",
-			"runed_bundles": map[string]any{
+			"rune_mcp_version": "v0.1.0-test",
+			"runed_version":    "v0.1.0-test",
+			"platforms": map[string]any{
 				PlatformTuple(): map[string]any{
-					"url":    fx.srv.URL + "/bundle.tar.gz",
-					"sha256": bundleSHA,
-					"size":   len(fx.bundleBody),
+					"runed":    map[string]any{"url": fx.srv.URL + "/runed", "sha256": runedSHA, "size": len(fx.runed)},
+					"rune_mcp": map[string]any{"url": fx.srv.URL + "/rune-mcp", "sha256": mcpSHA, "size": len(fx.runeMCP)},
 				},
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(manifest)
 	})
-	mux.HandleFunc("/bundle.tar.gz", func(w http.ResponseWriter, r *http.Request) {
-		fx.bundleHits++
-		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(fx.bundleBody)))
-		_, _ = w.Write(fx.bundleBody)
-	})
+
+	serveBinary := func(name string, body []byte) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			fx.hits[name]++
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+			_, _ = w.Write(body)
+		}
+	}
+
+	mux.HandleFunc("/runed", serveBinary("/runed", fx.runed))
+	mux.HandleFunc("/rune-mcp", serveBinary("/rune-mcp", fx.runeMCP))
 
 	fx.srv = httptest.NewServer(mux)
 	t.Cleanup(fx.srv.Close)
@@ -64,7 +80,7 @@ func newFixture(t *testing.T) *installFixture {
 
 func (fx *installFixture) manifestURL() string { return fx.srv.URL + "/manifest.json" }
 
-func TestInstall_NeverTouchesRune(t *testing.T) {
+func TestInstall_DoesNotWriteRuneConfig(t *testing.T) {
 	rune, _ := setRealms(t)
 	fx := newFixture(t)
 
@@ -72,72 +88,119 @@ func TestInstall_NeverTouchesRune(t *testing.T) {
 		t.Fatalf("Install: %v", err)
 	}
 
-	if _, err := os.Stat(rune); !os.IsNotExist(err) {
-		t.Errorf("~/.rune/ should not have been created by rune install; got err=%v", err)
+	if _, err := os.Stat(filepath.Join(rune, "config.json")); !os.IsNotExist(err) {
+		t.Errorf("~/.rune/config.json should not be written by rune install; got err=%v", err)
 	}
 }
 
-func TestInstall_Idempotent_SkipsExistingBundle(t *testing.T) {
+func TestInstall_HappyPath_PlacesBothBinaries(t *testing.T) {
+	rune, runed := setRealms(t)
+	fx := newFixture(t)
+
+	r, err := Install(context.Background(), InstallOptions{ManifestURL: fx.manifestURL()})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !r.OK {
+		t.Errorf("Result.OK = false, want true (r=%+v)", r)
+	}
+
+	for _, p := range []string{
+		filepath.Join(runed, "bin", "runed"),
+		filepath.Join(rune, "bin", "rune-mcp"),
+	} {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Errorf("missing %s: %v", p, err)
+			continue
+		}
+		// chmod 0755 was applied
+		if info.Mode().Perm()&0o100 == 0 {
+			t.Errorf("%s is not executable: mode=%v", p, info.Mode())
+		}
+	}
+	if fx.hits["/runed"] != 1 || fx.hits["/rune-mcp"] != 1 {
+		t.Errorf("expected one hit per artifact; got %+v", fx.hits)
+	}
+	if _, err := os.Stat(filepath.Join(runed, "bin", "llama-server")); !os.IsNotExist(err) {
+		t.Errorf("llama-server should NOT be installed by rune install; got err=%v", err)
+	}
+}
+
+func TestInstall_Idempotent_SkipsExistingBinaries(t *testing.T) {
 	setRealms(t)
 	fx := newFixture(t)
 
 	if _, err := Install(context.Background(), InstallOptions{ManifestURL: fx.manifestURL()}); err != nil {
 		t.Fatalf("first install: %v", err)
 	}
-	if fx.bundleHits != 1 {
-		t.Fatalf("first install: bundleHits=%d, want 1", fx.bundleHits)
+
+	beforeHits := map[string]int{}
+	for k, v := range fx.hits {
+		beforeHits[k] = v
 	}
 
 	r, err := Install(context.Background(), InstallOptions{ManifestURL: fx.manifestURL()})
 	if err != nil {
 		t.Fatalf("second install: %v", err)
 	}
-	if fx.bundleHits != 1 {
-		t.Errorf("second install re-downloaded bundle: hits=%d", fx.bundleHits)
+
+	// Second install must not re-download any binary
+	for _, name := range []string{"/runed", "/rune-mcp"} {
+		if fx.hits[name] != beforeHits[name] {
+			t.Errorf("second install re-downloaded %s: hits=%d, want %d", name, fx.hits[name], beforeHits[name])
+		}
 	}
+
 	skipMap := map[string]bool{}
 	for _, s := range r.Skipped {
 		skipMap[s] = true
 	}
-	if !skipMap[StepBundle] {
-		t.Errorf("Skipped missing bundle: %v", r.Skipped)
+	for _, step := range []string{StepRuned, StepRuneMCP} {
+		if !skipMap[step] {
+			t.Errorf("Skipped missing %s: %v", step, r.Skipped)
+		}
 	}
 }
 
-func TestInstall_Force_ReDownloadsBundle(t *testing.T) {
+func TestInstall_Force_ReDownloadsAllBinaries(t *testing.T) {
 	setRealms(t)
 	fx := newFixture(t)
 
 	if _, err := Install(context.Background(), InstallOptions{ManifestURL: fx.manifestURL()}); err != nil {
 		t.Fatalf("first install: %v", err)
 	}
+
 	if _, err := Install(context.Background(), InstallOptions{
 		ManifestURL: fx.manifestURL(),
 		Force:       true,
 	}); err != nil {
 		t.Fatalf("force install: %v", err)
 	}
-	if fx.bundleHits != 2 {
-		t.Errorf("force should re-download bundle: hits=%d, want 2", fx.bundleHits)
+
+	for _, name := range []string{"/runed", "/rune-mcp"} {
+		if fx.hits[name] != 2 {
+			t.Errorf("force should re-download %s: hits=%d, want 2", name, fx.hits[name])
+		}
 	}
 }
 
-func TestInstall_BundleChecksumMismatch_PartialFailure(t *testing.T) {
-	_, runed := setRealms(t)
+func TestInstall_ChecksumMismatch_PartialFailure(t *testing.T) {
+	rune, _ := setRealms(t)
 	fx := newFixture(t)
-	fx.manifestBundleSHA = "00" + fx.bundleSHA[2:]
+	fx.mismatchStep = StepRuneMCP
 
 	r, err := Install(context.Background(), InstallOptions{ManifestURL: fx.manifestURL()})
 	if err == nil {
-		t.Fatalf("expected bundle checksum error")
+		t.Fatalf("expected checksum error")
 	}
-	if r.Failed[StepBundle] == "" {
-		t.Errorf("Failed missing bundle: %+v", r.Failed)
+	if r.Failed[StepRuneMCP] == "" {
+		t.Errorf("Failed missing %s: %+v", StepRuneMCP, r.Failed)
 	}
 	if r.Status != "partial" {
 		t.Errorf("Status=%q, want partial", r.Status)
 	}
-	if _, err := os.Stat(filepath.Join(runed, "bin", "runed")); !os.IsNotExist(err) {
-		t.Errorf("binary should not exist after checksum failure (err=%v)", err)
+	if _, err := os.Stat(filepath.Join(rune, "bin", "rune-mcp")); !os.IsNotExist(err) {
+		t.Errorf("rune-mcp should not exist after checksum failure (err=%v)", err)
 	}
 }

--- a/internal/bootstrap/installcheck.go
+++ b/internal/bootstrap/installcheck.go
@@ -14,13 +14,13 @@ import (
 
 type InstallCheck struct {
 	Name    string `json:"name"`
-	Status  string `json:"status"`             // "ok" | "warn" | "fail"
+	Status  string `json:"status"` // "ok" | "warn" | "fail"
 	Detail  string `json:"detail,omitempty"`
 	FixHint string `json:"fix_hint,omitempty"`
 }
 
 type InstallChecks struct {
-	OK     bool             `json:"ok"`
+	OK     bool           `json:"ok"`
 	Checks []InstallCheck `json:"checks"`
 }
 
@@ -34,7 +34,6 @@ const (
 	CheckRuneConfig  = "rune_config"
 	CheckVaultCreds  = "vault_creds"
 	CheckRunedBinary = "runed_binary"
-	CheckLlamaServer = "llama_server"
 	CheckModelFile   = "model_file"
 	CheckSocket      = "daemon_socket"
 	CheckSpawnLock   = "spawn_lock"
@@ -71,8 +70,7 @@ func RunInstallChecks(ctx context.Context) *InstallChecks {
 	cfg, cfgChecks := loadRuneConfigChecks(paths)
 	checks := append([]InstallCheck{}, cfgChecks...)
 	checks = append(checks, vaultCredsCheck(cfg))
-	checks = append(checks, executableCheck(CheckRunedBinary, paths.RunedBinary, "run `rune install` to fetch the runed bundle"))
-	checks = append(checks, executableCheck(CheckLlamaServer, paths.LlamaServer, "run `rune install` to fetch the runed bundle"))
+	checks = append(checks, executableCheck(CheckRunedBinary, paths.RunedBinary, "run `rune install` to fetch runed"))
 	checks = append(checks, modelFileCheck(paths.RunedModels))
 	checks = append(checks, socketCheck(paths.RunedSocket, cfg))
 	checks = append(checks, spawnLockCheck(paths.RunedLock))

--- a/internal/bootstrap/installcheck_test.go
+++ b/internal/bootstrap/installcheck_test.go
@@ -53,7 +53,6 @@ func TestInstallChecks_HealthyInstall(t *testing.T) {
 	rune, runed := setRealms(t)
 	writeConfig(t, rune, "tcp://vault.example:50051", "evt_test")
 	writeFakeBinary(t, filepath.Join(runed, "bin", "runed"))
-	writeFakeBinary(t, filepath.Join(runed, "bin", "llama-server"))
 	// Plausibly-real GGUF: a file with size >= minModelSize.
 	if err := os.MkdirAll(filepath.Join(runed, "models"), 0o700); err != nil {
 		t.Fatal(err)
@@ -148,7 +147,6 @@ func TestInstallChecks_PartialModelFile(t *testing.T) {
 	rune, runed := setRealms(t)
 	writeConfig(t, rune, "tcp://x", "y")
 	writeFakeBinary(t, filepath.Join(runed, "bin", "runed"))
-	writeFakeBinary(t, filepath.Join(runed, "bin", "llama-server"))
 	if err := os.MkdirAll(filepath.Join(runed, "models"), 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +169,6 @@ func TestInstallChecks_NoModelYet_Warns(t *testing.T) {
 	rune, runed := setRealms(t)
 	writeConfig(t, rune, "tcp://x", "y")
 	writeFakeBinary(t, filepath.Join(runed, "bin", "runed"))
-	writeFakeBinary(t, filepath.Join(runed, "bin", "llama-server"))
 	if err := os.MkdirAll(filepath.Join(runed, "models"), 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +189,6 @@ func TestInstallChecks_DaemonNotRunning_Warns(t *testing.T) {
 	rune, runed := setRealms(t)
 	writeConfig(t, rune, "tcp://x", "y")
 	writeFakeBinary(t, filepath.Join(runed, "bin", "runed"))
-	writeFakeBinary(t, filepath.Join(runed, "bin", "llama-server"))
 
 	r := RunInstallChecks(context.Background())
 	sock := findCheck(t, r, CheckSocket)
@@ -205,7 +201,6 @@ func TestInstallChecks_DaemonReachable_OK(t *testing.T) {
 	rune, runed := setRealms(t)
 	writeConfig(t, rune, "tcp://x", "y")
 	writeFakeBinary(t, filepath.Join(runed, "bin", "runed"))
-	writeFakeBinary(t, filepath.Join(runed, "bin", "llama-server"))
 
 	// Stand up a unix-domain listener at the expected socket path.
 	if err := os.MkdirAll(runed, 0o700); err != nil {
@@ -238,7 +233,6 @@ func TestInstallChecks_SpawnLockPresent_Warns(t *testing.T) {
 	rune, runed := setRealms(t)
 	writeConfig(t, rune, "tcp://x", "y")
 	writeFakeBinary(t, filepath.Join(runed, "bin", "runed"))
-	writeFakeBinary(t, filepath.Join(runed, "bin", "llama-server"))
 	if err := os.MkdirAll(runed, 0o700); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/bootstrap/manifest.go
+++ b/internal/bootstrap/manifest.go
@@ -16,28 +16,42 @@ const ManifestVersion = 1
 const defaultManifestFetchTimeout = 30 * time.Second
 
 // Example JSON:
+//
 //	{
 //	  "version": 1,
-//	  "rune_mcp_version": "v0.4.0",
-//	  "runed_bundles": {
-//	    "linux-amd64":  {"url": "...", "sha256": "...", "size": 22846457},
-//	    "darwin-arm64": {"url": "...", "sha256": "...", "size": 21998765}
+//	  "rune_mcp_version": "v0.1.0",
+//	  "runed_version":    "v0.1.0-alpha.1",
+//	  "platforms": {
+//	    "linux-amd64": {
+//	      "runed":    {"url": "...", "sha256": "...", "size": 8123456},
+//	      "rune_mcp": {"url": "...", "sha256": "...", "size": 16234567}
+//	    },
+//	    "darwin-arm64": { ... }
 //	  }
 //	}
+
 type Manifest struct {
-	Version        int                     `json:"version"`
-	RuneMCPVersion string                  `json:"rune_mcp_version"`
-	RunedBundles   map[string]ArtifactSpec `json:"runed_bundles"`
+	Version        int                          `json:"version"`
+	RuneMCPVersion string                       `json:"rune_mcp_version"`
+	RunedVersion   string                       `json:"runed_version"`
+	Platforms      map[string]PlatformArtifacts `json:"platforms"`
+}
+
+type PlatformArtifacts struct {
+	Runed   ArtifactSpec `json:"runed"`    // ~/.runed/bin
+	RuneMCP ArtifactSpec `json:"rune_mcp"` // ~/.rune/bin
 }
 
 type ArtifactSpec struct {
 	URL    string `json:"url"`
 	SHA256 string `json:"sha256"`
-	Size   int64  `json:"size"`
+	Size   int64  `json:"size,omitempty"` // optional; used for progress UX and sanity check
 }
 
-var ErrUnsupportedManifestVersion = errors.New("manifest: unsupported version")
-var ErrNoBundleForPlatform = errors.New("manifest: no bundle for this platform")
+var (
+	ErrUnsupportedManifestVersion = errors.New("manifest: unsupported version")
+	ErrNoArtifactForPlatform      = errors.New("manifest: no artifacts for this platform")
+)
 
 func FetchManifest(ctx context.Context, manifestURL string) (*Manifest, error) {
 	if v := os.Getenv(envManifest); v != "" {
@@ -64,7 +78,7 @@ func FetchManifest(ctx context.Context, manifestURL string) (*Manifest, error) {
 		return nil, fmt.Errorf("manifest: GET %s: HTTP %d", manifestURL, resp.StatusCode)
 	}
 
-	const maxBody = 1 << 20 // multi-MB might be misconfiguration
+	const maxBody = 1 << 20 // multi-MB would be misconfiguration
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
 	if err != nil {
 		return nil, fmt.Errorf("manifest: read body: %w", err)
@@ -82,20 +96,31 @@ func FetchManifest(ctx context.Context, manifestURL string) (*Manifest, error) {
 	if m.Version != ManifestVersion {
 		return nil, fmt.Errorf("%w: got %d, want %d", ErrUnsupportedManifestVersion, m.Version, ManifestVersion)
 	}
-	if len(m.RunedBundles) == 0 {
-		return nil, errors.New("manifest: runed_bundles is empty")
+	if len(m.Platforms) == 0 {
+		return nil, errors.New("manifest: platforms is empty")
 	}
+
 	return &m, nil
 }
 
-func (m *Manifest) BundleForCurrentPlatform() (ArtifactSpec, error) {
+func (m *Manifest) ArtifactsForCurrentPlatform() (PlatformArtifacts, error) {
 	tuple := PlatformTuple()
-	spec, ok := m.RunedBundles[tuple]
+	arts, ok := m.Platforms[tuple]
 	if !ok {
-		return ArtifactSpec{}, fmt.Errorf("%w: %s", ErrNoBundleForPlatform, tuple)
+		return PlatformArtifacts{}, fmt.Errorf("%w: %s", ErrNoArtifactForPlatform, tuple)
 	}
-	if spec.URL == "" || spec.SHA256 == "" {
-		return ArtifactSpec{}, fmt.Errorf("manifest: bundle for %s missing url or sha256", tuple)
+
+	for _, pair := range []struct {
+		name string
+		spec ArtifactSpec
+	}{
+		{"runed", arts.Runed},
+		{"rune_mcp", arts.RuneMCP},
+	} {
+		if pair.spec.URL == "" || pair.spec.SHA256 == "" {
+			return PlatformArtifacts{}, fmt.Errorf("manifest: %s artifact for %s missing url or sha256", pair.name, tuple)
+		}
 	}
-	return spec, nil
+
+	return arts, nil
 }

--- a/internal/bootstrap/manifest_test.go
+++ b/internal/bootstrap/manifest_test.go
@@ -10,18 +10,24 @@ import (
 	"testing"
 )
 
-func TestFetchManifest_HappyPath(t *testing.T) {
-	body := fmt.Sprintf(`{
+func fullManifestJSON(extraFields string) string {
+	return fmt.Sprintf(`{
 		"version": 1,
-		"rune_mcp_version": "v0.4.0",
-		"runed_bundles": {
-			"%[1]s": {"url": "https://example/runed.tar.gz", "sha256": "abc", "size": 22846457}
-		}
-	}`, PlatformTuple())
+		"rune_mcp_version": "v0.1.0",
+		"runed_version": "v0.1.0-alpha.1",
+		"platforms": {
+			"%[1]s": {
+				"runed":    {"url": "https://example/runed-%[1]s",    "sha256": "aaa", "size": 8123456},
+				"rune_mcp": {"url": "https://example/rune-mcp-%[1]s", "sha256": "ccc", "size": 16234567}
+			}
+		}%[2]s
+	}`, PlatformTuple(), extraFields)
+}
 
+func TestFetchManifest_HappyPath(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(body))
+		_, _ = w.Write([]byte(fullManifestJSON("")))
 	}))
 	defer srv.Close()
 
@@ -32,15 +38,21 @@ func TestFetchManifest_HappyPath(t *testing.T) {
 	if m.Version != 1 {
 		t.Errorf("Version = %d, want 1", m.Version)
 	}
-	if m.RuneMCPVersion != "v0.4.0" {
+	if m.RuneMCPVersion != "v0.1.0" {
 		t.Errorf("RuneMCPVersion = %q", m.RuneMCPVersion)
 	}
-	spec, err := m.BundleForCurrentPlatform()
-	if err != nil {
-		t.Fatalf("BundleForCurrentPlatform: %v", err)
+	if m.RunedVersion != "v0.1.0-alpha.1" {
+		t.Errorf("RunedVersion = %q", m.RunedVersion)
 	}
-	if spec.URL != "https://example/runed.tar.gz" || spec.SHA256 != "abc" {
-		t.Errorf("bundle spec mismatch: %+v", spec)
+	arts, err := m.ArtifactsForCurrentPlatform()
+	if err != nil {
+		t.Fatalf("ArtifactsForCurrentPlatform: %v", err)
+	}
+	if arts.Runed.SHA256 != "aaa" || arts.RuneMCP.SHA256 != "ccc" {
+		t.Errorf("artifact SHA256s mismatch: %+v", arts)
+	}
+	if !strings.HasPrefix(arts.RuneMCP.URL, "https://example/rune-mcp-") {
+		t.Errorf("rune_mcp URL: %q", arts.RuneMCP.URL)
 	}
 }
 
@@ -49,7 +61,7 @@ func TestFetchManifest_EnvOverride(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		served = true
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(w, `{"version":1,"rune_mcp_version":"v0.4.0","runed_bundles":{"%s":{"url":"u","sha256":"s","size":1}}}`, PlatformTuple())
+		_, _ = w.Write([]byte(fullManifestJSON("")))
 	}))
 	defer srv.Close()
 
@@ -63,8 +75,9 @@ func TestFetchManifest_EnvOverride(t *testing.T) {
 }
 
 func TestFetchManifest_RejectsUnsupportedVersion(t *testing.T) {
+	body := strings.Replace(fullManifestJSON(""), `"version": 1`, `"version": 99`, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = fmt.Fprintf(w, `{"version":99,"rune_mcp_version":"v9.9.9","runed_bundles":{"%s":{"url":"u","sha256":"s","size":1}}}`, PlatformTuple())
+		_, _ = w.Write([]byte(body))
 	}))
 	defer srv.Close()
 
@@ -74,21 +87,22 @@ func TestFetchManifest_RejectsUnsupportedVersion(t *testing.T) {
 	}
 }
 
-func TestFetchManifest_RejectsEmptyBundles(t *testing.T) {
+func TestFetchManifest_RejectsEmptyPlatforms(t *testing.T) {
+	body := `{"version":1,"rune_mcp_version":"v0.1.0","runed_version":"v0.1.0","platforms":{}}`
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = fmt.Fprint(w, `{"version":1,"rune_mcp_version":"v0.4.0","runed_bundles":{}}`)
+		_, _ = w.Write([]byte(body))
 	}))
 	defer srv.Close()
 
 	_, err := FetchManifest(context.Background(), srv.URL)
-	if err == nil || !strings.Contains(err.Error(), "runed_bundles is empty") {
-		t.Errorf("want empty-bundles error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "platforms is empty") {
+		t.Errorf("want empty-platforms error, got %v", err)
 	}
 }
 
 func TestFetchManifest_RejectsUnknownFields(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = fmt.Fprintf(w, `{"version":1,"rune_mcp_version":"v0.4.0","runed_bundles":{"%s":{"url":"u","sha256":"s","size":1}},"extra":"field"}`, PlatformTuple())
+		_, _ = w.Write([]byte(fullManifestJSON(`, "extra": "field"`)))
 	}))
 	defer srv.Close()
 
@@ -110,13 +124,35 @@ func TestFetchManifest_HTTPError(t *testing.T) {
 	}
 }
 
-func TestBundleForCurrentPlatform_NotFound(t *testing.T) {
+func TestArtifactsForCurrentPlatform_NotFound(t *testing.T) {
 	m := &Manifest{
-		Version:      1,
-		RunedBundles: map[string]ArtifactSpec{"linux-mips": {URL: "u", SHA256: "s"}},
+		Version: 1,
+		Platforms: map[string]PlatformArtifacts{
+			"linux-mips": {
+				Runed:   ArtifactSpec{URL: "u", SHA256: "s"},
+				RuneMCP: ArtifactSpec{URL: "u", SHA256: "s"},
+			},
+		},
 	}
-	_, err := m.BundleForCurrentPlatform()
-	if !errors.Is(err, ErrNoBundleForPlatform) {
-		t.Errorf("want ErrNoBundleForPlatform, got %v", err)
+	_, err := m.ArtifactsForCurrentPlatform()
+	if !errors.Is(err, ErrNoArtifactForPlatform) {
+		t.Errorf("want ErrNoArtifactForPlatform, got %v", err)
+	}
+}
+
+func TestArtifactsForCurrentPlatform_IncompleteArtifact(t *testing.T) {
+	m := &Manifest{
+		Version: 1,
+		Platforms: map[string]PlatformArtifacts{
+			PlatformTuple(): {
+				Runed:   ArtifactSpec{URL: "u", SHA256: "s"},
+				RuneMCP: ArtifactSpec{URL: "u", SHA256: ""}, // missing sha256
+			},
+		},
+	}
+
+	_, err := m.ArtifactsForCurrentPlatform()
+	if err == nil || !strings.Contains(err.Error(), "rune_mcp") {
+		t.Errorf("want missing-artifact error for rune_mcp, got %v", err)
 	}
 }

--- a/internal/bootstrap/paths.go
+++ b/internal/bootstrap/paths.go
@@ -9,35 +9,38 @@ import (
 
 // Overrides default root: `~/.rune/`
 const envRuneHome = "RUNE_HOME"
+
 // Overrides default root: `~/.runed/`
 const envRunedHome = "RUNED_HOME"
 const envManifest = "RUNE_MANIFEST"
 
 // Two separate roots, NO cross-contamination:
 //
-//	~/.rune/
-//	└── config.json       - /rune:configure handle this
-//
-//	~/.runed/             - Runed itself handle this through `rune install`
+//	~/.rune/              - Rune plugin realm (config + rune-mcp binary)
 //	├── bin/
-//	│   ├── runed
-//	│   └── llama-server
+//	│   └── rune-mcp      - placed here by `rune install`
+//	└── config.json       - /rune:configure handles this
+//
+//	~/.runed/             - Runed daemon realm
+//	├── bin/
+//	│   ├── runed         - placed by `rune install`
+//	│   └── llama-server  - placed by runed on first boot (self-bootstrap)
 //	├── models/
-//	│   └── *.gguf
+//	│   └── *.gguf        - placed by runed on first boot
 //	├── embedding.sock
 //	├── spawn.lock
 //	├── install.lock
 //	├── cache/
 //	└── logs/daemon.log
-//
-// XXX: `rm -rf ~/.rune` clears rune-mcp state including Vault credentials;
-// `rm -rf ~/.runed` clears Runed daemon state including model
-type Paths struct {
-  // Rune
-	RuneHome   string // ~/.rune
-	RuneConfig string // ~/.rune/config.json
 
-  // Runed
+type Paths struct {
+	// Rune
+	RuneHome      string // ~/.rune
+	RuneBin       string // ~/.rune/bin
+	RuneMCPBinary string // ~/.rune/bin/rune-mcp
+	RuneConfig    string // ~/.rune/config.json
+
+	// Runed
 	RunedHome   string // ~/.runed
 	RunedBin    string // ~/.runed/bin
 	RunedModels string // ~/.runed/models
@@ -56,7 +59,7 @@ func Resolve() (*Paths, error) {
 		return nil, fmt.Errorf("resolve user home: %w", err)
 	}
 
-  // Rune
+	// Rune
 	runeHome := os.Getenv(envRuneHome)
 	if runeHome == "" {
 		runeHome = filepath.Join(userHome, ".rune")
@@ -67,7 +70,7 @@ func Resolve() (*Paths, error) {
 		return nil, fmt.Errorf("absolute path for rune home %s: %w", runeHome, err)
 	}
 
-  // Runed
+	// Runed
 	runedHome := os.Getenv(envRunedHome)
 	if runedHome == "" {
 		runedHome = filepath.Join(userHome, ".runed")
@@ -82,10 +85,13 @@ func Resolve() (*Paths, error) {
 }
 
 func newPaths(runeHome, runedHome string) *Paths {
+	runeBin := filepath.Join(runeHome, "bin")
 	runedBin := filepath.Join(runedHome, "bin")
 	return &Paths{
-		RuneHome:   runeHome,
-		RuneConfig: filepath.Join(runeHome, "config.json"),
+		RuneHome:      runeHome,
+		RuneBin:       runeBin,
+		RuneMCPBinary: filepath.Join(runeBin, "rune-mcp"),
+		RuneConfig:    filepath.Join(runeHome, "config.json"),
 
 		RunedHome:   runedHome,
 		RunedBin:    runedBin,
@@ -100,9 +106,9 @@ func newPaths(runeHome, runedHome string) *Paths {
 	}
 }
 
-// RuneHome is not created here
 func (p *Paths) EnsureDirs() error {
 	for _, d := range []string{
+		p.RuneBin,
 		p.RunedHome, p.RunedBin, p.RunedModels, p.RunedLogs, p.Cache,
 	} {
 		if err := os.MkdirAll(d, 0o700); err != nil {

--- a/internal/bootstrap/paths_test.go
+++ b/internal/bootstrap/paths_test.go
@@ -79,7 +79,7 @@ func TestResolve_Independent(t *testing.T) {
 	}
 }
 
-func TestEnsureDirs_CreatesRunedOnly(t *testing.T) {
+func TestEnsureDirs_CreatesAllInstallDirs(t *testing.T) {
 	t.Setenv(envRuneHome, filepath.Join(t.TempDir(), "rune"))
 	t.Setenv(envRunedHome, filepath.Join(t.TempDir(), "runed"))
 	p, err := Resolve()
@@ -95,6 +95,7 @@ func TestEnsureDirs_CreatesRunedOnly(t *testing.T) {
 	}
 
 	for _, expected := range []string{
+		p.RuneBin,
 		p.RunedHome, p.RunedBin, p.RunedModels, p.RunedLogs, p.Cache,
 	} {
 		info, err := os.Stat(expected)
@@ -107,8 +108,8 @@ func TestEnsureDirs_CreatesRunedOnly(t *testing.T) {
 		}
 	}
 
-	if _, err := os.Stat(p.RuneHome); !os.IsNotExist(err) {
-		t.Errorf("RuneHome %s should not be created by EnsureDirs (rune install must not touch rune-mcp's realm); got err=%v", p.RuneHome, err)
+	if _, err := os.Stat(p.RuneConfig); !os.IsNotExist(err) {
+		t.Errorf("RuneConfig %s should not be created by EnsureDirs; got err=%v", p.RuneConfig, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- What changed:
  - Add two subcommands `rune-mcp` and `runed` to spawn corresponding installed binary
  - Refactor installation to delegate handling `llama-server` and model to `runed`
- Why:
- Scope:

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [ ] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [ ] No agent-specific script duplicates bootstrap/setup logic
- [ ] Agent-specific scripts remain thin adapters (registration/wiring only)
- [ ] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [ ] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [ ] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas: This requires `runed` modification since we regard `runed` as fully standalone binary after this
- Backward compatibility impact:
- Follow-up work (if any):
