### PR TITLE
feat(cli): add supervisor mode and enhance initial installation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -13,8 +13,8 @@
   ],
   "mcpServers": {
     "envector": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/bin/rune-mcp",
-      "description": "enVector MCP server (Go binary, v0.4 migration)"
+      "command": "${HOME}/.rune/bin/rune-mcp",
+      "description": "enVector MCP server. Populated by '${CLAUDE_PLUGIN_ROOT}/bin/rune install'; before that, this path doesn't exist and the spawn fails - which the skill markdown catches and recovers from"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ $ gemini extensions install https://github.com/CryptoLabInc/rune.git
 > $skill-installer install https://github.com/CryptoLabInc/rune.git
 ```
 
+> **Your next step is always `/rune:configure`.** The plugin install
+> only places a small bootstrap; the actual runtime (rune-mcp + runed
+> daemon) is downloaded the first time you run `/rune:configure`, in a
+> single flow that also collects your Vault credentials. You never need
+> to run a separate install command yourself.
+
 ### Configure
 
 ```
@@ -59,7 +65,7 @@ $ gemini extensions install https://github.com/CryptoLabInc/rune.git
 You'll need from your team admin:
 - **Vault endpoint** + **token**
 
-That's all. enVector Cloud credentials are delivered automatically via the Vault bundle.
+That's all. enVector Cloud credentials are delivered automatically via the Vault bundle. On a fresh machine, `/rune:configure` also handles binary download and daemon setup in the same step.
 
 Don't have these? See [rune-admin](https://github.com/CryptoLabInc/rune-admin) for deployment, or [examples/team-setup-example.md](examples/team-setup-example.md) for a walkthrough.
 

--- a/bin/rune
+++ b/bin/rune
@@ -1,73 +1,90 @@
 #!/usr/bin/env bash
-# Platform-detecting wrapper that fetches and runs the rune CLI binary
-# from GitHub Releases.
-# We don't use a bash installer to prevent agents from decomposing the
-# script into ad-hoc steps rather than just invoking it
+# bin/rune - Rune plugin bootstrap entrypoint at ${CLAUDE_PLUGIN_ROOT}/bin/rune
+#
+# Responsibility: ensure the rune CLI Go binary exists at
+# ~/.rune/bin/rune (the canonical install location)
+#
+# Subcommand surface:
+#   - When ~/.rune/bin/rune already exists: delegates ALL subcommands
+#     unchanged (safety guard)
+#   - When ~/.rune/bin/rune is missing: only `install` is accepted as
+#     the bootstrap entry point
 #
 # Windows support: this wrapper is bash-only. Native Windows shells
 # (PowerShell / cmd) cannot execute this. Windows users must invoke it
-# from WSL or Git Bash, where `uname -s` returns MSYS_NT-* or MINGW64_NT-*;
-#
-# Usage: invoked transparently by agent or user as `rune <subcommand>`.
+# from WSL or Git Bash, where `uname -s` returns MSYS_NT-* or MINGW64_NT-*
 set -euo pipefail
 
 RUNE_VERSION="${RUNE_VERSION:-v0.4.0}"
+RUNE_HOME="${RUNE_HOME:-$HOME/.rune}"
+TARGET="$RUNE_HOME/bin/rune"
 
-CACHE_ROOT="$HOME/.cache/rune"
-CACHE_DIR="$CACHE_ROOT/$RUNE_VERSION"
+# Delegate to ~/.rune/bin/rune
+if [ -x "$TARGET" ]; then
+  exec "$TARGET" "$@"
+fi
 
+# Bootstrap path (~/.rune/bin/rune missing)
+case "${1:-}" in
+  install)
+    ;;
+  *)
+    echo "rune: rune is not fully configured yet." >&2
+    echo "       Running /rune:configure first." >&2
+    exit 127
+    ;;
+esac
+
+# Map (OS, arch) to release asset name
 case "$(uname -s)-$(uname -m)" in
-  Linux-x86_64)               ASSET="rune-linux-amd64"      ;;
-  Linux-aarch64)              ASSET="rune-linux-arm64"      ;;
-  Darwin-x86_64)              ASSET="rune-darwin-amd64"     ;;
-  Darwin-arm64)               ASSET="rune-darwin-arm64"     ;;
-  MINGW64_NT-*-x86_64)        ASSET="rune-windows-amd64.exe" ;;
-  MSYS_NT-*-x86_64)           ASSET="rune-windows-amd64.exe" ;;
+  Linux-x86_64)         ASSET="rune-linux-amd64"        ;;
+  Linux-aarch64)        ASSET="rune-linux-arm64"        ;;
+  Darwin-x86_64)        ASSET="rune-darwin-amd64"       ;;
+  Darwin-arm64)         ASSET="rune-darwin-arm64"       ;;
+  MINGW64_NT-*-x86_64)  ASSET="rune-windows-amd64.exe"  ;;
+  MSYS_NT-*-x86_64)     ASSET="rune-windows-amd64.exe"  ;;
   *)
     echo "rune: unsupported platform $(uname -s)-$(uname -m)" >&2
-    echo "       Supported: Linux x86_64/aarch64, macOS x86_64/arm64, Windows x86_64 via WSL or Git Bash" >&2
+    echo "      Supported: Linux x86_64/aarch64, macOS x86_64/arm64, Windows x86_64 via WSL/Git Bash" >&2
     exit 1
     ;;
 esac
 
-BIN="$CACHE_DIR/$ASSET"
+echo "rune: bootstrapping CLI ($ASSET $RUNE_VERSION) to $TARGET" >&2
 
-if [ ! -x "$BIN" ]; then
-  mkdir -p "$CACHE_DIR"
-  RELEASE_BASE="https://github.com/CryptoLabInc/rune/releases/download/$RUNE_VERSION"
-  echo "rune: fetching $ASSET ($RUNE_VERSION)..." >&2
+RELEASE_BASE="https://github.com/CryptoLabInc/rune/releases/download/$RUNE_VERSION"
+mkdir -p "$(dirname "$TARGET")"
 
-  # Download atomically by rename to prevent partially downloaded binary
-  curl --fail --silent --show-error --location \
-    "$RELEASE_BASE/$ASSET" -o "$BIN.tmp"
-  curl --fail --silent --show-error --location \
-    "$RELEASE_BASE/checksums.txt" -o "$CACHE_DIR/checksums.txt.tmp"
-  mv "$CACHE_DIR/checksums.txt.tmp" "$CACHE_DIR/checksums.txt"
+# Download and verify
+TMP="$(mktemp -t rune-bootstrap-XXXXXX)"
+SUMS="$(mktemp -t rune-bootstrap-sums-XXXXXX)"
+trap 'rm -f "$TMP" "$SUMS"' EXIT
 
-  # Verify
-  EXPECTED="$(grep " $ASSET\$" "$CACHE_DIR/checksums.txt" | cut -d' ' -f1)"
-  if [ -z "$EXPECTED" ]; then
-    rm -f "$BIN.tmp"
-    echo "rune: $ASSET not listed in checksums.txt for $RUNE_VERSION" >&2
-    exit 1
-  fi
+curl --fail --silent --show-error --location "$RELEASE_BASE/$ASSET"        -o "$TMP"
+curl --fail --silent --show-error --location "$RELEASE_BASE/checksums.txt" -o "$SUMS"
 
-  if command -v sha256sum >/dev/null 2>&1; then
-    ACTUAL="$(sha256sum "$BIN.tmp" | cut -d' ' -f1)"
-  else
-    ACTUAL="$(shasum -a 256 "$BIN.tmp" | cut -d' ' -f1)"
-  fi
-
-  if [ "$ACTUAL" != "$EXPECTED" ]; then
-    rm -f "$BIN.tmp"
-    echo "rune: checksum mismatch for $ASSET" >&2
-    echo "       expected: $EXPECTED" >&2
-    echo "       actual:   $ACTUAL" >&2
-    exit 1
-  fi
-
-  chmod +x "$BIN.tmp"
-  mv "$BIN.tmp" "$BIN"
+EXPECTED="$(grep " $ASSET\$" "$SUMS" | cut -d' ' -f1)"
+if [ -z "$EXPECTED" ]; then
+  echo "rune: $ASSET not listed in checksums.txt for $RUNE_VERSION" >&2
+  exit 1
 fi
 
-exec "$BIN" "$@"
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL="$(sha256sum "$TMP" | cut -d' ' -f1)"
+else
+  ACTUAL="$(shasum -a 256 "$TMP" | cut -d' ' -f1)"
+fi
+
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+  echo "rune: checksum mismatch for $ASSET" >&2
+  echo "      expected: $EXPECTED" >&2
+  echo "      actual:   $ACTUAL" >&2
+  exit 1
+fi
+
+# Post-download
+chmod +x "$TMP"
+mv -f "$TMP" "$TARGET"
+
+# Delegate to the freshly-installed Go binary
+exec "$TARGET" "$@"

--- a/cmd/rune/launch.go
+++ b/cmd/rune/launch.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"syscall"
 	"time"
+
+	"github.com/CryptoLabInc/rune-cli/internal/bootstrap"
 )
 
 const gracefulShutdownGrace = 5 * time.Second
@@ -18,8 +20,9 @@ func execInstalledBinary(ctx context.Context, binDir, name string, args []string
 
 	if _, err := os.Stat(binPath); err != nil {
 		fmt.Fprintf(stderr,
-			"rune: %s not installed at %s.\nRun `rune install` first (then restart your Claude session if you were trying to launch rune-mcp).\n",
-			name, binPath)
+			"rune: %s not installed at %s (exit 127).\n"+
+				"Agent recovery: invoke %s, then re-attempt the failed slash command.\n",
+			name, binPath, bootstrap.AgentInstallRecoveryHint())
 		return 127 // not installed (missing binary)
 	}
 

--- a/cmd/rune/main.go
+++ b/cmd/rune/main.go
@@ -22,7 +22,10 @@
 //      mcpServers entry uses this to spawn mcp server
 //
 //	rune runed [args...]
-//      Forward stdio + args to ~/.runed/bin/runed
+//      Forward stdio + args to ~/.runed/bin/runed (foreground)
+//
+//	rune runed --detach [args...]
+//      Execute runed as a user-space daemon and supervise its lifecycle in a restart loop
 
 package main
 
@@ -87,7 +90,10 @@ Usage:
   rune mcp-server [args...]
         forward stdio to ~/.rune/bin/rune-mcp (plugin-manifest entry point)
   rune runed [args...]
-        forward stdio + args to ~/.runed/bin/runed
+        forward stdio + args to ~/.runed/bin/runed (foreground)
+  rune runed --detach [args...]
+        supervise runed as a background daemon: detach + log to
+        ~/.runed/logs/daemon.log + auto-restart on crash
 
 Environment:
   RUNE_HOME       override ~/.rune/  (rune plugin realm: config + rune-mcp)

--- a/cmd/rune/runed.go
+++ b/cmd/rune/runed.go
@@ -6,13 +6,60 @@ import (
 	"io"
 
 	"github.com/CryptoLabInc/rune-cli/internal/bootstrap"
+	"github.com/CryptoLabInc/rune-cli/internal/supervisor"
 )
 
+// runRuned dispatches `rune runed [args...]`:
+//   - Without `--detach`: forwards stdio + args to ~/.runed/bin/runed.
+//     Runed is executed in the foerground.
+//   - With `--detach`: supervisor mode - re-exec itself with setsid()
+//     to become a process group leader, redirect stdio to ~/.runed/logs/daemon.log,
+//     take ~/.runed/supervisor.lock to prevent race, and watch runed in a restart loop.
+//     The user-facing invocation returns immediately once supervisor is launched.
 func runRuned(ctx context.Context, args []string, stderr io.Writer) int {
 	paths, err := bootstrap.Resolve()
 	if err != nil {
 		fmt.Fprintf(stderr, "rune: cannot resolve home directories: %v\n", err)
 		return 1
 	}
-	return execInstalledBinary(ctx, paths.RunedBin, "runed", args, stderr)
+
+	detach, forwardedArgs := extractDetachFlag(args)
+	if !detach {
+		return execInstalledBinary(ctx, paths.RunedBin, "runed", forwardedArgs, stderr)
+	}
+
+	if err := paths.EnsureDirs(); err != nil {
+		fmt.Fprintf(stderr, "rune: ensure dirs: %v\n", err)
+		return 1
+	}
+	if err := supervisor.EnsureLogDir(paths.DaemonLog); err != nil {
+		fmt.Fprintf(stderr, "rune: prepare log dir: %v\n", err)
+		return 1
+	}
+
+	cfg := supervisor.Config{
+		RunedBinary: paths.RunedBinary,
+		RunedArgs:   forwardedArgs,
+		LogPath:     paths.DaemonLog,
+		LockPath:    paths.SupervisorLock,
+	}
+	if err := supervisor.RunDetached(ctx, cfg); err != nil {
+		fmt.Fprintf(stderr, "rune: supervisor: %v\n", err)
+		return 1
+	}
+
+	return 0
+}
+
+func extractDetachFlag(args []string) (detach bool, rest []string) {
+	rest = make([]string, 0, len(args))
+	for _, a := range args {
+		if a == "--detach" || a == "-detach" {
+			detach = true
+			continue
+		}
+		rest = append(rest, a)
+	}
+
+	return detach, rest
 }

--- a/cmd/rune/runed.go
+++ b/cmd/rune/runed.go
@@ -11,7 +11,7 @@ import (
 
 // runRuned dispatches `rune runed [args...]`:
 //   - Without `--detach`: forwards stdio + args to ~/.runed/bin/runed.
-//     Runed is executed in the foerground.
+//     Runed is executed in the foreground.
 //   - With `--detach`: supervisor mode - re-exec itself with setsid()
 //     to become a process group leader, redirect stdio to ~/.runed/logs/daemon.log,
 //     take ~/.runed/supervisor.lock to prevent race, and watch runed in a restart loop.

--- a/cmd/rune/runed_test.go
+++ b/cmd/rune/runed_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractDetachFlag(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      []string
+		wantDetach bool
+		wantRest   []string
+	}{
+		{
+			name:       "absent",
+			input:      []string{"--foreground", "--verbose"},
+			wantDetach: false,
+			wantRest:   []string{"--foreground", "--verbose"},
+		},
+		{
+			name:       "double-dash form",
+			input:      []string{"--detach"},
+			wantDetach: true,
+			wantRest:   []string{},
+		},
+		{
+			name:       "single-dash form",
+			input:      []string{"-detach"},
+			wantDetach: true,
+			wantRest:   []string{},
+		},
+		{
+			name:       "mixed flags",
+			input:      []string{"--detach", "--foreground", "--log-level=debug"},
+			wantDetach: true,
+			wantRest:   []string{"--foreground", "--log-level=debug"},
+		},
+		{
+			name:       "no args",
+			input:      []string{},
+			wantDetach: false,
+			wantRest:   []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotDetach, gotRest := extractDetachFlag(tc.input)
+			if gotDetach != tc.wantDetach {
+				t.Errorf("detach = %v, want %v", gotDetach, tc.wantDetach)
+			}
+			if !reflect.DeepEqual(gotRest, tc.wantRest) {
+				t.Errorf("rest = %#v, want %#v", gotRest, tc.wantRest)
+			}
+		})
+	}
+}

--- a/commands/claude/activate.md
+++ b/commands/claude/activate.md
@@ -1,17 +1,42 @@
 ---
 description: Activate Rune (resume from dormant) and verify pipelines come up healthy
-allowed-tools: mcp__envector__activate, mcp__envector__diagnostics, mcp__envector__vault_status
+allowed-tools: Bash(~/.rune/bin/rune install:*), Bash(${CLAUDE_PLUGIN_ROOT}/bin/rune install:*), mcp__envector__activate, mcp__envector__diagnostics, mcp__envector__vault_status
 ---
 
 # /rune:activate — Activate Plugin
 
 Resume Rune from a dormant state and verify the boot loop reaches Active.
 
-The MCP server is a Go binary auto-spawned by Claude Code from the plugin
-manifest. `mcp__envector__activate` runs the prereq checks server-side
-(config presence + runed socket) and only triggers the boot loop if both
-prereqs pass - so this skill is now a single tool call plus result
-rendering.
+The MCP server is a Go binary spawned by Claude Code from the plugin manifest's
+`${HOME}/.rune/bin/rune-mcp`. `mcp__envector__activate` runs the prereq
+checks server-side (config presence + runed socket reachability, plus a
+runed Health probe) and only triggers the boot loop if everything's ready.
+
+## Preflight: auto-install on first MCP call
+
+`mcp__envector__*` tools spawn the MCP server lazily - on a fresh
+`claude plugin install rune`, the binary the manifest points at
+(`${HOME}/.rune/bin/rune-mcp`) does not exist yet, so the very first
+MCP call below will fail with a transport / connection / spawn error.
+
+When that happens, recover by running ONE of these install entry points
+via the Bash tool, in priority order — try the first applicable:
+
+1. **`~/.rune/bin/rune install`** - when the canonical Go binary
+   already exists and is executable. One exec hop, no bash wrapper.
+   Used in steady state and on every install after the first.
+2. **`bash -c "${CLAUDE_PLUGIN_ROOT}/bin/rune install"`** - when
+   `~/.rune/bin/rune` doesn't exist yet (very first install). The
+   plugin's bash bootstrap downloads the Go binary to
+   `~/.rune/bin/rune` and then delegates to it for the actual install.
+
+Surface the install output to the user verbatim so they see what got
+installed - this is the only point in any /rune:* skill where the user
+sees the underlying `rune install` happen.
+
+Retry the failed MCP call once. If the retry ALSO fails, surface the
+error and stop. Do NOT loop the install. The user does NOT type
+`rune install` themselves - this preflight is the only sanctioned path.
 
 ## Steps
 
@@ -56,10 +81,16 @@ The response shape:
 - Use the `hint` verbatim - it already names the exact next step.
 - Stop. Do NOT call `mcp__envector__diagnostics`; the agent already has the answer.
 
-**`install_pending`** — runed daemon not installed or not running.
-- Render: `"runed daemon not reachable. Run `rune install` (and ensure the daemon is running), then re-run /rune:activate."`
-- The `hint` field carries the exact socket path that was probed.
-- Stop. Don't call diagnostics.
+**`install_pending`** - the activate handler tried to auto-spawn the runed
+daemon (via `${HOME}/bin/rune runed --detach` or the
+canonical equivalent) but couldn't make the socket reachable. The
+response's `hint` field already contains the specific recovery - usually
+the agent-facing form is `bash -c "${CLAUDE_PLUGIN_ROOT}/bin/rune install"`
+(or `~/.rune/bin/rune install` once the CLI is installed).
+- Render the `hint` verbatim to the user, then invoke the hint (recovery command).
+- After install succeeds, retry `/rune:activate` once.
+- Do NOT instruct the user to type the underlying `rune install`
+  themselves - the agent runs it. Stop. Don't call diagnostics.
 
 **`waiting_for_bootstrap`** - runed is up but still self-bootstrapping.
 This is expected on the very first activate after a fresh install: runed

--- a/commands/claude/configure.md
+++ b/commands/claude/configure.md
@@ -1,6 +1,6 @@
 ---
 description: Configure Rune — collect Vault credentials and write ~/.rune/config.json
-allowed-tools: Bash(cp:*), Read, AskUserQuestion, mcp__envector__configure, mcp__envector__activate, mcp__envector__diagnostics
+allowed-tools: Bash(cp:*), Bash(~/.rune/bin/rune install:*), Bash(${CLAUDE_PLUGIN_ROOT}/bin/rune install:*), Read, AskUserQuestion, mcp__envector__configure, mcp__envector__activate, mcp__envector__diagnostics
 ---
 
 # /rune:configure — Setup & Configuration
@@ -9,10 +9,36 @@ Single entry after `claude plugin install rune`. Collects Vault credentials,
 calls `mcp__envector__configure` (atomic 0600 write + soft Vault probe), and
 hands off to `mcp__envector__activate` to bring pipelines online.
 
-The MCP server is a Go binary fetched by `rune install` (or auto-spawned
-by Claude Code from the plugin manifest, depending on the deployment).
-There is no Python venv, no install script, and no separate `claude mcp add`
-step.
+The MCP server is a Go binary placed at `~/.rune/bin/rune-mcp` by the
+plugin's bootstrap (see Preflight below). The plugin manifest's
+`mcpServers.envector.command` resolves directly to that path; Claude
+spawns it on the first `mcp__envector__*` call.
+
+## Preflight: auto-install on first MCP call
+
+`mcp__envector__*` tools spawn the MCP server lazily - on a fresh
+`claude plugin install rune`, the binary the manifest points at
+(`${HOME}/.rune/bin/rune-mcp`) does not exist yet, so the very first
+MCP call below will fail with a transport / connection / spawn error.
+
+When that happens, recover by running ONE of these install entry points
+via the Bash tool, in priority order — try the first applicable:
+
+1. **`~/.rune/bin/rune install`** - when the canonical Go binary
+   already exists and is executable. One exec hop, no bash wrapper.
+   Used in steady state and on every install after the first.
+2. **`bash -c "${CLAUDE_PLUGIN_ROOT}/bin/rune install"`** - when
+   `~/.rune/bin/rune` doesn't exist yet (very first install). The
+   plugin's bash bootstrap downloads the Go binary to
+   `~/.rune/bin/rune` and then delegates to it for the actual install.
+
+Surface the install output to the user verbatim so they see what got
+installed - this is the only point in any /rune:* skill where the user
+sees the underlying `rune install` happen.
+
+Retry the failed MCP call once. If the retry ALSO fails, surface the
+error and stop. Do NOT loop the install. The user does NOT type
+`rune install` themselves - this preflight is the only sanctioned path.
 
 ## Quick Update Mode
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/CryptoLabInc/rune-cli
 
 go 1.26.2
+
+require golang.org/x/sys v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/bootstrap/installcheck.go
+++ b/internal/bootstrap/installcheck.go
@@ -70,7 +70,7 @@ func RunInstallChecks(ctx context.Context) *InstallChecks {
 	cfg, cfgChecks := loadRuneConfigChecks(paths)
 	checks := append([]InstallCheck{}, cfgChecks...)
 	checks = append(checks, vaultCredsCheck(cfg))
-	checks = append(checks, executableCheck(CheckRunedBinary, paths.RunedBinary, "run `rune install` to fetch runed"))
+	checks = append(checks, executableCheck(CheckRunedBinary, paths.RunedBinary, "agent: invoke "+AgentInstallRecoveryHint()+" to fetch runed"))
 	checks = append(checks, modelFileCheck(paths.RunedModels))
 	checks = append(checks, socketCheck(paths.RunedSocket, cfg))
 	checks = append(checks, spawnLockCheck(paths.RunedLock))

--- a/internal/bootstrap/paths.go
+++ b/internal/bootstrap/paths.go
@@ -42,16 +42,17 @@ type Paths struct {
 	InstalledManifest string // ~/.rune/installed.json - install audit log
 
 	// Runed
-	RunedHome   string // ~/.runed
-	RunedBin    string // ~/.runed/bin
-	RunedModels string // ~/.runed/models
-	RunedSocket string // ~/.runed/embedding.sock
-	RunedLock   string // ~/.runed/spawn.lock
-	RunedLogs   string // ~/.runed/logs
-	RunedBinary string // ~/.runed/bin/runed
-	LlamaServer string // ~/.runed/bin/llama-server
-	InstallLock string // ~/.runed/install.lock
-	Cache       string // ~/.runed/cache
+	RunedHome      string // ~/.runed
+	RunedBin       string // ~/.runed/bin
+	RunedModels    string // ~/.runed/models
+	RunedSocket    string // ~/.runed/embedding.sock
+	RunedLock      string // ~/.runed/spawn.lock
+	RunedLogs      string // ~/.runed/logs
+	RunedBinary    string // ~/.runed/bin/runed
+	InstallLock    string // ~/.runed/install.lock
+	SupervisorLock string // ~/.runed/supervisor.lock (`rune runed --detach` hold it during lifetime)
+	DaemonLog      string // ~/.runed/logs/daemon.log
+	Cache          string // ~/.runed/cache
 }
 
 func Resolve() (*Paths, error) {
@@ -95,16 +96,17 @@ func newPaths(runeHome, runedHome string) *Paths {
 		RuneConfig:        filepath.Join(runeHome, "config.json"),
 		InstalledManifest: filepath.Join(runeHome, "installed.json"),
 
-		RunedHome:   runedHome,
-		RunedBin:    runedBin,
-		RunedModels: filepath.Join(runedHome, "models"),
-		RunedSocket: filepath.Join(runedHome, "embedding.sock"),
-		RunedLock:   filepath.Join(runedHome, "spawn.lock"),
-		RunedLogs:   filepath.Join(runedHome, "logs"),
-		RunedBinary: filepath.Join(runedBin, "runed"),
-		LlamaServer: filepath.Join(runedBin, "llama-server"),
-		InstallLock: filepath.Join(runedHome, "install.lock"),
-		Cache:       filepath.Join(runedHome, "cache"),
+		RunedHome:      runedHome,
+		RunedBin:       runedBin,
+		RunedModels:    filepath.Join(runedHome, "models"),
+		RunedSocket:    filepath.Join(runedHome, "embedding.sock"),
+		RunedLock:      filepath.Join(runedHome, "spawn.lock"),
+		RunedLogs:      filepath.Join(runedHome, "logs"),
+		RunedBinary:    filepath.Join(runedBin, "runed"),
+		InstallLock:    filepath.Join(runedHome, "install.lock"),
+		SupervisorLock: filepath.Join(runedHome, "supervisor.lock"),
+		DaemonLog:      filepath.Join(runedHome, "logs", "daemon.log"),
+		Cache:          filepath.Join(runedHome, "cache"),
 	}
 }
 

--- a/internal/bootstrap/paths.go
+++ b/internal/bootstrap/paths.go
@@ -125,3 +125,13 @@ func (p *Paths) EnsureDirs() error {
 func PlatformTuple() string {
 	return runtime.GOOS + "-" + runtime.GOARCH // {os}-{arch}, e.g. "linux-amd64"
 }
+
+func AgentInstallRecoveryHint() string {
+	if paths, err := Resolve(); err == nil {
+		if _, err := os.Stat(paths.RuneCLIBinary); err == nil {
+			return fmt.Sprintf("`%s install`", paths.RuneCLIBinary)
+		}
+	}
+
+	return "`bash -c \"${CLAUDE_PLUGIN_ROOT}/bin/rune install\"`"
+}

--- a/internal/bootstrap/paths.go
+++ b/internal/bootstrap/paths.go
@@ -37,6 +37,7 @@ type Paths struct {
 	// Rune
 	RuneHome          string // ~/.rune
 	RuneBin           string // ~/.rune/bin
+	RuneCLIBinary     string // ~/.rune/bin/rune
 	RuneMCPBinary     string // ~/.rune/bin/rune-mcp
 	RuneConfig        string // ~/.rune/config.json
 	InstalledManifest string // ~/.rune/installed.json - install audit log
@@ -92,6 +93,7 @@ func newPaths(runeHome, runedHome string) *Paths {
 	return &Paths{
 		RuneHome:          runeHome,
 		RuneBin:           runeBin,
+		RuneCLIBinary:     filepath.Join(runeBin, "rune"),
 		RuneMCPBinary:     filepath.Join(runeBin, "rune-mcp"),
 		RuneConfig:        filepath.Join(runeHome, "config.json"),
 		InstalledManifest: filepath.Join(runeHome, "installed.json"),

--- a/internal/supervisor/daemonizestub.go
+++ b/internal/supervisor/daemonizestub.go
@@ -1,0 +1,15 @@
+//go:build !unix
+
+package supervisor
+
+import (
+	"errors"
+	"os/exec"
+)
+
+// Stubs for non-unix builds
+func applyDetachAttrs(*exec.Cmd) {}
+
+func redirectStdio(string) error {
+	return errors.New("supervisor: detached mode is not supported on this platform")
+}

--- a/internal/supervisor/daemonizeunix.go
+++ b/internal/supervisor/daemonizeunix.go
@@ -1,0 +1,47 @@
+//go:build unix
+
+package supervisor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func applyDetachAttrs(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setsid = true
+}
+
+func redirectStdio(logPath string) error {
+	logFile, err := os.OpenFile(logPath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o600)
+	if err != nil {
+		return fmt.Errorf("open log %s: %w", logPath, err)
+	}
+	defer logFile.Close()
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", os.DevNull, err)
+	}
+	defer devNull.Close()
+
+	// Replace stdin with /dev/null: prevent user interaction
+	if err := unix.Dup2(int(devNull.Fd()), int(os.Stdin.Fd())); err != nil {
+		return fmt.Errorf("dup2 stdin: %w", err)
+	}
+	// Replace stdout and stderr with log file descriptor: log outputs
+	if err := unix.Dup2(int(logFile.Fd()), int(os.Stdout.Fd())); err != nil {
+		return fmt.Errorf("dup2 stdout: %w", err)
+	}
+	if err := unix.Dup2(int(logFile.Fd()), int(os.Stderr.Fd())); err != nil {
+		return fmt.Errorf("dup2 stderr: %w", err)
+	}
+
+	return nil
+}

--- a/internal/supervisor/lockstub.go
+++ b/internal/supervisor/lockstub.go
@@ -1,0 +1,13 @@
+//go:build !unix
+
+package supervisor
+
+import (
+	"errors"
+	"os"
+)
+
+// Stub for non-unix builds
+func acquireSupervisorLock(string) (*os.File, bool, error) {
+	return nil, false, errors.New("supervisor: file-lock based supervisor is not supported on this platform")
+}

--- a/internal/supervisor/lockunix.go
+++ b/internal/supervisor/lockunix.go
@@ -1,0 +1,36 @@
+//go:build unix
+
+package supervisor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// Open lockPath and take exclusive flock(2), returns:
+//   - (file, true, nil): lock acquired, caller must Close() to release
+//   - (nil, false, nil): another process already hold lock
+//   - (nil, false, err): unexpected error
+func acquireSupervisorLock(lockPath string) (*os.File, bool, error) {
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		return nil, false, fmt.Errorf("mkdir parent: %w", err)
+	}
+
+	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, false, fmt.Errorf("open %s: %w", lockPath, err)
+	}
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("flock %s: %w", lockPath, err)
+	}
+
+	return f, true, nil
+}

--- a/internal/supervisor/lockunix_test.go
+++ b/internal/supervisor/lockunix_test.go
@@ -1,0 +1,72 @@
+//go:build unix
+
+package supervisor
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestAcquireSupervisorLock_FirstCallerWins(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "supervisor.lock")
+
+	// First attempt
+	f1, locked1, err := acquireSupervisorLock(lockPath)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	if !locked1 {
+		t.Fatal("first acquire should succeed (no contention)")
+	}
+	t.Cleanup(func() { _ = f1.Close() })
+
+	// Second attempt
+	f2, locked2, err := acquireSupervisorLock(lockPath)
+	if err != nil {
+		t.Fatalf("second acquire: %v", err)
+	}
+	if locked2 {
+		t.Error("second acquire should fail (lock held by f1)")
+		_ = f2.Close()
+	}
+	if f2 != nil {
+		t.Error("contended acquire should return nil file handle")
+	}
+}
+
+func TestAcquireSupervisorLock_ReleasedOnClose(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "supervisor.lock")
+
+	// Acquire lock
+	f1, locked, err := acquireSupervisorLock(lockPath)
+	if err != nil || !locked {
+		t.Fatalf("first acquire: locked=%v err=%v", locked, err)
+	}
+	// Release lock
+	if err := f1.Close(); err != nil {
+		t.Fatalf("close first: %v", err)
+	}
+
+	// Acquire lock
+	f2, locked2, err := acquireSupervisorLock(lockPath)
+	if err != nil {
+		t.Fatalf("re-acquire: %v", err)
+	}
+	if !locked2 {
+		t.Fatal("re-acquire after close should succeed")
+	}
+	_ = f2.Close()
+}
+
+func TestAcquireSupervisorLock_CreatesParentDir(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "nested", "deeper", "supervisor.lock")
+
+	f, locked, err := acquireSupervisorLock(lockPath)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if !locked {
+		t.Fatal("acquire should succeed even with missing parent dir")
+	}
+	_ = f.Close()
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1,0 +1,205 @@
+package supervisor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// Supervisor runtime parameters
+type Config struct {
+	RunedBinary string // default: ~/.runed/bin/runed
+	RunedArgs   []string
+	LogPath     string // default: ~/.runed/logs/daemon.log
+	LockPath    string // default: ~/.runed/supervisor.lock
+
+	BackoffSchedule []time.Duration // nil for DefaultBackoff
+	MaxCrashes      int             // 0 for DefaultMaxCrashes
+	MaxCrashWindow  time.Duration   // 0 for DefaultMaxCrashWindow
+	ShutdownGrace   time.Duration   // 0 for DefaultShutdownGrace
+}
+
+var (
+	DefaultBackoff = []time.Duration{
+		2 * time.Second,
+		5 * time.Second,
+		10 * time.Second,
+		15 * time.Second,
+	}
+	DefaultMaxCrashes     = 5
+	DefaultMaxCrashWindow = 60 * time.Second
+	DefaultShutdownGrace  = 5 * time.Second
+)
+
+const envMarker = "_RUNE_RUNED_SUPERVISOR" // supervisor mode marker
+
+// `rune runed --detach` entrypoint
+func RunDetached(ctx context.Context, cfg Config) error {
+	if os.Getenv(envMarker) == "" {
+		return spawnSupervisor(cfg)
+	}
+	return runSupervisor(ctx, cfg)
+}
+
+// spawnSupervisor re-execs the current binary with the marker env var
+// set and SysProcAttr.Setsid = true. After cmd.Start() returns, we
+// release the child handle so the kernel re-parents it to init when
+// the current process exits.
+func spawnSupervisor(cfg Config) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("supervisor: resolve executable path: %w", err)
+	}
+	args := []string{"runed", "--detach"}
+	args = append(args, cfg.RunedArgs...)
+
+	cmd := exec.Command(exe, args...)
+	cmd.Env = append(os.Environ(), envMarker+"=1")
+	applyDetachAttrs(cmd)
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("supervisor: start detached: %w", err)
+	}
+
+	// Set userspace daemon's parent to init (PID 1)
+	if err := cmd.Process.Release(); err != nil {
+		return fmt.Errorf("supervisor: release child: %w", err)
+	}
+	return nil
+}
+
+// Deatched process body
+func runSupervisor(ctx context.Context, cfg Config) error {
+	if err := redirectStdio(cfg.LogPath); err != nil {
+		return fmt.Errorf("supervisor: redirect stdio: %w", err)
+	}
+
+	lockFile, locked, err := acquireSupervisorLock(cfg.LockPath)
+	if err != nil {
+		return fmt.Errorf("supervisor: acquire lock: %w", err)
+	}
+	if !locked {
+		fmt.Fprintf(os.Stderr, "supervisor: %s already held - another supervisor is running, exiting\n", cfg.LockPath)
+		return nil
+	}
+	defer lockFile.Close()
+
+	return runWatcher(ctx, cfg)
+}
+
+// runWatcher exec's RunedBinary in a loop, restarts on non-zero exit
+// with backoff, gives up after MaxCrashes crashes in MaxCrashWindow,
+// and forwards SIGINT/SIGTERM cleanly. Extracted from runSupervisor
+// so it can be exercised in tests without going through the detach
+// machinery.
+func runWatcher(ctx context.Context, cfg Config) error {
+	cfg = applyDefaults(cfg)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	var crashes []time.Time
+	backoffIdx := 0
+
+	for {
+		cmd := exec.Command(cfg.RunedBinary, cfg.RunedArgs...)
+		cmd.Stdin = nil
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		fmt.Fprintf(os.Stderr, "supervisor: starting %s %v\n", cfg.RunedBinary, cfg.RunedArgs)
+		if err := cmd.Start(); err != nil {
+			return fmt.Errorf("supervisor: start %s: %w", cfg.RunedBinary, err)
+		}
+
+		done := make(chan error, 1)
+		go func() { done <- cmd.Wait() }()
+
+		// Forward SIGINT/SIGTERM to child, detect child exited
+		select {
+		case <-ctx.Done():
+			return shutdownChild(cmd, cfg.ShutdownGrace, done)
+		case sig := <-sigCh:
+			fmt.Fprintf(os.Stderr, "supervisor: received %s, forwarding to child\n", sig)
+			return shutdownChild(cmd, cfg.ShutdownGrace, done)
+		case err := <-done:
+			exitCode := -1
+			if cmd.ProcessState != nil {
+				exitCode = cmd.ProcessState.ExitCode()
+			}
+			fmt.Fprintf(os.Stderr, "supervisor: child exited (code=%d err=%v)\n", exitCode, err)
+
+			if exitCode == 0 {
+				return nil // clean exit
+			}
+
+			now := time.Now()
+			crashes = append(crashes, now)
+			cutoff := now.Add(-cfg.MaxCrashWindow) // crashes older than now - cfg.MaxCrashWindow are considered expired
+			i := 0
+			for i < len(crashes) && crashes[i].Before(cutoff) {
+				i++
+			}
+			crashes = crashes[i:] // sliding-window
+
+			if len(crashes) >= cfg.MaxCrashes {
+				return fmt.Errorf("supervisor: %d crashes within %s - giving up", len(crashes), cfg.MaxCrashWindow)
+			}
+
+			wait := cfg.BackoffSchedule[min(backoffIdx, len(cfg.BackoffSchedule)-1)]
+			backoffIdx++
+			fmt.Fprintf(os.Stderr, "supervisor: backing off %s before restart (crash %d of max %d in %s window)\n", wait, len(crashes), cfg.MaxCrashes, cfg.MaxCrashWindow)
+			select {
+			case <-time.After(wait):
+				continue
+			case <-ctx.Done():
+				return nil
+			case <-sigCh:
+				return nil
+			}
+		}
+	}
+}
+
+func shutdownChild(cmd *exec.Cmd, grace time.Duration, done <-chan error) error {
+	if cmd.Process == nil {
+		return nil
+	}
+
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	select {
+	case <-done:
+		return nil
+	case <-time.After(grace):
+		fmt.Fprintf(os.Stderr, "supervisor: child didn't exit within %s, sending SIGKILL\n", grace)
+		_ = cmd.Process.Kill()
+		<-done
+		return nil
+	}
+}
+
+func applyDefaults(cfg Config) Config {
+	if len(cfg.BackoffSchedule) == 0 {
+		cfg.BackoffSchedule = DefaultBackoff
+	}
+	if cfg.MaxCrashes == 0 {
+		cfg.MaxCrashes = DefaultMaxCrashes
+	}
+	if cfg.MaxCrashWindow == 0 {
+		cfg.MaxCrashWindow = DefaultMaxCrashWindow
+	}
+	if cfg.ShutdownGrace == 0 {
+		cfg.ShutdownGrace = DefaultShutdownGrace
+	}
+	return cfg
+}
+
+func EnsureLogDir(logPath string) error {
+	return os.MkdirAll(filepath.Dir(logPath), 0o700)
+}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1,0 +1,157 @@
+//go:build unix
+
+package supervisor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const fakeRunedEnv = "RUNE_SUPERVISOR_FAKE_RUNED_BEHAVIOR"
+const crashCountFileEnv = "RUNE_SUPERVISOR_FAKE_CRASH_COUNT_FILE"
+
+func TestMain(m *testing.M) {
+	if behavior := os.Getenv(fakeRunedEnv); behavior != "" {
+		fakeRuned(behavior)
+		return
+	}
+	os.Exit(m.Run())
+}
+
+func fakeRuned(behavior string) {
+	if path := os.Getenv(crashCountFileEnv); path != "" {
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+		if err == nil {
+			fmt.Fprintln(f, behavior) // append "\n" for counting invocation
+			_ = f.Close()
+		}
+	}
+
+	// Simulate behavior
+	switch behavior {
+	case "clean":
+		os.Exit(0)
+	case "crash":
+		os.Exit(1)
+	case "sleep": // simulate graceful shutdown
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+		<-sigCh
+		os.Exit(0)
+	case "crash_then_clean": // first crash, second exit cleanly
+		path := os.Getenv(crashCountFileEnv)
+		if path == "" {
+			os.Exit(0)
+		}
+
+		data, _ := os.ReadFile(path)
+		if strings.Count(string(data), "\n") == 1 {
+			os.Exit(1)
+		}
+		os.Exit(0)
+	default:
+		os.Exit(99)
+	}
+}
+
+func testWatcherConfig(t *testing.T) Config {
+	t.Helper()
+	return Config{
+		RunedBinary:     os.Args[0],
+		BackoffSchedule: []time.Duration{time.Millisecond},
+		MaxCrashes:      5,
+		MaxCrashWindow:  10 * time.Second,
+		ShutdownGrace:   500 * time.Millisecond,
+	}
+}
+
+func TestWatcher_CleanExitReturnsNil(t *testing.T) {
+	t.Setenv(fakeRunedEnv, "clean")
+	cfg := testWatcherConfig(t)
+
+	if err := runWatcher(context.Background(), cfg); err != nil {
+		t.Errorf("runWatcher: %v, want nil for clean exit", err)
+	}
+}
+
+func TestWatcher_RestartsAfterCrash(t *testing.T) {
+	countFile := t.TempDir() + "/crashes.log"
+	t.Setenv(fakeRunedEnv, "crash_then_clean")
+	t.Setenv(crashCountFileEnv, countFile)
+	cfg := testWatcherConfig(t)
+
+	if err := runWatcher(context.Background(), cfg); err != nil {
+		t.Errorf("runWatcher: %v, want nil (first crash -> restart -> clean exit)", err)
+	}
+
+	data, err := os.ReadFile(countFile)
+	if err != nil {
+		t.Fatalf("read count file: %v", err)
+	}
+
+	lines := strings.Count(string(data), "\n")
+	if lines != 2 {
+		t.Errorf("fake invocations: got %d, want 2 (crash + restart) - log=%s", lines, data)
+	}
+}
+
+func TestWatcher_GivesUpAfterMaxCrashes(t *testing.T) {
+	countFile := t.TempDir() + "/crashes.log"
+	t.Setenv(fakeRunedEnv, "crash")
+	t.Setenv(crashCountFileEnv, countFile)
+	cfg := testWatcherConfig(t)
+	cfg.MaxCrashes = 3
+	cfg.MaxCrashWindow = 10 * time.Second
+	cfg.BackoffSchedule = []time.Duration{time.Millisecond}
+
+	err := runWatcher(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("runWatcher should return error after MaxCrashes")
+	}
+	if !strings.Contains(err.Error(), "giving up") {
+		t.Errorf("error message: got %q, want substring 'giving up'", err.Error())
+	}
+
+	data, _ := os.ReadFile(countFile)
+	lines := strings.Count(string(data), "\n")
+	if lines != cfg.MaxCrashes {
+		t.Errorf("fake invocations: got %d, want %d (one per crash before giving up)", lines, cfg.MaxCrashes)
+	}
+}
+
+func TestWatcher_ContextCancelTriggersShutdown(t *testing.T) {
+	t.Setenv(fakeRunedEnv, "sleep")
+	cfg := testWatcherConfig(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var watcherErr atomic.Value
+	done := make(chan struct{})
+	go func() {
+		err := runWatcher(ctx, cfg)
+		if err != nil {
+			watcherErr.Store(err)
+		}
+		close(done)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done: // good path
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not exit within 2s of ctx cancellation")
+	}
+
+	if v := watcherErr.Load(); v != nil {
+		t.Errorf("runWatcher returned %v; want nil on graceful shutdown", v)
+	}
+}


### PR DESCRIPTION
## Summary

- What changed:
  - Add supervisor mode rune running with `rune runed --detach`
  - Refactor bash wrapper and initial setup
  - Change mcpServer binary path to `${HOME}/.rune/bin/rune-mcp`
- Why:
  - We need to manage `runed` as user-level daemon since we don't want user to register `runed` as a system daemon manually
  - Elaborate initial setup
- Scope:

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [ ] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [ ] No agent-specific script duplicates bootstrap/setup logic
- [ ] Agent-specific scripts remain thin adapters (registration/wiring only)
- [ ] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [ ] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [ ] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
