### PR TITLE
feat: support Tarball install and release with manifest

### DIFF
--- a/.github/workflows/release-rune-cli.yml
+++ b/.github/workflows/release-rune-cli.yml
@@ -71,13 +71,14 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.arch }}
+          MANIFEST_URL: https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/manifest.json
         run: |
           EXT=""
           if [ "${{ matrix.os }}" = "windows" ]; then EXT=".exe"; fi
           ASSET="rune-${{ matrix.os }}-${{ matrix.arch }}${EXT}"
           mkdir -p dist
           go build -trimpath \
-            -ldflags "-s -w -X main.runeVersion=${VERSION}" \
+            -ldflags "-s -w -X main.runeVersion=${VERSION} -X main.manifestURL=${MANIFEST_URL}" \
             -o "dist/${ASSET}" \
             ./cmd/rune
           ls -lh "dist/${ASSET}"
@@ -110,6 +111,8 @@ jobs:
     name: Publish prerelease
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # softprops/action-gh-release
     steps:
       - name: Resolve version
         id: version
@@ -123,8 +126,13 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.version.outputs.version }}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
         with:
           path: dist/
           merge-multiple: true
@@ -134,6 +142,96 @@ jobs:
           ls -lh dist/
           (cd dist && sha256sum rune-* > checksums.txt)
           cat dist/checksums.txt
+
+      - name: Generate manifest
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION:  ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          RUNE_MCP_VERSION=$(awk '/^rune_mcp_version:/ {print $2}' .release-pins.yaml)
+          RUNED_VERSION=$(awk    '/^runed_version:/    {print $2}' .release-pins.yaml)
+          if [ -z "${RUNE_MCP_VERSION:-}" ] || [ -z "${RUNED_VERSION:-}" ]; then
+            echo "::error::missing pin in .release-pins.yaml (rune_mcp_version=${RUNE_MCP_VERSION}, runed_version=${RUNED_VERSION})" >&2
+            exit 1
+          fi
+          echo "Pinning rune-mcp=${RUNE_MCP_VERSION}, runed=${RUNED_VERSION}"
+
+          mkdir -p _downstream/runed _downstream/rune-mcp
+
+          # runed
+          gh release download "${RUNED_VERSION}" \
+            --repo CryptoLabInc/runed \
+            --pattern '*.sha256' \
+            --dir _downstream/runed
+
+          # rune-mcp
+          gh release download "${RUNE_MCP_VERSION}" \
+            --repo CryptoLabInc/rune-mcp \
+            --pattern 'checksums.txt' \
+            --dir _downstream/rune-mcp
+
+          runed_sha() {
+            local os=$1 arch=$2
+            awk '{print $1}' "_downstream/runed/runed-${RUNED_VERSION}-${os}-${arch}.tar.gz.sha256"
+          }
+          runemcp_sha() {
+            local os=$1 arch=$2
+            awk -v f="rune-mcp-${os}-${arch}" '$2 == f {print $1}' "_downstream/rune-mcp/checksums.txt"
+          }
+
+          RUNED_BASE="https://github.com/CryptoLabInc/runed/releases/download/${RUNED_VERSION}"
+          MCP_BASE="https://github.com/CryptoLabInc/rune-mcp/releases/download/${RUNE_MCP_VERSION}"
+
+          mkdir -p dist
+          cat > dist/manifest.json <<EOF
+          {
+            "version": 1,
+            "rune_mcp_version": "${RUNE_MCP_VERSION}",
+            "runed_version": "${RUNED_VERSION}",
+            "platforms": {
+              "darwin-arm64": {
+                "runed": {
+                  "url":     "${RUNED_BASE}/runed-${RUNED_VERSION}-darwin-arm64.tar.gz",
+                  "sha256":  "$(runed_sha darwin arm64)",
+                  "extract": "tar.gz"
+                },
+                "rune_mcp": {
+                  "url":    "${MCP_BASE}/rune-mcp-darwin-arm64",
+                  "sha256": "$(runemcp_sha darwin arm64)"
+                }
+              },
+              "linux-amd64": {
+                "runed": {
+                  "url":     "${RUNED_BASE}/runed-${RUNED_VERSION}-linux-amd64.tar.gz",
+                  "sha256":  "$(runed_sha linux amd64)",
+                  "extract": "tar.gz"
+                },
+                "rune_mcp": {
+                  "url":    "${MCP_BASE}/rune-mcp-linux-amd64",
+                  "sha256": "$(runemcp_sha linux amd64)"
+                }
+              },
+              "linux-arm64": {
+                "runed": {
+                  "url":     "${RUNED_BASE}/runed-${RUNED_VERSION}-linux-arm64.tar.gz",
+                  "sha256":  "$(runed_sha linux arm64)",
+                  "extract": "tar.gz"
+                },
+                "rune_mcp": {
+                  "url":    "${MCP_BASE}/rune-mcp-linux-arm64",
+                  "sha256": "$(runemcp_sha linux arm64)"
+                }
+              }
+            }
+          }
+          EOF
+
+          # Validate JSON
+          jq . dist/manifest.json > /dev/null
+          cat dist/manifest.json
 
       - name: Publish prerelease
         if: github.event_name != 'workflow_dispatch' || !inputs.dry_run
@@ -149,5 +247,6 @@ jobs:
             dist/rune-darwin-arm64
             dist/rune-windows-amd64.exe
             dist/checksums.txt
+            dist/manifest.json
           fail_on_unmatched_files: true
           generate_release_notes: true

--- a/.release-pins.yaml
+++ b/.release-pins.yaml
@@ -1,0 +1,2 @@
+rune_mcp_version: v0.1.0-alpha.1
+runed_version: v0.1.0-alpha.2

--- a/cmd/rune/launch.go
+++ b/cmd/rune/launch.go
@@ -15,7 +15,7 @@ import (
 
 const gracefulShutdownGrace = 5 * time.Second
 
-func execInstalledBinary(ctx context.Context, binDir, name string, args []string, stderr io.Writer) int {
+func execInstalledBinary(ctx context.Context, binDir, name string, args []string, extraEnv []string, stderr io.Writer) int {
 	binPath := filepath.Join(binDir, name)
 
 	if _, err := os.Stat(binPath); err != nil {
@@ -30,6 +30,9 @@ func execInstalledBinary(ctx context.Context, binDir, name string, args []string
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
 	// Forward SIGTERM to the child instead of SIGKILL
 	cmd.Cancel = func() error {
 		return cmd.Process.Signal(syscall.SIGTERM)

--- a/cmd/rune/mcpserver.go
+++ b/cmd/rune/mcpserver.go
@@ -15,5 +15,5 @@ func runMCPServer(ctx context.Context, args []string, stderr io.Writer) int {
 		return 1
 	}
 
-	return execInstalledBinary(ctx, paths.RuneBin, "rune-mcp", args, stderr)
+	return execInstalledBinary(ctx, paths.RuneBin, "rune-mcp", args, nil, stderr)
 }

--- a/cmd/rune/runed.go
+++ b/cmd/rune/runed.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/CryptoLabInc/rune-cli/internal/bootstrap"
 	"github.com/CryptoLabInc/rune-cli/internal/supervisor"
@@ -23,9 +24,16 @@ func runRuned(ctx context.Context, args []string, stderr io.Writer) int {
 		return 1
 	}
 
+	// Point runed at the llama-server that `rune install` extracted from the
+	// runed full-stack tarball. Without this, runed would re-download
+	// llama-server from its own manifest. Set on the process env (rather
+	// than via execInstalledBinary's extraEnv) so the supervisor path's
+	// re-exec/setsid/fork chain also propagates it to the daemon's child.
+	_ = os.Setenv("RUNED_LLAMA_SERVER", paths.LlamaServer)
+
 	detach, forwardedArgs := extractDetachFlag(args)
 	if !detach {
-		return execInstalledBinary(ctx, paths.RunedBin, "runed", forwardedArgs, stderr)
+		return execInstalledBinary(ctx, paths.RunedBin, "runed", forwardedArgs, nil, stderr)
 	}
 
 	if err := paths.EnsureDirs(); err != nil {

--- a/internal/bootstrap/extract.go
+++ b/internal/bootstrap/extract.go
@@ -1,0 +1,92 @@
+package bootstrap
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Unapck tarPath into destDir
+func ExtractTarball(tarPath, destDir string) error {
+	f, err := os.Open(tarPath)
+	if err != nil {
+		return fmt.Errorf("extract: open %s: %w", tarPath, err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("extract: gzip %s: %w", tarPath, err)
+	}
+	defer gz.Close()
+
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("extract: mkdir %s: %w", destDir, err)
+	}
+
+	destAbs, err := filepath.Abs(destDir)
+	if err != nil {
+		return fmt.Errorf("extract: abs %s: %w", destDir, err)
+	}
+
+	tr := tar.NewReader(gz)
+	for {
+		h, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("extract: read entry: %w", err)
+		}
+
+		target, err := safeJoin(destAbs, h.Name) // check path-traversal safety
+		if err != nil {
+			return err
+		}
+
+		switch h.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("extract: mkdir %s: %w", target, err)
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("extract: mkdir parent of %s: %w", target, err)
+			}
+
+			mode := os.FileMode(h.Mode) & 0o755
+			if mode == 0 {
+				mode = 0o644
+			}
+
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+			if err != nil {
+				return fmt.Errorf("extract: open %s: %w", target, err)
+			}
+
+			if _, err := io.Copy(out, tr); err != nil {
+				_ = out.Close()
+				return fmt.Errorf("extract: write %s: %w", target, err)
+			}
+
+			if err := out.Close(); err != nil {
+				return fmt.Errorf("extract: close %s: %w", target, err)
+			}
+		default:
+			// non-regular binareis (symlink, devices, etc) are skipped
+		}
+	}
+}
+
+func safeJoin(destAbs, name string) (string, error) {
+	path := filepath.FromSlash(name)
+	if !filepath.IsLocal(path) {
+		return "", fmt.Errorf("extract: non-local entry path %q not allowed", name)
+	}
+
+	return filepath.Join(destAbs, path), nil
+}

--- a/internal/bootstrap/extract_test.go
+++ b/internal/bootstrap/extract_test.go
@@ -1,0 +1,110 @@
+package bootstrap
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func makeTarball(t *testing.T, path string, files map[string]struct {
+	body []byte
+	mode int64
+}) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	for name, f := range files {
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     name,
+			Mode:     f.mode,
+			Size:     int64(len(f.body)),
+			Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatalf("tar header: %v", err)
+		}
+
+		if _, err := tw.Write(f.body); err != nil {
+			t.Fatalf("tar write: %v", err)
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gz close: %v", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write tarball: %v", err)
+	}
+}
+
+func TestExtractTarball_RunedStackLayout(t *testing.T) {
+	dir := t.TempDir()
+	tarPath := filepath.Join(dir, "runed-test.tar.gz")
+	dest := filepath.Join(dir, "out")
+
+	makeTarball(t, tarPath, map[string]struct {
+		body []byte
+		mode int64
+	}{
+		"runed":        {body: []byte("RUNED-BIN"), mode: 0o755},
+		"llama-server": {body: []byte("LLAMA-BIN"), mode: 0o755},
+	})
+
+	if err := ExtractTarball(tarPath, dest); err != nil {
+		t.Fatalf("ExtractTarball: %v", err)
+	}
+
+	for _, name := range []string{"runed", "llama-server"} {
+		p := filepath.Join(dest, name)
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Errorf("expected %s extracted: %v", name, err)
+			continue
+		}
+
+		if mode := info.Mode().Perm(); mode&0o100 == 0 {
+			t.Errorf("%s mode = %v, want executable bit set", name, mode)
+		}
+	}
+}
+
+func TestExtractTarball_RejectsPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	tarPath := filepath.Join(dir, "malicious.tar.gz")
+
+	makeTarball(t, tarPath, map[string]struct {
+		body []byte
+		mode int64
+	}{
+		"../escaped": {body: []byte("OUT"), mode: 0o644},
+	})
+
+	err := ExtractTarball(tarPath, filepath.Join(dir, "out"))
+	if err == nil {
+		t.Fatal("expected error for ../ entry, got nil")
+	}
+}
+
+func TestExtractTarball_RejectsAbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	tarPath := filepath.Join(dir, "abs.tar.gz")
+
+	makeTarball(t, tarPath, map[string]struct {
+		body []byte
+		mode int64
+	}{
+		"/etc/passwd": {body: []byte("OUT"), mode: 0o644},
+	})
+
+	if err := ExtractTarball(tarPath, filepath.Join(dir, "out")); err == nil {
+		t.Fatal("expected error for absolute entry path, got nil")
+	}
+}

--- a/internal/bootstrap/install.go
+++ b/internal/bootstrap/install.go
@@ -108,15 +108,10 @@ func Install(ctx context.Context, opts InstallOptions) (*Result, error) {
 		}
 
 		logf("[%d/3] %s (%d bytes): downloading...", stepNum, in.step, in.spec.Size)
-		if err := DownloadAndVerify(ctx, in.spec, in.dest, opts.Progress); err != nil {
+		if err := installArtifact(ctx, paths, in.spec, in.dest, opts.Progress); err != nil {
 			r.Failed[in.step] = err.Error()
 			r.Status = "partial"
 			return r, err
-		}
-		if err := os.Chmod(in.dest, binaryMode); err != nil {
-			r.Failed[in.step] = err.Error()
-			r.Status = "partial"
-			return r, fmt.Errorf("install: chmod %s: %w", in.dest, err)
 		}
 
 		r.Completed = append(r.Completed, in.step)
@@ -180,6 +175,46 @@ func onlySkipped(r *Result) bool {
 		}
 	}
 	return len(r.Skipped) > 0
+}
+
+// spec.Extract == ""      : raw binaries are downloaded directly to dest
+// spec.Extract == "tar.gz": archive is extracted into dest
+// Others treat as error
+func installArtifact(ctx context.Context, paths *Paths, spec ArtifactSpec, dest string, progress ProgressFunc) error {
+	switch spec.Extract {
+	case "": // raw binaries
+		if err := DownloadAndVerify(ctx, spec, dest, progress); err != nil {
+			return err
+		}
+		if err := os.Chmod(dest, binaryMode); err != nil {
+			return fmt.Errorf("install: chmod %s: %w", dest, err)
+		}
+
+		return nil
+	case "tar.gz": // Tarball archive
+		// Download archive under paths.Cache first
+		tarPath := filepath.Join(paths.Cache, filepath.Base(dest)+".tar.gz")
+		if err := DownloadAndVerify(ctx, spec, tarPath, progress); err != nil {
+			return err
+		}
+		defer os.Remove(tarPath)
+
+		// Extract to destDir
+		destDir := filepath.Dir(dest)
+		if err := ExtractTarball(tarPath, destDir); err != nil {
+			return fmt.Errorf("install: extract %s into %s: %w", tarPath, destDir, err)
+		}
+		if !fileExists(dest) {
+			return fmt.Errorf("install: tarball did not have expected file at %s", dest)
+		}
+		if err := os.Chmod(dest, binaryMode); err != nil {
+			return fmt.Errorf("install: chmod %s: %w", dest, err)
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("install: unsupported extract type %q", spec.Extract)
+	}
 }
 
 func probeSocket(path string) bool {

--- a/internal/bootstrap/manifest.go
+++ b/internal/bootstrap/manifest.go
@@ -43,9 +43,10 @@ type PlatformArtifacts struct {
 }
 
 type ArtifactSpec struct {
-	URL    string `json:"url"`
-	SHA256 string `json:"sha256"`
-	Size   int64  `json:"size,omitempty"` // optional; used for progress UX and sanity check
+	URL     string `json:"url"`
+	SHA256  string `json:"sha256"`
+	Size    int64  `json:"size,omitempty"`    // optional; used for progress UX and sanity check
+	Extract string `json:"extract,omitempty"` // "" = raw binary, "tar.gz" = extract tarball
 }
 
 var (

--- a/internal/bootstrap/paths.go
+++ b/internal/bootstrap/paths.go
@@ -50,6 +50,7 @@ type Paths struct {
 	RunedLock      string // ~/.runed/spawn.lock
 	RunedLogs      string // ~/.runed/logs
 	RunedBinary    string // ~/.runed/bin/runed
+	LlamaServer    string // ~/.runed/bin/llama-server (extracted from runed tarball; RUNED_LLAMA_SERVER env points here)
 	InstallLock    string // ~/.runed/install.lock
 	SupervisorLock string // ~/.runed/supervisor.lock (`rune runed --detach` hold it during lifetime)
 	DaemonLog      string // ~/.runed/logs/daemon.log
@@ -105,6 +106,7 @@ func newPaths(runeHome, runedHome string) *Paths {
 		RunedLock:      filepath.Join(runedHome, "spawn.lock"),
 		RunedLogs:      filepath.Join(runedHome, "logs"),
 		RunedBinary:    filepath.Join(runedBin, "runed"),
+		LlamaServer:    filepath.Join(runedBin, "llama-server"),
 		InstallLock:    filepath.Join(runedHome, "install.lock"),
 		SupervisorLock: filepath.Join(runedHome, "supervisor.lock"),
 		DaemonLog:      filepath.Join(runedHome, "logs", "daemon.log"),


### PR DESCRIPTION
## Summary

- What changed:
  - Tarball installation support
  - Release with manifest.json
- Why: Release
- Scope:

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [ ] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [ ] No agent-specific script duplicates bootstrap/setup logic
- [ ] Agent-specific scripts remain thin adapters (registration/wiring only)
- [ ] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [ ] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [ ] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
