### PR TITLE
refactor: minor updates for robustness on v0.4.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,12 +138,12 @@ Feature requests should include:
 
 Use this checklist for any integration/setup/runtime change:
 
-- [ ] The Go binary at `cmd/rune-mcp/` remains the single MCP server entry point — no per-agent server process
+- [ ] The rune CLI (`cmd/rune`, `mcp-server` subcommand) forwards to the single rune-mcp binary — no per-agent server process
 - [ ] Agent-specific scripts stay thin adapters (registration/wiring only)
 - [ ] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
 - [ ] Claude/Gemini/OpenAI instructions do not include Codex-only commands
 - [ ] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` remain consistent on common vs agent-specific boundaries
-- [ ] Plugin manifests (`.claude-plugin/plugin.json`, `gemini-extension.json`) point at the same Go binary command path
+- [ ] The plugin manifest (`.claude-plugin/plugin.json`) spawns `${CLAUDE_PLUGIN_ROOT}/bin/rune mcp-server`
 
 ### Manual Testing Checklist
 
@@ -265,11 +265,10 @@ rune/
 ├── CONTRIBUTING.md              # This file
 ├── LICENSE                      # Apache License 2.0
 ├── go.mod / go.sum              # Go module pin (toolchain + deps)
-├── package.json                 # Package metadata (version source)
+├── package.json                 # Package metadata (private; not the version source)
 ├── .claude-plugin/
-│   ├── plugin.json              # Claude Code plugin manifest (points at bin/rune-mcp)
+│   ├── plugin.json              # Claude Code plugin manifest (spawns bin/rune mcp-server)
 │   └── marketplace.json         # Marketplace listing
-├── gemini-extension.json        # Gemini CLI extension manifest
 ├── hooks/
 │   └── hooks.json               # Gemini lifecycle hooks
 ├── cmd/
@@ -306,17 +305,16 @@ rune/
 
 - **CLAUDE.md**: Claude Code project guidelines
 - **GEMINI.md**: Gemini CLI context file
-- **.claude-plugin/plugin.json**: Claude Code plugin manifest (points at `${CLAUDE_PLUGIN_ROOT}/bin/rune-mcp`)
-- **gemini-extension.json**: Gemini CLI extension manifest
-- **cmd/rune-mcp/main.go**: MCP server entry point — wires services + boot loop + slog
-- **internal/lifecycle/boot.go**: Boot loop (Vault dial → EncKey → embedder → envector → Active)
-- **internal/service/{capture,recall,lifecycle}.go**: 8 MCP tool handlers
+- **.claude-plugin/plugin.json**: Claude Code plugin manifest (spawns `${CLAUDE_PLUGIN_ROOT}/bin/rune mcp-server`)
+- **cmd/rune/**: the rune CLI — `install`, `mcp-server`, `runed`, `verify`, `version` subcommands (the MCP server binary, rune-mcp, lives in the CryptoLabInc/rune-mcp repo)
+- **internal/bootstrap/**: manifest fetch + download/verify/extract + install lock
+- **internal/supervisor/**: `rune runed --detach` userspace daemon supervisor
 
 ## Release Process
 
 Maintainers only:
 
-1. Update version in `package.json`, `.claude-plugin/plugin.json`, and `gemini-extension.json`
+1. Update version in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` (and the release tag / `main.runeVersion` ldflag; `.release-pins.yaml` pins the downstream rune-mcp + runed versions)
 2. Update CHANGELOG.md
 3. Run tests: `go test -race ./...`
 4. Create git tag: `git tag v0.4.0`

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,10 +9,11 @@ description: Encrypted organizational memory workflow for Rune with activation c
 
 ## Execution Model
 
-In v0.4 the MCP server is a single Go binary (`${CLAUDE_PLUGIN_ROOT}/bin/rune-mcp`)
-auto-spawned by the host CLI from the plugin manifest. There is no venv, no
-install script, and no `bootstrap-mcp.sh` to source. The runtime is the
-binary the CLI already launched.
+In v0.4 the MCP server is a single Go binary (`~/.rune/bin/rune-mcp`), spawned
+by the host CLI from the plugin manifest via the committed wrapper (e.g.,
+`${CLAUDE_PLUGIN_ROOT}/bin/rune mcp-server` for Claude Code) which always present at session start;
+it self-installs rune-mcp on first run, so the server comes online in-session
+with no restart. There is no venv, no install script. The runtime is the binary the CLI already launched.
 
 **Agent-specific surface** stays thin:
 - Codex: `codex mcp add/remove/list` registration actions
@@ -245,7 +246,7 @@ signal on its own.) Treat `last_boot_error` as ground truth.
    - `config_*`, `vault_*` (TLS, auth, endpoint, manifest, etc.) → re-run
      `/rune:configure` after applying the hint's fix.
    - `user_deactivated` → `/rune:activate`.
-   - `embedder_unreachable` → start `runed` (`runed start`), then `/rune:status`.
+   - `embedder_unreachable` → re-run `/rune:activate` to spawn the daemon, then `/rune:status`.
    - `envector_*` → share `detail` with the Vault admin.
    - `unknown` → show `kind` + `detail`, suggest sharing with admin.
 

--- a/bin/rune
+++ b/bin/rune
@@ -85,10 +85,10 @@ if [ -z "$RUNE_VERSION" ]; then
   # Use token if exist
   token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
   if [ -n "$token" ]; then
-    body="$(curl --fail --silent --show-error --location \
+    body="$(curl --fail --silent --show-error --location --connect-timeout 10 --max-time 20 \
       --header "Authorization: Bearer $token" "$api" || true)"
   else
-    body="$(curl --fail --silent --show-error --location "$api" || true)"
+    body="$(curl --fail --silent --show-error --location --connect-timeout 10 --max-time 20 "$api" || true)"
   fi
 
   RUNE_VERSION="$(printf '%s' "$body" \
@@ -122,12 +122,12 @@ echo "rune: bootstrapping CLI ($ASSET $RUNE_VERSION) to $TARGET" >&2
 RELEASE_BASE="https://github.com/CryptoLabInc/rune/releases/download/$RUNE_VERSION"
 mkdir -p "$(dirname "$TARGET")"
 
-# Download and verify
-TMP="$(mktemp -t rune-bootstrap-XXXXXX)"
+# Leave TMP on the same filesystem as TARGET
+TMP="$(mktemp "$(dirname "$TARGET")/.rune-bootstrap-XXXXXX")"
 SUMS="$(mktemp -t rune-bootstrap-sums-XXXXXX)"
 
-curl --fail --silent --show-error --location "$RELEASE_BASE/$ASSET"        -o "$TMP"
-curl --fail --silent --show-error --location "$RELEASE_BASE/checksums.txt" -o "$SUMS"
+curl --fail --silent --show-error --location --connect-timeout 10 --max-time 120 "$RELEASE_BASE/$ASSET"        -o "$TMP"
+curl --fail --silent --show-error --location --connect-timeout 10 --max-time 30  "$RELEASE_BASE/checksums.txt" -o "$SUMS"
 
 EXPECTED="$(grep " $ASSET\$" "$SUMS" | cut -d' ' -f1)"
 if [ -z "$EXPECTED" ]; then

--- a/cmd/rune/mcpserver.go
+++ b/cmd/rune/mcpserver.go
@@ -10,6 +10,8 @@ import (
 	"github.com/CryptoLabInc/rune-cli/internal/bootstrap"
 )
 
+const mcpSelfhealBudget = 25 * time.Second // (download:25s + (exec + MCP handshake):5s) < plugin manifest 30s MCP connection timeout
+
 func runMCPServer(ctx context.Context, args []string, stderr io.Writer) int {
 	paths, err := bootstrap.Resolve()
 	if err != nil {
@@ -27,8 +29,11 @@ func runMCPServer(ctx context.Context, args []string, stderr io.Writer) int {
 			manifest = env
 		}
 
+		healCtx, cancel := context.WithTimeout(ctx, mcpSelfhealBudget)
+		defer cancel()
+
 		// Concurrency-safe install
-		_, instErr := bootstrap.Install(ctx, bootstrap.InstallOptions{
+		_, instErr := bootstrap.Install(healCtx, bootstrap.InstallOptions{
 			ManifestURL: manifest,
 			Target:      []string{bootstrap.StepRuneMCP},
 			Log: func(format string, a ...any) {
@@ -36,9 +41,9 @@ func runMCPServer(ctx context.Context, args []string, stderr io.Writer) int {
 			},
 		})
 		if instErr != nil {
-			// Sessions which do not invoke install wait here
-			if !waitForFile(ctx, paths.RuneMCPBinary, bootstrap.InstallLockTimeout) {
-				fmt.Fprintf(stderr, "rune: failed to install rune-mcp: %v\n", instErr)
+			if !waitForFile(healCtx, paths.RuneMCPBinary, mcpSelfhealBudget) {
+				fmt.Fprintf(stderr, "rune: failed to install rune-mcp within %s: %v\n", mcpSelfhealBudget, instErr)
+				fmt.Fprintln(stderr, "     another session may still be installing it; reconnect via /mcp once it completes")
 				return 1
 			}
 

--- a/cmd/rune/runed.go
+++ b/cmd/rune/runed.go
@@ -24,22 +24,34 @@ func runRuned(ctx context.Context, args []string, stderr io.Writer) int {
 		return 1
 	}
 
-	// Point runed at the llama-server that `rune install` extracted from the
-	// runed full-stack tarball. Without this, runed would re-download
-	// llama-server from its own manifest. Set on the process env (rather
+	// If a llama-server is present in ~/.runed/bin, point runed at it so it skips
+	// re-download. When it's absent, leave the env UNSET so runed
+	// self-bootstraps llama-server on first boot. Set on the process env (rather
 	// than via execInstalledBinary's extraEnv) so the supervisor path's
 	// re-exec/setsid/fork chain also propagates it to the daemon's child.
-	_ = os.Setenv("RUNED_LLAMA_SERVER", paths.LlamaServer)
+	if _, err := os.Stat(paths.LlamaServer); err == nil {
+		_ = os.Setenv("RUNED_LLAMA_SERVER", paths.LlamaServer)
+	}
 
 	detach, forwardedArgs := extractDetachFlag(args)
 	if !detach {
 		return execInstalledBinary(ctx, paths.RunedBin, "runed", forwardedArgs, nil, stderr)
 	}
 
+	// Verify path since `rune runed --detach` return immediately without error (exit 0)
+	if _, err := os.Stat(paths.RunedBinary); err != nil {
+		fmt.Fprintf(stderr,
+			"rune: runed not installed at %s (exit 127).\n"+
+				"Agent recovery: invoke %s, then re-attempt.\n",
+			paths.RunedBinary, bootstrap.AgentInstallRecoveryHint())
+		return 127
+	}
+
 	if err := paths.EnsureDirs(); err != nil {
 		fmt.Fprintf(stderr, "rune: ensure dirs: %v\n", err)
 		return 1
 	}
+
 	if err := supervisor.EnsureLogDir(paths.DaemonLog); err != nil {
 		fmt.Fprintf(stderr, "rune: prepare log dir: %v\n", err)
 		return 1

--- a/commands/claude/activate.md
+++ b/commands/claude/activate.md
@@ -7,36 +7,32 @@ allowed-tools: Bash(~/.rune/bin/rune install:*), Bash(${CLAUDE_PLUGIN_ROOT}/bin/
 
 Resume Rune from a dormant state and verify the boot loop reaches Active.
 
-The MCP server is a Go binary spawned by Claude Code from the plugin manifest's
-`${HOME}/.rune/bin/rune-mcp`. `mcp__rune__activate` runs the prereq
-checks server-side (config presence + runed socket reachability, plus a
-runed Health probe) and only triggers the boot loop if everything's ready.
+The MCP server is a Go binary at `~/.rune/bin/rune-mcp`, spawned by Claude Code
+via the plugin manifest's committed wrapper `${CLAUDE_PLUGIN_ROOT}/bin/rune
+mcp-server` (always present at session start; self-installs rune-mcp on first
+run). `mcp__rune__activate` runs the prereq checks server-side (config presence
++ runed socket reachability, plus a runed Health probe) and only triggers the
+boot loop if everything's ready.
 
-## Preflight: auto-install on first MCP call
+## Preflight: the first MCP call self-installs
 
-`mcp__rune__*` tools spawn the MCP server lazily - on a fresh
-`claude plugin install rune`, the binary the manifest points at
-(`${HOME}/.rune/bin/rune-mcp`) does not exist yet, so the very first
-MCP call below will fail with a transport / connection / spawn error.
+On a fresh `claude plugin install rune`, the first `mcp__rune__*` call spawns
+`${CLAUDE_PLUGIN_ROOT}/bin/rune mcp-server`, which self-installs rune-mcp and
+then serves — so the call is EXPECTED to succeed in-session (may be slow on a
+cold download, bounded by the manifest's spawn timeout; that is normal).
 
-When that happens, recover by running ONE of these install entry points
-via the Bash tool, in priority order — try the first applicable:
+You normally do NOT need to run anything here. ONLY if a `mcp__rune__*` call
+actually fails with a transport / connection / spawn error (e.g. the server
+shows failed in `/mcp`) — a genuinely broken bootstrap — recover by running
+ONE of these via the Bash tool, then retry the failed MCP call once:
 
-1. **`~/.rune/bin/rune install`** - when the canonical Go binary
-   already exists and is executable. One exec hop, no bash wrapper.
-   Used in steady state and on every install after the first.
+1. **`~/.rune/bin/rune install`** - canonical Go binary already exists.
 2. **`bash -c "${CLAUDE_PLUGIN_ROOT}/bin/rune install"`** - when
-   `~/.rune/bin/rune` doesn't exist yet (very first install). The
-   plugin's bash bootstrap downloads the Go binary to
-   `~/.rune/bin/rune` and then delegates to it for the actual install.
+   `~/.rune/bin/rune` doesn't exist yet (the bash wrapper downloads the Go
+   binary, then installs).
 
-Surface the install output to the user verbatim so they see what got
-installed - this is the only point in any /rune:* skill where the user
-sees the underlying `rune install` happen.
-
-Retry the failed MCP call once. If the retry ALSO fails, surface the
-error and stop. Do NOT loop the install. The user does NOT type
-`rune install` themselves - this preflight is the only sanctioned path.
+Surface the install output verbatim. If the retry ALSO fails, surface the
+error and stop — do NOT loop. The user never types `rune install` themselves.
 
 ## Steps
 
@@ -82,7 +78,7 @@ The response shape:
 - Stop. Do NOT call `mcp__rune__diagnostics`; the agent already has the answer.
 
 **`install_pending`** - the activate handler tried to auto-spawn the runed
-daemon (via `${HOME}/bin/rune runed --detach` or the
+daemon (via `${HOME}/.rune/bin/rune runed --detach` or the
 canonical equivalent) but couldn't make the socket reachable. The
 response's `hint` field already contains the specific recovery - usually
 the agent-facing form is `bash -c "${CLAUDE_PLUGIN_ROOT}/bin/rune install"`

--- a/commands/claude/configure.md
+++ b/commands/claude/configure.md
@@ -9,36 +9,34 @@ Single entry after `claude plugin install rune`. Collects Vault credentials,
 calls `mcp__rune__configure` (atomic 0600 write + soft Vault probe), and
 hands off to `mcp__rune__activate` to bring pipelines online.
 
-The MCP server is a Go binary placed at `~/.rune/bin/rune-mcp` by the
-plugin's bootstrap (see Preflight below). The plugin manifest's
-`mcpServers.rune.command` resolves directly to that path; Claude
-spawns it on the first `mcp__rune__*` call.
+The MCP server is a Go binary at `~/.rune/bin/rune-mcp`. The plugin manifest
+spawns it via the committed bash wrapper `${CLAUDE_PLUGIN_ROOT}/bin/rune
+mcp-server` (always present at session start). On a fresh install the wrapper
+bootstraps the rune CLI and self-installs rune-mcp, then execs it — so the MCP
+server comes online in the SAME session, with no restart.
 
-## Preflight: auto-install on first MCP call
+## Preflight: the first MCP call self-installs
 
-`mcp__rune__*` tools spawn the MCP server lazily - on a fresh
-`claude plugin install rune`, the binary the manifest points at
-(`${HOME}/.rune/bin/rune-mcp`) does not exist yet, so the very first
-MCP call below will fail with a transport / connection / spawn error.
+On a fresh `claude plugin install rune`, the first `mcp__rune__*` call spawns
+`${CLAUDE_PLUGIN_ROOT}/bin/rune mcp-server`, which self-installs rune-mcp
+(downloading the CLI + rune-mcp if needed) and then serves — so the call is
+EXPECTED to succeed in-session. On a cold download it may be slow (bounded by
+the manifest's spawn timeout); that is normal, not an error.
 
-When that happens, recover by running ONE of these install entry points
-via the Bash tool, in priority order — try the first applicable:
+You normally do NOT need to run anything here. ONLY if a `mcp__rune__*` call
+actually fails with a transport / connection / spawn error (e.g. the server
+shows failed in `/mcp`) — a genuinely broken bootstrap — recover by running
+ONE of these via the Bash tool, then retry the failed MCP call once:
 
-1. **`~/.rune/bin/rune install`** - when the canonical Go binary
-   already exists and is executable. One exec hop, no bash wrapper.
-   Used in steady state and on every install after the first.
+1. **`~/.rune/bin/rune install`** - when the canonical Go binary already
+   exists and is executable (steady state).
 2. **`bash -c "${CLAUDE_PLUGIN_ROOT}/bin/rune install"`** - when
-   `~/.rune/bin/rune` doesn't exist yet (very first install). The
-   plugin's bash bootstrap downloads the Go binary to
-   `~/.rune/bin/rune` and then delegates to it for the actual install.
+   `~/.rune/bin/rune` doesn't exist yet (the bash wrapper downloads the Go
+   binary, then installs).
 
-Surface the install output to the user verbatim so they see what got
-installed - this is the only point in any /rune:* skill where the user
-sees the underlying `rune install` happen.
-
-Retry the failed MCP call once. If the retry ALSO fails, surface the
-error and stop. Do NOT loop the install. The user does NOT type
-`rune install` themselves - this preflight is the only sanctioned path.
+Surface the install output to the user verbatim. If the retry ALSO fails,
+surface the error and stop — do NOT loop. The user never types `rune install`
+themselves; this recovery is the agent's only sanctioned path.
 
 ## Quick Update Mode
 
@@ -132,7 +130,7 @@ mkdir -p ~/.rune/certs && cp <user_ca_path> ~/.rune/certs/ca.pem && chmod 600 ~/
 
 If `cp` fails (file not found / permission denied), surface the error
 and ask the user for a readable path (one more `AskUserQuestion`). Common
-recovery: `sudo cp /opt/runevault/certs/ca.pem ~/.rune/ca.pem && sudo chown $USER ~/.rune/ca.pem`.
+recovery: `mkdir -p ~/.rune/certs && sudo cp /opt/runevault/certs/ca.pem ~/.rune/certs/ca.pem && sudo chown $USER ~/.rune/certs/ca.pem`.
 
 ### 4. Call `mcp__rune__configure`
 
@@ -203,7 +201,7 @@ Render based on `last_boot_error.kind`:
 | `vault_manifest`      | Vault connected but no manifest for this token. Token probably not provisioned for an agent. |
 | `vault_rate_limit`    | Token throttled. Show `hint`. Wait and retry. |
 | `vault_bad_endpoint`  | Endpoint syntax invalid. Show `hint`. Re-run `/rune:configure` with corrected format. |
-| `embedder_unreachable`| `runed` daemon not running. Show `hint`. User should run `rune install` (and start the daemon). |
+| `embedder_unreachable`| `runed` daemon not running. Show `hint`. Re-run `/rune:activate` to (re)spawn the daemon; if it persists, the agent runs the Preflight install, then `/rune:activate`. |
 | `envector_init` / `envector_index` | Envector side. Show `hint` + `detail`. |
 | `key_save` / `local_io` | Local FS issue. Show `hint` + suggest checking `~/.rune/` permissions. |
 | anything else (incl. `unknown`) | Show `kind`, `hint`, and `detail`. Suggest user share the detail with their Vault admin. |

--- a/commands/claude/status.md
+++ b/commands/claude/status.md
@@ -92,7 +92,7 @@ Examples:
 - `kind=vault_network` → "Vault endpoint `<endpoint>` is not reachable.
   Verify the host/port and your network/firewall."
 - `kind=embedder_unreachable` → "Embedder daemon (`runed`) is not running on
-  its UDS socket. Start it with `runed start`."
+  its UDS socket. Re-run `/rune:activate` to (re)spawn it."
 - `kind=unknown` → show both `hint` and `detail` and suggest sharing with admin.
 
 DO NOT call shell tools (`openssl`, `nc`, `curl`, etc.) to "verify" the

--- a/internal/bootstrap/download.go
+++ b/internal/bootstrap/download.go
@@ -9,13 +9,25 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 var ErrChecksumMismatch = errors.New("checksum mismatch")
+
+// HTTP client with timeout
+var downloadClient = &http.Client{
+	Transport: &http.Transport{
+		DialContext:           (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		IdleConnTimeout:       30 * time.Second,
+	},
+}
 
 type ProgressFunc func(downloaded, total int64)
 
@@ -29,7 +41,7 @@ func DownloadAndVerify(ctx context.Context, spec ArtifactSpec, destPath string, 
 		return fmt.Errorf("download: build request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := downloadClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("download: GET %s: %w", spec.URL, err)
 	}

--- a/internal/bootstrap/extract.go
+++ b/internal/bootstrap/extract.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 )
 
-// Unapck tarPath into destDir
+// Unpack tarPath into destDir, caller should hold install lock to prevent concurrent extraction
 func ExtractTarball(tarPath, destDir string) error {
 	f, err := os.Open(tarPath)
 	if err != nil {
@@ -63,18 +63,9 @@ func ExtractTarball(tarPath, destDir string) error {
 				mode = 0o644
 			}
 
-			out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
-			if err != nil {
-				return fmt.Errorf("extract: open %s: %w", target, err)
-			}
-
-			if _, err := io.Copy(out, tr); err != nil {
-				_ = out.Close()
-				return fmt.Errorf("extract: write %s: %w", target, err)
-			}
-
-			if err := out.Close(); err != nil {
-				return fmt.Errorf("extract: close %s: %w", target, err)
+			// Atomic extraction
+			if err := extractRegularFile(tr, target, mode); err != nil {
+				return err
 			}
 		default:
 			// non-regular binareis (symlink, devices, etc) are skipped
@@ -89,4 +80,43 @@ func safeJoin(destAbs, name string) (string, error) {
 	}
 
 	return filepath.Join(destAbs, path), nil
+}
+
+func extractRegularFile(r io.Reader, dest string, mode os.FileMode) error {
+	// Try extraction as temp file
+	tmp := dest + ".partial"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return fmt.Errorf("extract: open %s: %w", tmp, err)
+	}
+
+	if _, err := io.Copy(out, r); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("extract: write %s: %w", tmp, err)
+	}
+
+	if err := out.Sync(); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("extract: fsync %s: %w", tmp, err)
+	}
+
+	if err := out.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("extract: close %s: %w", tmp, err)
+	}
+
+	if err := os.Chmod(tmp, mode); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("extract: chmod %s: %w", tmp, err)
+	}
+
+	// Rename to dest for atomicity
+	if err := os.Rename(tmp, dest); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("extract: rename %s to %s: %w", tmp, dest, err)
+	}
+
+	return nil
 }

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -114,6 +114,7 @@ func runWatcher(ctx context.Context, cfg Config) error {
 		cmd.Stderr = os.Stderr
 
 		fmt.Fprintf(os.Stderr, "supervisor: starting %s %v\n", cfg.RunedBinary, cfg.RunedArgs)
+		started := time.Now()
 		if err := cmd.Start(); err != nil {
 			return fmt.Errorf("supervisor: start %s: %w", cfg.RunedBinary, err)
 		}
@@ -139,7 +140,12 @@ func runWatcher(ctx context.Context, cfg Config) error {
 				return nil // clean exit
 			}
 
+			// Reset backoff count if child live longer than crash window
 			now := time.Now()
+			if now.Sub(started) > cfg.MaxCrashWindow {
+				backoffIdx = 0
+			}
+
 			crashes = append(crashes, now)
 			cutoff := now.Add(-cfg.MaxCrashWindow) // crashes older than now - cfg.MaxCrashWindow are considered expired
 			i := 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cryptolab/rune",
-  "version": "0.3.1",
+  "version": "0.4.0-dev",
   "description": "FHE-encrypted organizational memory for teams",
   "private": true,
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- What changed: Add missing timeout and safety guards
- Why: Better UX
- Scope:

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [ ] `scripts/bootstrap-mcp.sh` remains the single source of truth for runtime prep (venv/deps/self-heal)
- [ ] No agent-specific script duplicates bootstrap/setup logic
- [ ] Agent-specific scripts remain thin adapters (registration/wiring only)
- [ ] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [ ] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [ ] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
