### PR TITLE
feat(bootstrap): add audit installation

### DIFF
--- a/internal/bootstrap/audit.go
+++ b/internal/bootstrap/audit.go
@@ -1,0 +1,85 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type InstalledManifest struct {
+	ManifestURL     string `json:"manifest_url"`
+	ManifestVersion int    `json:"manifest_version"`
+
+	RuneMCPVersion string `json:"rune_mcp_version,omitempty"`
+	RunedVersion   string `json:"runed_version,omitempty"`
+
+	Platform    string                       `json:"platform"`
+	InstalledAt string                       `json:"installed_at"` // UTC RFC3339 timestamp
+	Artifacts   map[string]InstalledArtifact `json:"artifacts"`
+}
+
+type InstalledArtifact struct {
+	URL    string `json:"url"`
+	SHA256 string `json:"sha256"`
+	Path   string `json:"path"`
+	Size   int64  `json:"size,omitempty"`
+}
+
+func WriteInstalledManifest(paths *Paths, manifestURL string, manifest *Manifest, artifacts map[string]InstalledArtifact) error {
+	record := InstalledManifest{
+		ManifestURL:     manifestURL,
+		ManifestVersion: manifest.Version,
+		RuneMCPVersion:  manifest.RuneMCPVersion,
+		RunedVersion:    manifest.RunedVersion,
+		Platform:        PlatformTuple(),
+		InstalledAt:     time.Now().UTC().Format(time.RFC3339),
+		Artifacts:       artifacts,
+	}
+	data, err := json.MarshalIndent(&record, "", "  ")
+	if err != nil {
+		return fmt.Errorf("installed.json: marshal: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(paths.InstalledManifest), 0o700); err != nil {
+		return fmt.Errorf("installed.json: mkdir parent: %w", err)
+	}
+
+	// Atomic write by writing to tmp then renaming
+	tmp, err := os.CreateTemp(filepath.Dir(paths.InstalledManifest), ".installed.json.*")
+	if err != nil {
+		return fmt.Errorf("installed.json: tmp: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("installed.json: write: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("installed.json: close: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		return fmt.Errorf("installed.json: chmod: %w", err)
+	}
+	if err := os.Rename(tmpName, paths.InstalledManifest); err != nil {
+		return fmt.Errorf("installed.json: rename: %w", err)
+	}
+	return nil
+}
+
+func ReadInstalledManifest(paths *Paths) (*InstalledManifest, error) {
+	data, err := os.ReadFile(paths.InstalledManifest)
+	if err != nil {
+		return nil, err
+	}
+
+	var record InstalledManifest
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, fmt.Errorf("installed.json: parse: %w", err)
+	}
+
+	return &record, nil
+}

--- a/internal/bootstrap/audit_test.go
+++ b/internal/bootstrap/audit_test.go
@@ -1,0 +1,126 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestWriteAndReadInstalledManifest_RoundTrip(t *testing.T) {
+	setRealms(t)
+
+	paths, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if err := paths.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	manifest := &Manifest{
+		Version:        1,
+		RuneMCPVersion: "v0.1.0",
+		RunedVersion:   "v0.1.0-alpha.1",
+	}
+
+	artifacts := map[string]InstalledArtifact{
+		StepRuned: {
+			URL:    "https://example/runed-linux-amd64",
+			SHA256: "aaa",
+			Path:   paths.RunedBinary,
+			Size:   12345,
+		},
+		StepRuneMCP: {
+			URL:    "https://example/rune-mcp-linux-amd64",
+			SHA256: "ccc",
+			Path:   paths.RuneMCPBinary,
+			Size:   67890,
+		},
+	}
+
+	if err := WriteInstalledManifest(paths, "https://example/manifest.json", manifest, artifacts); err != nil {
+		t.Fatalf("WriteInstalledManifest: %v", err)
+	}
+
+	info, err := os.Stat(paths.InstalledManifest)
+	if err != nil {
+		t.Fatalf("stat installed.json: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("mode = %v, want 0o600", perm)
+	}
+
+	got, err := ReadInstalledManifest(paths)
+	if err != nil {
+		t.Fatalf("ReadInstalledManifest: %v", err)
+	}
+	if got.ManifestURL != "https://example/manifest.json" {
+		t.Errorf("ManifestURL = %q", got.ManifestURL)
+	}
+	if got.ManifestVersion != 1 {
+		t.Errorf("ManifestVersion = %d", got.ManifestVersion)
+	}
+	if got.RuneMCPVersion != "v0.1.0" {
+		t.Errorf("RuneMCPVersion = %q", got.RuneMCPVersion)
+	}
+	if got.RunedVersion != "v0.1.0-alpha.1" {
+		t.Errorf("RunedVersion = %q", got.RunedVersion)
+	}
+	if got.Platform == "" {
+		t.Error("Platform empty; want <os>-<arch>")
+	}
+	if got.InstalledAt == "" {
+		t.Error("InstalledAt empty")
+	}
+	if len(got.Artifacts) != 2 {
+		t.Errorf("Artifacts: got %d, want 2", len(got.Artifacts))
+	}
+	if got.Artifacts[StepRuned].SHA256 != "aaa" {
+		t.Errorf("runed SHA256 = %q", got.Artifacts[StepRuned].SHA256)
+	}
+}
+
+func TestReadInstalledManifest_NotInstalled(t *testing.T) {
+	setRealms(t)
+	paths, _ := Resolve()
+
+	_, err := ReadInstalledManifest(paths)
+	if !os.IsNotExist(err) {
+		t.Errorf("err = %v, want os.IsNotExist (no install has run)", err)
+	}
+}
+
+func TestWriteInstalledManifest_OverwritesAtomically(t *testing.T) {
+	setRealms(t)
+	paths, _ := Resolve()
+	_ = paths.EnsureDirs()
+
+	// Initial installation
+	manifest := &Manifest{Version: 1}
+	first := map[string]InstalledArtifact{StepRuned: {URL: "u1", SHA256: "s1", Path: "/p1"}}
+	if err := WriteInstalledManifest(paths, "https://first", manifest, first); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update (or re-install)
+	second := map[string]InstalledArtifact{StepRuned: {URL: "u2", SHA256: "s2", Path: "/p2"}}
+	if err := WriteInstalledManifest(paths, "https://second", manifest, second); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(paths.InstalledManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got InstalledManifest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.ManifestURL != "https://second" {
+		t.Errorf("ManifestURL = %q, want second write to have won", got.ManifestURL)
+	}
+	if got.Artifacts[StepRuned].URL != "u2" {
+		t.Errorf("artifact URL = %q, want u2", got.Artifacts[StepRuned].URL)
+	}
+}

--- a/internal/bootstrap/install.go
+++ b/internal/bootstrap/install.go
@@ -126,6 +126,28 @@ func Install(ctx context.Context, opts InstallOptions) (*Result, error) {
 		logf("[%d/3] %s: installed at %s", stepNum, in.step, in.dest)
 	}
 
+	// Record install audit
+	auditArtifacts := make(map[string]InstalledArtifact, len(installs))
+	for _, in := range installs {
+		entry := InstalledArtifact{
+			URL:    in.spec.URL,
+			SHA256: in.spec.SHA256,
+			Path:   in.dest,
+			Size:   in.spec.Size,
+		}
+
+		if info, statErr := os.Stat(in.dest); statErr == nil {
+			entry.Size = info.Size()
+		}
+
+		auditArtifacts[in.step] = entry
+	}
+	if err := WriteInstalledManifest(paths, opts.ManifestURL, manifest, auditArtifacts); err != nil {
+		logf("warning: installed.json write failed: %v", err) // not fatal error
+	} else {
+		logf("audit: installed.json updated at %s", paths.InstalledManifest)
+	}
+
 	// Probe socket
 	if probeSocket(paths.RunedSocket) {
 		logf("probe: daemon already running at %s", paths.RunedSocket)

--- a/internal/bootstrap/paths.go
+++ b/internal/bootstrap/paths.go
@@ -35,10 +35,11 @@ const envManifest = "RUNE_MANIFEST"
 
 type Paths struct {
 	// Rune
-	RuneHome      string // ~/.rune
-	RuneBin       string // ~/.rune/bin
-	RuneMCPBinary string // ~/.rune/bin/rune-mcp
-	RuneConfig    string // ~/.rune/config.json
+	RuneHome          string // ~/.rune
+	RuneBin           string // ~/.rune/bin
+	RuneMCPBinary     string // ~/.rune/bin/rune-mcp
+	RuneConfig        string // ~/.rune/config.json
+	InstalledManifest string // ~/.rune/installed.json - install audit log
 
 	// Runed
 	RunedHome   string // ~/.runed
@@ -88,10 +89,11 @@ func newPaths(runeHome, runedHome string) *Paths {
 	runeBin := filepath.Join(runeHome, "bin")
 	runedBin := filepath.Join(runedHome, "bin")
 	return &Paths{
-		RuneHome:      runeHome,
-		RuneBin:       runeBin,
-		RuneMCPBinary: filepath.Join(runeBin, "rune-mcp"),
-		RuneConfig:    filepath.Join(runeHome, "config.json"),
+		RuneHome:          runeHome,
+		RuneBin:           runeBin,
+		RuneMCPBinary:     filepath.Join(runeBin, "rune-mcp"),
+		RuneConfig:        filepath.Join(runeHome, "config.json"),
+		InstalledManifest: filepath.Join(runeHome, "installed.json"),
 
 		RunedHome:   runedHome,
 		RunedBin:    runedBin,


### PR DESCRIPTION
## Summary

- What changed: TSIA.
- Why: Validate installed artifact is matched with manifest
- Scope:

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [ ] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [ ] No agent-specific script duplicates bootstrap/setup logic
- [ ] Agent-specific scripts remain thin adapters (registration/wiring only)
- [ ] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [ ] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [ ] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
