### PR TITLE
fix(mcp): bootstrap rune-mcp on first MCP spawn (no manual reconnect)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,7 +15,8 @@
     "rune": {
       "command": "${CLAUDE_PLUGIN_ROOT}/bin/rune",
       "args": ["mcp-server"],
-      "description": "Rune MCP server entry point. Routes through the always-present bin/rune bootstrap (the CLI's documented 'mcp-server' entry point) so a fresh install self-heals: on first spawn it installs the CLI + rune-mcp if missing, then forwards stdio to ~/.rune/bin/rune-mcp, which boots dormant until /rune:configure. No manual /mcp reconnect needed."
+      "timeout": 30000,
+      "description": "Rune MCP server (talks to Vault + embedder + enVector). The command is the plugin's bash wrapper, which always exists at session start; on first run it self-install rune-mcp, then exec - MCP server comes online in the same session with no restart."
     }
   }
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -13,8 +13,9 @@
   ],
   "mcpServers": {
     "rune": {
-      "command": "${HOME}/.rune/bin/rune-mcp",
-      "description": "Rune MCP server (talks to Vault + embedder + enVector). Populated by '${CLAUDE_PLUGIN_ROOT}/bin/rune install'; before that, this path doesn't exist and the spawn fails - which the skill markdown catches and recovers from"
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/rune",
+      "args": ["mcp-server"],
+      "description": "Rune MCP server entry point. Routes through the always-present bin/rune bootstrap (the CLI's documented 'mcp-server' entry point) so a fresh install self-heals: on first spawn it installs the CLI + rune-mcp if missing, then forwards stdio to ~/.rune/bin/rune-mcp, which boots dormant until /rune:configure. No manual /mcp reconnect needed."
     }
   }
 }

--- a/bin/rune
+++ b/bin/rune
@@ -10,7 +10,7 @@
 #   - When ~/.rune/bin/rune is missing: `install` and `mcp-server` are
 #     accepted as bootstrap entry points (mcp-server self-installs the
 #     CLI + rune-mcp first, so a fresh plugin install boots without a
-#     manual /mcp reconnect)
+#     manual /mcp reconnect or session restart)
 #
 # Windows support: this wrapper is bash-only. Native Windows shells
 # (PowerShell / cmd) cannot execute this. Windows users must invoke it
@@ -20,14 +20,8 @@ set -euo pipefail
 RUNE_HOME="${RUNE_HOME:-$HOME/.rune}"
 TARGET="$RUNE_HOME/bin/rune"
 
-# Delegate to ~/.rune/bin/rune
+# Delegate to ~/.rune/bin/rune immediately
 if [ -x "$TARGET" ]; then
-  # MCP entry point: ensure rune-mcp is also present before forwarding.
-  # A partial install (CLI present, rune-mcp missing) would otherwise fail
-  # the spawn. Install output goes to stderr — stdout is the MCP channel.
-  if [ "${1:-}" = "mcp-server" ] && [ ! -x "$RUNE_HOME/bin/rune-mcp" ]; then
-    "$TARGET" install >&2 || true
-  fi
   exec "$TARGET" "$@"
 fi
 
@@ -45,6 +39,42 @@ case "${1:-}" in
     ;;
 esac
 
+# Concurrency-safe CLI download
+mkdir -p "$RUNE_HOME"
+LOCK_DIR="$RUNE_HOME/bootstrap.lock.d"
+TMP=""
+SUMS=""
+cleanup() {
+  [ -n "$TMP" ] && rm -f "$TMP"
+  [ -n "$SUMS" ] && rm -f "$SUMS"
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+}
+
+waited=0
+while ! mkdir "$LOCK_DIR" 2>/dev/null; do # another session hold lock
+  if [ -x "$TARGET" ]; then
+    exec "$TARGET" "$@"   # bootstrap finished
+  fi
+
+  sleep 1
+  waited=$((waited + 1))
+  if [ "$waited" -ge 120 ]; then
+    echo "rune: bootstrap lock held >120s, reclaiming" >&2
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+    waited=0
+  fi
+done
+
+# Check error
+trap cleanup EXIT INT TERM
+
+if [ -x "$TARGET" ]; then
+  cleanup
+  trap - EXIT INT TERM
+  exec "$TARGET" "$@"
+fi
+
+# Lazy version evaluation
 # Priority: RUNE_VERSION > latest release (including pre-release for now)
 # TODO: switch to .../rune/releases/latest
 RUNE_VERSION="${RUNE_VERSION:-}"
@@ -96,7 +126,6 @@ mkdir -p "$(dirname "$TARGET")"
 # Download and verify
 TMP="$(mktemp -t rune-bootstrap-XXXXXX)"
 SUMS="$(mktemp -t rune-bootstrap-sums-XXXXXX)"
-trap 'rm -f "$TMP" "$SUMS"' EXIT
 
 curl --fail --silent --show-error --location "$RELEASE_BASE/$ASSET"        -o "$TMP"
 curl --fail --silent --show-error --location "$RELEASE_BASE/checksums.txt" -o "$SUMS"
@@ -120,16 +149,12 @@ if [ "$ACTUAL" != "$EXPECTED" ]; then
   exit 1
 fi
 
-# Post-download
+# Atomic publish
 chmod +x "$TMP"
 mv -f "$TMP" "$TARGET"
-
-# If we bootstrapped via the `mcp-server` entry point, the rune-mcp binary
-# must also exist before we can forward stdio to it — install it now.
-# (stderr, not stdout: stdout becomes the MCP channel after exec.)
-if [ "${1:-}" = "mcp-server" ] && [ ! -x "$RUNE_HOME/bin/rune-mcp" ]; then
-  "$TARGET" install >&2 || { echo "rune: mcp-server bootstrap (install) failed" >&2; exit 127; }
-fi
+TMP=""
 
 # Delegate to the freshly-installed Go binary
+cleanup
+trap - EXIT INT TERM
 exec "$TARGET" "$@"

--- a/bin/rune
+++ b/bin/rune
@@ -7,8 +7,10 @@
 # Subcommand surface:
 #   - When ~/.rune/bin/rune already exists: delegates ALL subcommands
 #     unchanged (safety guard)
-#   - When ~/.rune/bin/rune is missing: only `install` is accepted as
-#     the bootstrap entry point
+#   - When ~/.rune/bin/rune is missing: `install` and `mcp-server` are
+#     accepted as bootstrap entry points (mcp-server self-installs the
+#     CLI + rune-mcp first, so a fresh plugin install boots without a
+#     manual /mcp reconnect)
 #
 # Windows support: this wrapper is bash-only. Native Windows shells
 # (PowerShell / cmd) cannot execute this. Windows users must invoke it
@@ -20,12 +22,21 @@ TARGET="$RUNE_HOME/bin/rune"
 
 # Delegate to ~/.rune/bin/rune
 if [ -x "$TARGET" ]; then
+  # MCP entry point: ensure rune-mcp is also present before forwarding.
+  # A partial install (CLI present, rune-mcp missing) would otherwise fail
+  # the spawn. Install output goes to stderr — stdout is the MCP channel.
+  if [ "${1:-}" = "mcp-server" ] && [ ! -x "$RUNE_HOME/bin/rune-mcp" ]; then
+    "$TARGET" install >&2 || true
+  fi
   exec "$TARGET" "$@"
 fi
 
 # Bootstrap path (~/.rune/bin/rune missing)
+# `mcp-server` is accepted here too (not just `install`): it is the plugin
+# manifest's spawn-time entry point, so a fresh install must self-heal
+# instead of failing the MCP spawn (which would force a manual /mcp reconnect).
 case "${1:-}" in
-  install)
+  install|mcp-server)
     ;;
   *)
     echo "rune: rune is not fully configured yet." >&2
@@ -112,6 +123,13 @@ fi
 # Post-download
 chmod +x "$TMP"
 mv -f "$TMP" "$TARGET"
+
+# If we bootstrapped via the `mcp-server` entry point, the rune-mcp binary
+# must also exist before we can forward stdio to it — install it now.
+# (stderr, not stdout: stdout becomes the MCP channel after exec.)
+if [ "${1:-}" = "mcp-server" ] && [ ! -x "$RUNE_HOME/bin/rune-mcp" ]; then
+  "$TARGET" install >&2 || { echo "rune: mcp-server bootstrap (install) failed" >&2; exit 127; }
+fi
 
 # Delegate to the freshly-installed Go binary
 exec "$TARGET" "$@"

--- a/cmd/rune/mcpserver.go
+++ b/cmd/rune/mcpserver.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"time"
 
 	"github.com/CryptoLabInc/rune-cli/internal/bootstrap"
 )
@@ -15,5 +17,59 @@ func runMCPServer(ctx context.Context, args []string, stderr io.Writer) int {
 		return 1
 	}
 
+	// Fresh `claude plugin install rune` try to spawn MCP server via
+	// "${CLAUDE_PLUGIN_ROOT}/bin/rune mcp-server" which does not exist yet.
+	// Self-install rune-mcp itself in this case.
+	if _, statErr := os.Stat(paths.RuneMCPBinary); statErr != nil {
+		fmt.Fprintln(stderr, "rune: rune-mcp not installed yet; fetching before launch...")
+		manifest := manifestURL
+		if env := os.Getenv("RUNE_MANIFEST"); env != "" {
+			manifest = env
+		}
+
+		// Concurrency-safe install
+		_, instErr := bootstrap.Install(ctx, bootstrap.InstallOptions{
+			ManifestURL: manifest,
+			Target:      []string{bootstrap.StepRuneMCP},
+			Log: func(format string, a ...any) {
+				fmt.Fprintf(stderr, format+"\n", a...)
+			},
+		})
+		if instErr != nil {
+			// Sessions which do not invoke install wait here
+			if !waitForFile(ctx, paths.RuneMCPBinary, bootstrap.InstallLockTimeout) {
+				fmt.Fprintf(stderr, "rune: failed to install rune-mcp: %v\n", instErr)
+				return 1
+			}
+
+			fmt.Fprintln(stderr, "rune: rune-mcp installed by a concurrent session")
+		}
+	}
+
 	return execInstalledBinary(ctx, paths.RuneBin, "rune-mcp", args, nil, stderr)
+}
+
+func waitForFile(ctx context.Context, path string, timeout time.Duration) bool {
+	if _, err := os.Stat(path); err == nil {
+		return true
+	}
+
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+
+	tick := time.NewTicker(300 * time.Millisecond)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-deadline.C:
+			return false
+		case <-tick.C:
+			if _, err := os.Stat(path); err == nil {
+				return true
+			}
+		}
+	}
 }

--- a/internal/bootstrap/install.go
+++ b/internal/bootstrap/install.go
@@ -6,12 +6,14 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 )
 
 type InstallOptions struct {
 	ManifestURL string
-	Force       bool // `rune install --force` to force re-download
+	Force       bool     // `rune install --force` to force re-download
+	Target      []string // empty = all; StepRuneMCP | StepRuned
 	Progress    ProgressFunc
 	Log         func(format string, args ...any)
 }
@@ -66,8 +68,14 @@ func Install(ctx context.Context, opts InstallOptions) (*Result, error) {
 		Installed: map[string]ArtifactInfo{},
 	}
 
+	// Total step count
+	total := 3 // all steps
+	if len(opts.Target) > 0 {
+		total = 1 + len(opts.Target) // manifest + num artifacts
+	}
+
 	// Fetch manifest
-	logf("[1/3] manifest: fetching from %s", opts.ManifestURL)
+	logf("[1/%d] manifest: fetching from %s", total, opts.ManifestURL)
 	manifest, err := FetchManifest(ctx, opts.ManifestURL)
 	if err != nil {
 		r.Failed[StepManifest] = err.Error()
@@ -75,7 +83,7 @@ func Install(ctx context.Context, opts InstallOptions) (*Result, error) {
 		return r, err
 	}
 	r.Completed = append(r.Completed, StepManifest)
-	logf("[1/3] manifest: ok (rune-mcp %s, runed %s)", manifest.RuneMCPVersion, manifest.RunedVersion)
+	logf("[1/%d] manifest: ok (rune-mcp %s, runed %s)", total, manifest.RuneMCPVersion, manifest.RunedVersion)
 
 	artifacts, err := manifest.ArtifactsForCurrentPlatform()
 	if err != nil {
@@ -95,11 +103,18 @@ func Install(ctx context.Context, opts InstallOptions) (*Result, error) {
 		{StepRuneMCP, artifacts.RuneMCP, paths.RuneMCPBinary},
 	}
 
+	// Filter install target
+	if len(opts.Target) > 0 {
+		installs = slices.DeleteFunc(installs, func(in install) bool {
+			return !slices.Contains(opts.Target, in.step)
+		})
+	}
+
 	for i, in := range installs {
-		stepNum := i + 2 // starting from [2/3]
+		stepNum := i + 2 // step 1: manifest
 		if !opts.Force {
 			if fileExists(in.dest) {
-				logf("[%d/3] %s: skipped (already at %s)", stepNum, in.step, in.dest)
+				logf("[%d/%d] %s: skipped (already at %s)", stepNum, total, in.step, in.dest)
 				r.Completed = append(r.Completed, in.step)
 				r.Skipped = append(r.Skipped, in.step)
 
@@ -107,7 +122,7 @@ func Install(ctx context.Context, opts InstallOptions) (*Result, error) {
 			}
 		}
 
-		logf("[%d/3] %s (%d bytes): downloading...", stepNum, in.step, in.spec.Size)
+		logf("[%d/%d] %s (%d bytes): downloading...", stepNum, total, in.step, in.spec.Size)
 		if err := installArtifact(ctx, paths, in.spec, in.dest, opts.Progress); err != nil {
 			r.Failed[in.step] = err.Error()
 			r.Status = "partial"
@@ -118,29 +133,32 @@ func Install(ctx context.Context, opts InstallOptions) (*Result, error) {
 		if info, statErr := os.Stat(in.dest); statErr == nil {
 			r.Installed[filepath.Base(in.dest)] = ArtifactInfo{Path: in.dest, Size: info.Size()}
 		}
-		logf("[%d/3] %s: installed at %s", stepNum, in.step, in.dest)
+		logf("[%d/%d] %s: installed at %s", stepNum, total, in.step, in.dest)
 	}
 
-	// Record install audit
-	auditArtifacts := make(map[string]InstalledArtifact, len(installs))
-	for _, in := range installs {
-		entry := InstalledArtifact{
-			URL:    in.spec.URL,
-			SHA256: in.spec.SHA256,
-			Path:   in.dest,
-			Size:   in.spec.Size,
+	// Record install audit is only available with full `rune install` (no not allow partial record)
+	if len(opts.Target) == 0 {
+		auditArtifacts := make(map[string]InstalledArtifact, len(installs))
+		for _, in := range installs {
+			entry := InstalledArtifact{
+				URL:    in.spec.URL,
+				SHA256: in.spec.SHA256,
+				Path:   in.dest,
+				Size:   in.spec.Size,
+			}
+
+			if info, statErr := os.Stat(in.dest); statErr == nil {
+				entry.Size = info.Size()
+			}
+
+			auditArtifacts[in.step] = entry
 		}
 
-		if info, statErr := os.Stat(in.dest); statErr == nil {
-			entry.Size = info.Size()
+		if err := WriteInstalledManifest(paths, opts.ManifestURL, manifest, auditArtifacts); err != nil {
+			logf("warning: installed.json write failed: %v", err) // not fatal error
+		} else {
+			logf("audit: installed.json updated at %s", paths.InstalledManifest)
 		}
-
-		auditArtifacts[in.step] = entry
-	}
-	if err := WriteInstalledManifest(paths, opts.ManifestURL, manifest, auditArtifacts); err != nil {
-		logf("warning: installed.json write failed: %v", err) // not fatal error
-	} else {
-		logf("audit: installed.json updated at %s", paths.InstalledManifest)
 	}
 
 	// Probe socket


### PR DESCRIPTION
## Summary
On a fresh `plugin install rune`, the MCP server shows failed in `/mcp` and the user must manually reconnect.

`mcpServers.rune.command` pointed directly at `~/.rune/bin/rune-mcp`, which only exists after `/rune:configure`. Claude Code spawns the stdio MCP server once at session startup, so the binary is missing -> ENOENT ->  failed. 

The agent can't reconnect it programmatically, so a manual `/mcp` reconnect is forced.

## Fix
Route the manifest command through the always-present `bin/rune` bootstrap via the CLI's documented `mcp-server` entry point, and accept `mcp-server` in the bootstrap path: on first spawn it installs the CLI + rune-mcp if missing, then forwards stdio to rune-mcp (which boots dormant until `/rune:configure`). No manual reconnect needed.

- `plugin.json`: command → `${CLAUDE_PLUGIN_ROOT}/bin/rune`, args `["mcp-server"]`
- `bin/rune`: accept `mcp-server`; install rune-mcp before forwarding
