### PR TITLE
refactor: add release-ci safe guard and update docs for better UX

### DIFF
--- a/.github/workflows/release-rune-cli.yml
+++ b/.github/workflows/release-rune-cli.yml
@@ -143,6 +143,34 @@ jobs:
           (cd dist && sha256sum rune-* > checksums.txt)
           cat dist/checksums.txt
 
+      - name: Verify pinned releases existency
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          RUNE_MCP_VERSION=$(awk '/^rune_mcp_version:/ {print $2}' .release-pins.yaml)
+          RUNED_VERSION=$(awk    '/^runed_version:/    {print $2}' .release-pins.yaml)
+          if [ -z "${RUNE_MCP_VERSION:-}" ] || [ -z "${RUNED_VERSION:-}" ]; then
+            echo "::error::missing pin in .release-pins.yaml (rune_mcp_version=${RUNE_MCP_VERSION:-}, runed_version=${RUNED_VERSION:-})" >&2
+            exit 1
+          fi
+          echo "Checking pinned releases: rune-mcp=${RUNE_MCP_VERSION}, runed=${RUNED_VERSION}"
+
+          fail=0
+          if ! gh release view "${RUNE_MCP_VERSION}" --repo CryptoLabInc/rune-mcp >/dev/null 2>&1; then
+            echo "::error::rune-mcp ${RUNE_MCP_VERSION} (pinned in .release-pins.yaml) is not published. Release it before tagging rune, or bump the pin." >&2
+            fail=1
+          fi
+          if ! gh release view "${RUNED_VERSION}" --repo CryptoLabInc/runed >/dev/null 2>&1; then
+            echo "::error::runed ${RUNED_VERSION} (pinned in .release-pins.yaml) is not published. Release it before tagging rune, or bump the pin." >&2
+            fail=1
+          fi
+          
+          [ "$fail" -eq 0 ] || exit 1
+          echo "Both pinned releases are published."
+
       - name: Generate manifest
         shell: bash
         env:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You'll need from your team admin:
 
 That's all. enVector Cloud credentials are delivered automatically via the Vault bundle. On a fresh machine, `/rune:configure` also handles binary download and daemon setup in the same step.
 
-Don't have these? See [rune-admin](https://github.com/CryptoLabInc/rune-admin) for deployment, or [examples/team-setup-example.md](examples/team-setup-example.md) for a walkthrough.
+Don't have these? See [rune-admin](https://github.com/CryptoLabInc/rune-admin) for deployment, [setup/check-prerequisites.md](setup/check-prerequisites.md) for the full prerequisite checklist, or [examples/team-setup-example.md](examples/team-setup-example.md) for a walkthrough.
 
 ### That's It
 

--- a/bin/rune
+++ b/bin/rune
@@ -15,7 +15,6 @@
 # from WSL or Git Bash, where `uname -s` returns MSYS_NT-* or MINGW64_NT-*
 set -euo pipefail
 
-RUNE_VERSION="${RUNE_VERSION:-v0.4.0}"
 RUNE_HOME="${RUNE_HOME:-$HOME/.rune}"
 TARGET="$RUNE_HOME/bin/rune"
 
@@ -34,6 +33,34 @@ case "${1:-}" in
     exit 127
     ;;
 esac
+
+# Priority: RUNE_VERSION > latest release (including pre-release for now)
+# TODO: switch to .../rune/releases/latest
+RUNE_VERSION="${RUNE_VERSION:-}"
+if [ -z "$RUNE_VERSION" ]; then
+  echo "rune: resolving latest release..." >&2
+  api="https://api.github.com/repos/CryptoLabInc/rune/releases?per_page=1"
+
+  # Use token if exist
+  token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+  if [ -n "$token" ]; then
+    body="$(curl --fail --silent --show-error --location \
+      --header "Authorization: Bearer $token" "$api" || true)"
+  else
+    body="$(curl --fail --silent --show-error --location "$api" || true)"
+  fi
+
+  RUNE_VERSION="$(printf '%s' "$body" \
+    | grep -m1 '"tag_name"' \
+    | sed 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/' \
+    || true)"
+fi
+
+if [ -z "$RUNE_VERSION" ]; then
+  echo "rune: cannot determine the latest release" >&2
+  echo "      Pin it explicitly, e.g.: RUNE_VERSION=v0.4.0 ${CLAUDE_PLUGIN_ROOT:-.}/bin/rune install" >&2
+  exit 1
+fi
 
 # Map (OS, arch) to release asset name
 case "$(uname -s)-$(uname -m)" in

--- a/commands/claude/configure.md
+++ b/commands/claude/configure.md
@@ -84,20 +84,33 @@ Issue a SINGLE `AskUserQuestion` with three bundled questions. The tool
 accepts 1–4 questions per call; bundling saves 2 turns + ~50k cache_read
 tokens per separated call.
 
-Questions:
+**Mental model**: the user comes in with an admin-issued endpoint, an
+`evt_...` token, and (for self-signed) a `ca.pem` - all from their Vault
+admin. The agent's job is to collect and format-check those values, NOT to
+invent `localhost` defaults. Give each question exactly two paths: "I have
+it (paste below)" or "I don't have it yet (stop)".
 
-1. **Vault Endpoint** (required, format: `tcp://<host>:50051`).
-   Auto-prepend `tcp://` if the user omits the scheme.
+Questions (use this exact option intent - do not synthesize `tcp://localhost`-style defaults):
+
+1. **Vault Endpoint** (required, format: `tcp://<host>:50051`; auto-prepend `tcp://` if the scheme is omitted).
+   - "Paste endpoint below":  paste the `tcp://host:port` value from your admin into the Other field.
+   - "I don't have one yet": stop; request the endpoint from your Vault admin first.
 2. **Vault Token** (required, format: `evt_xxx...`).
+   - "Paste token below": paste the `evt_...` token from your admin.
+   - "I don't have one yet": stop; request a token from your Vault admin first.
 3. **TLS Mode**:
-   - `self-signed` — team uses a self-signed CA (Recommended).
-   - `public_ca` — Let's Encrypt etc.; system CA pool handles verification.
-   - `no_tls` — local dev only; Vault must also be running with
-     `server.grpc.tls.disable: true`. Warn if selected.
+   - `self-signed`: team uses a self-signed CA (Recommended).
+   - `public_ca`: Let's Encrypt etc.; system CA pool handles verification.
+   - `no_tls`: local dev only; Vault must also be running with `server.grpc.tls.disable: true`. Warn if selected.
 
-**If `self-signed` was chosen**: follow-up `AskUserQuestion` with the
-single question "Path to CA certificate PEM file:" (one question, one turn).
+**If `self-signed` was chosen**: follow-up `AskUserQuestion` with the single
+question "Path to CA certificate PEM file:" - offer "Paste path below"
+(`~` expansion supported) and "I don't have it yet" (stop; request `ca.pem` from your admin).
 Otherwise skip the follow-up.
+
+**On any "I don't have it yet" answer**: stop the flow immediately.
+Tell the user exactly what to request from their Vault admin (endpoint / `evt_...` token / `ca.pem`),
+point them at `setup/check-prerequisites.md`, and exit **without writing any files** - do not call `mcp__rune__configure`.
 
 Resulting argument mapping for the configure call:
 


### PR DESCRIPTION
## Summary

- What changed:
  - Verify pinned releases before release
  - Update plugin skill and readme
  - For the first run, resolve latest release tag at runtime rather than fixed tag
- Why: Better user experience
- Scope:

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [ ] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [ ] No agent-specific script duplicates bootstrap/setup logic
- [ ] Agent-specific scripts remain thin adapters (registration/wiring only)
- [ ] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [ ] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [ ] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
