### PR TITLE
refactor: rename MCP namespace `envector` to `rune`

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -12,9 +12,9 @@
     "./agents/claude/retriever.md"
   ],
   "mcpServers": {
-    "envector": {
+    "rune": {
       "command": "${HOME}/.rune/bin/rune-mcp",
-      "description": "enVector MCP server. Populated by '${CLAUDE_PLUGIN_ROOT}/bin/rune install'; before that, this path doesn't exist and the spawn fails - which the skill markdown catches and recovers from"
+      "description": "Rune MCP server (talks to Vault + embedder + enVector). Populated by '${CLAUDE_PLUGIN_ROOT}/bin/rune install'; before that, this path doesn't exist and the spawn fails - which the skill markdown catches and recovers from"
     }
   }
 }

--- a/commands/claude/activate.md
+++ b/commands/claude/activate.md
@@ -1,6 +1,6 @@
 ---
 description: Activate Rune (resume from dormant) and verify pipelines come up healthy
-allowed-tools: Bash(~/.rune/bin/rune install:*), Bash(${CLAUDE_PLUGIN_ROOT}/bin/rune install:*), mcp__envector__activate, mcp__envector__diagnostics, mcp__envector__vault_status
+allowed-tools: Bash(~/.rune/bin/rune install:*), Bash(${CLAUDE_PLUGIN_ROOT}/bin/rune install:*), mcp__rune__activate, mcp__rune__diagnostics, mcp__rune__vault_status
 ---
 
 # /rune:activate — Activate Plugin
@@ -8,13 +8,13 @@ allowed-tools: Bash(~/.rune/bin/rune install:*), Bash(${CLAUDE_PLUGIN_ROOT}/bin/
 Resume Rune from a dormant state and verify the boot loop reaches Active.
 
 The MCP server is a Go binary spawned by Claude Code from the plugin manifest's
-`${HOME}/.rune/bin/rune-mcp`. `mcp__envector__activate` runs the prereq
+`${HOME}/.rune/bin/rune-mcp`. `mcp__rune__activate` runs the prereq
 checks server-side (config presence + runed socket reachability, plus a
 runed Health probe) and only triggers the boot loop if everything's ready.
 
 ## Preflight: auto-install on first MCP call
 
-`mcp__envector__*` tools spawn the MCP server lazily - on a fresh
+`mcp__rune__*` tools spawn the MCP server lazily - on a fresh
 `claude plugin install rune`, the binary the manifest points at
 (`${HOME}/.rune/bin/rune-mcp`) does not exist yet, so the very first
 MCP call below will fail with a transport / connection / spawn error.
@@ -40,7 +40,7 @@ error and stop. Do NOT loop the install. The user does NOT type
 
 ## Steps
 
-### 1. Call `mcp__envector__activate`
+### 1. Call `mcp__rune__activate`
 
 That's it - no Read, no Edit, no manual state inspection. The MCP tool
 performs:
@@ -79,7 +79,7 @@ The response shape:
 **`configure_required`** - Vault credentials missing.
 - Render: `"Rune is not yet configured. Run /rune:configure to set Vault credentials."`
 - Use the `hint` verbatim - it already names the exact next step.
-- Stop. Do NOT call `mcp__envector__diagnostics`; the agent already has the answer.
+- Stop. Do NOT call `mcp__rune__diagnostics`; the agent already has the answer.
 
 **`install_pending`** - the activate handler tried to auto-spawn the runed
 daemon (via `${HOME}/bin/rune runed --detach` or the
@@ -118,7 +118,7 @@ it can serve embeddings.
 - Stop. DO NOT poll automatically; DO NOT re-run `/rune:activate`.
 
 **`active`** — happy path. Pipelines initialized, ready to capture/recall.
-- Optionally call `mcp__envector__diagnostics` ONCE to render the
+- Optionally call `mcp__rune__diagnostics` ONCE to render the
   per-subsystem summary below. Skip if you only need to confirm activation;
   `response.reload.state == "active"` is authoritative.
 
@@ -134,7 +134,7 @@ it can serve embeddings.
 
 ### 3. Render success snapshot (active path only)
 
-When `status == "active"`, call `mcp__envector__diagnostics` once and
+When `status == "active"`, call `mcp__rune__diagnostics` once and
 render the per-subsystem report (use ✓ for healthy, ✗ for failures with
 the specific error on the same line):
 

--- a/commands/claude/capture.md
+++ b/commands/claude/capture.md
@@ -1,6 +1,6 @@
 ---
 description: Capture organizational context to encrypted memory
-allowed-tools: Bash(cat ~/.rune/*), Read, mcp__envector__*
+allowed-tools: Bash(cat ~/.rune/*), Read, mcp__rune__*
 ---
 
 # /rune:capture — Store Context
@@ -19,7 +19,7 @@ The argument `$ARGUMENTS` contains the context to capture.
 
 1. Parse `$ARGUMENTS` as the context to capture.
 2. Add metadata: timestamp, domain classification (infer from content).
-3. Use the envector MCP tools to embed and store the context.
+3. Use the Rune MCP tools to embed and store the context.
 4. Confirm what was stored with a brief summary.
 
 ## Example

--- a/commands/claude/configure.md
+++ b/commands/claude/configure.md
@@ -1,22 +1,22 @@
 ---
 description: Configure Rune — collect Vault credentials and write ~/.rune/config.json
-allowed-tools: Bash(cp:*), Bash(~/.rune/bin/rune install:*), Bash(${CLAUDE_PLUGIN_ROOT}/bin/rune install:*), Read, AskUserQuestion, mcp__envector__configure, mcp__envector__activate, mcp__envector__diagnostics
+allowed-tools: Bash(cp:*), Bash(~/.rune/bin/rune install:*), Bash(${CLAUDE_PLUGIN_ROOT}/bin/rune install:*), Read, AskUserQuestion, mcp__rune__configure, mcp__rune__activate, mcp__rune__diagnostics
 ---
 
 # /rune:configure — Setup & Configuration
 
 Single entry after `claude plugin install rune`. Collects Vault credentials,
-calls `mcp__envector__configure` (atomic 0600 write + soft Vault probe), and
-hands off to `mcp__envector__activate` to bring pipelines online.
+calls `mcp__rune__configure` (atomic 0600 write + soft Vault probe), and
+hands off to `mcp__rune__activate` to bring pipelines online.
 
 The MCP server is a Go binary placed at `~/.rune/bin/rune-mcp` by the
 plugin's bootstrap (see Preflight below). The plugin manifest's
-`mcpServers.envector.command` resolves directly to that path; Claude
-spawns it on the first `mcp__envector__*` call.
+`mcpServers.rune.command` resolves directly to that path; Claude
+spawns it on the first `mcp__rune__*` call.
 
 ## Preflight: auto-install on first MCP call
 
-`mcp__envector__*` tools spawn the MCP server lazily - on a fresh
+`mcp__rune__*` tools spawn the MCP server lazily - on a fresh
 `claude plugin install rune`, the binary the manifest points at
 (`${HOME}/.rune/bin/rune-mcp`) does not exist yet, so the very first
 MCP call below will fail with a transport / connection / spawn error.
@@ -49,10 +49,10 @@ If $ARGUMENTS contains any of: `--vault-token`, `--vault-endpoint`:
 2. Merge the partial update into the existing values:
    - `--vault-token <value>`: use as the new `token`, keep existing `endpoint`/`ca_cert`/`tls_disable`.
    - `--vault-endpoint <value>`: auto-prepend `tcp://` if no scheme, keep existing `token`/`ca_cert`/`tls_disable`.
-3. Call `mcp__envector__configure` with the merged values. Server-side
+3. Call `mcp__rune__configure` with the merged values. Server-side
    handles atomic write + 0600 perms + `metadata.lastUpdated` refresh +
    the soft Vault probe.
-4. Call `mcp__envector__activate` to apply.
+4. Call `mcp__rune__activate` to apply.
 5. Render: `"Updated [field]. Use /rune:status to verify."`
 
 Skip all steps below.
@@ -73,7 +73,7 @@ to do so.
 - File present: mask the token (first 8 chars + "***") and show the
   current `endpoint`, `ca_cert`, `tls_disable`, `state`, masked token.
   Then issue a single `AskUserQuestion("Reconfigure these values?")`:
-    - User declines: call `mcp__envector__activate` and stop (just bring
+    - User declines: call `mcp__rune__activate` and stop (just bring
       the existing config online).
     - User confirms: continue to Step 2 with the existing values as
       defaults the user can override.
@@ -121,7 +121,7 @@ If `cp` fails (file not found / permission denied), surface the error
 and ask the user for a readable path (one more `AskUserQuestion`). Common
 recovery: `sudo cp /opt/runevault/certs/ca.pem ~/.rune/ca.pem && sudo chown $USER ~/.rune/ca.pem`.
 
-### 4. Call `mcp__envector__configure`
+### 4. Call `mcp__rune__configure`
 
 ```jsonc
 {
@@ -155,13 +155,13 @@ Response:
 ### 5. Decide what to do next based on the probe
 
 **`vault_reachable: true`** - credentials look good. Call
-`mcp__envector__activate` to bring pipelines up. Proceed to Step 6.
+`mcp__rune__activate` to bring pipelines up. Proceed to Step 6.
 
 **`vault_reachable: false`** - early warning. The file IS written and
 `state` IS active, but the probe couldn't dial Vault. Two ways to proceed:
 
   - **Common case (transient / first-time):** still call
-    `mcp__envector__activate`. The boot loop has retries with backoff,
+    `mcp__rune__activate`. The boot loop has retries with backoff,
     and the classified `last_boot_error` it produces will be richer than
     the probe error.
   - **Obvious typo case** (`probe_error` contains "no such host" /
@@ -204,7 +204,7 @@ classifier has already done that work server-side.
 ### 7. Completion Summary (success path)
 
 When `activate.status == "active"`, optionally call
-`mcp__envector__diagnostics` once for the rich per-subsystem snapshot and
+`mcp__rune__diagnostics` once for the rich per-subsystem snapshot and
 render:
 
 ```

--- a/commands/claude/deactivate.md
+++ b/commands/claude/deactivate.md
@@ -1,6 +1,6 @@
 ---
 description: Deactivate Rune to pause organizational memory without clearing configuration
-allowed-tools: Read, Edit, mcp__envector__reload_pipelines
+allowed-tools: Read, Edit, mcp__rune__reload_pipelines
 ---
 
 # /rune:deactivate — Deactivate Plugin
@@ -20,7 +20,7 @@ Switch from active to dormant state. Configuration is preserved — use `/rune:a
    - Set `dormant_reason` to `"user_deactivated"`
    - Set `dormant_since` to current timestamp (e.g., `"2026-03-26T10:00:00Z"`)
 
-4. Call `reload_pipelines` as a **native MCP tool** (`mcp__envector__reload_pipelines`) — invoke it directly like any other tool, do NOT use `claude mcp call` via Bash (that subcommand doesn't exist).
+4. Call `reload_pipelines` as a **native MCP tool** (`mcp__rune__reload_pipelines`) — invoke it directly like any other tool, do NOT use `claude mcp call` via Bash (that subcommand doesn't exist).
    - This ensures MCP tools (`capture`/`recall`) immediately return errors instead of processing.
 
 5. Respond: "Rune deactivated. Organizational memory is paused. Config preserved — `/rune:activate` to resume."

--- a/commands/claude/delete.md
+++ b/commands/claude/delete.md
@@ -1,6 +1,6 @@
 ---
 description: Delete a captured decision record
-allowed-tools: mcp__envector__delete_capture, mcp__envector__capture_history
+allowed-tools: mcp__rune__delete_capture, mcp__rune__capture_history
 ---
 
 # /rune:delete — Delete Captured Record

--- a/commands/claude/history.md
+++ b/commands/claude/history.md
@@ -1,6 +1,6 @@
 ---
 description: View recent capture history
-allowed-tools: mcp__envector__capture_history
+allowed-tools: mcp__rune__capture_history
 ---
 
 # /rune:history — View Capture History

--- a/commands/claude/recall.md
+++ b/commands/claude/recall.md
@@ -1,6 +1,6 @@
 ---
 description: Search organizational memory for past decisions and context
-allowed-tools: Bash(cat ~/.rune/*), Read, mcp__envector__*
+allowed-tools: Bash(cat ~/.rune/*), Read, mcp__rune__*
 ---
 
 # /rune:recall — Search Memory
@@ -18,7 +18,7 @@ The argument `$ARGUMENTS` contains the search query.
 ## When Active
 
 1. Parse `$ARGUMENTS` as the search query.
-2. Use the envector MCP tools to search encrypted vectors.
+2. Use the Rune MCP tools to search encrypted vectors.
 3. Return relevant results with:
    - Source attribution (who/when)
    - Relevant excerpts

--- a/commands/claude/status.md
+++ b/commands/claude/status.md
@@ -1,6 +1,6 @@
 ---
 description: Check Rune plugin activation status and infrastructure health
-allowed-tools: Bash(cat ~/.rune/*), Bash(ls:*), Read, mcp__envector__diagnostics, mcp__envector__vault_status
+allowed-tools: Bash(cat ~/.rune/*), Bash(ls:*), Read, mcp__rune__diagnostics, mcp__rune__vault_status
 ---
 
 # /rune:status — Plugin Status


### PR DESCRIPTION
## Summary

- What changed: TSIA
- Why: Clarify
- Scope:

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [ ] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [ ] No agent-specific script duplicates bootstrap/setup logic
- [ ] Agent-specific scripts remain thin adapters (registration/wiring only)
- [ ] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [ ] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [ ] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
