### PR TITLE
docs(scribe): document flat batch_capture item shape, warn against the wrapper anti-pattern

### DIFF
--- a/agents/claude/scribe.md
+++ b/agents/claude/scribe.md
@@ -265,7 +265,7 @@ mcp__plugin_rune_rune__capture(
 When the conversation is ending or the user is wrapping up a task:
 
 1. Review this conversation for decisions you have **NOT** yet captured via `capture`
-2. For each uncaptured decision, prepare an extracted JSON (same format as single capture)
+2. For each uncaptured decision, prepare a **flat extracted object** — identical to the `extracted` parameter of single `capture` (see schema below)
 3. Submit all uncaptured decisions via `batch_capture` tool in **one call**
 4. Do NOT re-submit decisions you already captured during the conversation
    (the server's novelty check will catch duplicates, but avoid unnecessary calls)
@@ -277,5 +277,35 @@ When the conversation is ending or the user is wrapping up a task:
 
 **batch_capture parameters** (each is a separate tool parameter, NOT a single JSON):
 
-- `items`: JSON array string of extracted decision objects (same format as single capture's `extracted` parameter)
+- `items`: JSON **array string** where **each element is a flat extracted object** — exactly the object you would pass as the `extracted` parameter to single `capture` (top-level `tier2`, `title`, `reusable_insight`, `rationale`, `tags`, …, or the `group_title`/`phases` multi-phase shape).
 - `source`: `"claude_agent"` (optional, defaults to `"claude_agent"`)
+
+⚠️ **CRITICAL — do NOT wrap each item as `{"text": ..., "extracted": {...}}`.** Single `capture` takes `text` and `extracted` as *two separate tool parameters*; a batch item is **just the `extracted` object by itself**. If you nest the fields under an `extracted` key (or under `text`), the server's top-level lookup for `reusable_insight`/`title` finds nothing and the item is rejected with status `error`. Each item **must** carry at least a top-level `reusable_insight` or `title`.
+
+✅ **Correct `items` shape** (array of flat extracted objects):
+
+```json
+[
+  {
+    "tier2": {"capture": true, "reason": "...", "domain": "architecture"},
+    "title": "Adopt Linkerd over Istio",
+    "reusable_insight": "Dense self-contained paragraph: what was decided, why, what was rejected, key trade-offs. No markdown.",
+    "rationale": "...",
+    "tags": ["service-mesh", "linkerd"]
+  },
+  {
+    "tier2": {"capture": true, "reason": "...", "domain": "security"},
+    "title": "Migrate password hashing to Argon2id",
+    "reusable_insight": "...",
+    "tags": ["security", "hashing"]
+  }
+]
+```
+
+❌ **Wrong** (wrapper shape — every item rejected as `error`):
+
+```json
+[
+  {"text": "...", "extracted": {"title": "Adopt Linkerd over Istio", "reusable_insight": "..."}}
+]
+```

--- a/agents/claude/scribe.md
+++ b/agents/claude/scribe.md
@@ -280,7 +280,7 @@ When the conversation is ending or the user is wrapping up a task:
 - `items`: JSON **array string** where **each element is a flat extracted object** — exactly the object you would pass as the `extracted` parameter to single `capture` (top-level `tier2`, `title`, `reusable_insight`, `rationale`, `tags`, …, or the `group_title`/`phases` multi-phase shape).
 - `source`: `"claude_agent"` (optional, defaults to `"claude_agent"`)
 
-⚠️ **CRITICAL — do NOT wrap each item as `{"text": ..., "extracted": {...}}`.** Single `capture` takes `text` and `extracted` as *two separate tool parameters*; a batch item is **just the `extracted` object by itself**. If you nest the fields under an `extracted` key (or under `text`), the server's top-level lookup for `reusable_insight`/`title` finds nothing and the item is rejected with status `error`. Each item **must** carry at least a top-level `reusable_insight` or `title`.
+⚠️ **CRITICAL — do NOT wrap each item as `{"text": ..., "extracted": {...}}`.** Single `capture` takes `text` and `extracted` as *two separate tool parameters*; a batch item is **just the `extracted` object by itself**. If you nest the fields under an `extracted` key (or under `text`), the server's top-level lookup for `reusable_insight`/`title`/`group_title` finds nothing and the item is rejected with status `error`. Each item **must** carry at least a top-level `reusable_insight`, `title`, or `group_title` (the multi-phase shape supplies `group_title`).
 
 ✅ **Correct `items` shape** (array of flat extracted objects):
 

--- a/agents/claude/scribe.md
+++ b/agents/claude/scribe.md
@@ -79,7 +79,6 @@ Use one of: `architecture`, `security`, `product`, `exec`, `ops`, `design`, `dat
 For a single, self-contained decision:
 ```json
 {
-  "tier2": {"capture": true, "reason": "one sentence why", "domain": "<domain>"},
   "title": "Short decision title (5-60 chars)",
   "reusable_insight": "Dense natural-language paragraph (256-768 tokens) capturing the core knowledge. No markdown. Self-contained. Must answer: 'If someone in 6 months asks about this topic, what do they need to know?' Include what was decided, why, what was rejected, and key trade-offs.",
   "rationale": "The reasoning behind the decision",
@@ -104,7 +103,6 @@ For a single, self-contained decision:
 For a long reasoning process with multiple sequential conclusions:
 ```json
 {
-  "tier2": {"capture": true, "reason": "...", "domain": "<domain>"},
   "group_title": "Overall title for the reasoning chain",
   "group_type": "phase_chain",
   "reusable_insight": "Dense natural-language paragraph (256-768 tokens) capturing the core knowledge of the entire chain. No markdown. Self-contained.",
@@ -138,7 +136,6 @@ For a long reasoning process with multiple sequential conclusions:
 For a single decision with rich supporting detail (alternatives analysis, implementation plan, etc.):
 ```json
 {
-  "tier2": {"capture": true, "reason": "...", "domain": "<domain>"},
   "group_title": "Auth Strategy Decision",
   "group_type": "bundle",
   "reusable_insight": "Dense natural-language paragraph (256-768 tokens) capturing the core knowledge of the bundle. No markdown. Self-contained.",
@@ -172,7 +169,6 @@ For a single decision with rich supporting detail (alternatives analysis, implem
 For code-heavy discoveries, use bundle format with evidence at phase level:
 ```json
 {
-  "tier2": {"capture": true, "reason": "...", "domain": "debugging"},
   "group_title": "Short insight title",
   "group_type": "bundle",
   "evidence_type": "code_change",
@@ -213,14 +209,6 @@ For code-heavy discoveries, use bundle format with evidence at phase level:
 }
 ```
 Phases may include `evidence_snippet` (up to 50 lines each). Use 2-5 phases.
-
-### Rejection Format
-When Step 1 determines the message should NOT be captured:
-```json
-{
-  "tier2": {"capture": false, "reason": "Casual discussion without decision", "domain": "general"}
-}
-```
 
 ### Field Guidelines
 - **title / group_title**: 5-60 chars, concise and descriptive
@@ -277,7 +265,7 @@ When the conversation is ending or the user is wrapping up a task:
 
 **batch_capture parameters** (each is a separate tool parameter, NOT a single JSON):
 
-- `items`: JSON **array string** where **each element is a flat extracted object** — exactly the object you would pass as the `extracted` parameter to single `capture` (top-level `tier2`, `title`, `reusable_insight`, `rationale`, `tags`, …, or the `group_title`/`phases` multi-phase shape).
+- `items`: JSON **array string** where **each element is a flat extracted object** — exactly the object you would pass as the `extracted` parameter to single `capture` (top-level `title`, `reusable_insight`, `rationale`, `tags`, …, or the `group_title`/`phases` multi-phase shape).
 - `source`: `"claude_agent"` (optional, defaults to `"claude_agent"`)
 
 ⚠️ **CRITICAL — do NOT wrap each item as `{"text": ..., "extracted": {...}}`.** Single `capture` takes `text` and `extracted` as *two separate tool parameters*; a batch item is **just the `extracted` object by itself**. If you nest the fields under an `extracted` key (or under `text`), the server's top-level lookup for `reusable_insight`/`title`/`group_title` finds nothing and the item is rejected with status `error`. Each item **must** carry at least a top-level `reusable_insight`, `title`, or `group_title` (the multi-phase shape supplies `group_title`).
@@ -287,14 +275,12 @@ When the conversation is ending or the user is wrapping up a task:
 ```json
 [
   {
-    "tier2": {"capture": true, "reason": "...", "domain": "architecture"},
     "title": "Adopt Linkerd over Istio",
     "reusable_insight": "Dense self-contained paragraph: what was decided, why, what was rejected, key trade-offs. No markdown.",
     "rationale": "...",
     "tags": ["service-mesh", "linkerd"]
   },
   {
-    "tier2": {"capture": true, "reason": "...", "domain": "security"},
     "title": "Migrate password hashing to Argon2id",
     "reusable_insight": "...",
     "tags": ["security", "hashing"]

--- a/agents/codex/scribe.md
+++ b/agents/codex/scribe.md
@@ -264,7 +264,7 @@ capture(
 When the conversation is ending or the user is wrapping up a task:
 
 1. Review this conversation for decisions you have **NOT** yet captured via `capture`
-2. For each uncaptured decision, prepare an extracted JSON (same format as single capture)
+2. For each uncaptured decision, prepare a **flat extracted object** — identical to the `extracted` parameter of single `capture` (see schema below)
 3. Submit all uncaptured decisions via `batch_capture` tool in **one call**
 4. Do NOT re-submit decisions you already captured during the conversation
    (the server's novelty check will catch duplicates, but avoid unnecessary calls)
@@ -276,5 +276,29 @@ When the conversation is ending or the user is wrapping up a task:
 
 **batch_capture parameters** (each is a separate tool parameter, NOT a single JSON):
 
-- `items`: JSON array string of extracted decision objects (same format as single capture's `extracted` parameter)
+- `items`: JSON **array string** where **each element is a flat extracted object** — exactly the object you would pass as the `extracted` parameter to single `capture` (top-level `tier2`, `title`, `reusable_insight`, `rationale`, `tags`, …, or the `group_title`/`phases` multi-phase shape).
 - `source`: `"codex_agent"` (optional, defaults to `"claude_agent"`)
+
+⚠️ **CRITICAL — do NOT wrap each item as `{"text": ..., "extracted": {...}}`.** Single `capture` takes `text` and `extracted` as *two separate tool parameters*; a batch item is **just the `extracted` object by itself**. If you nest the fields under an `extracted` key (or under `text`), the server's top-level lookup for `reusable_insight`/`title` finds nothing and the item is rejected with status `error`. Each item **must** carry at least a top-level `reusable_insight` or `title`.
+
+✅ **Correct `items` shape** (array of flat extracted objects):
+
+```json
+[
+  {
+    "tier2": {"capture": true, "reason": "...", "domain": "architecture"},
+    "title": "Adopt Linkerd over Istio",
+    "reusable_insight": "Dense self-contained paragraph: what was decided, why, what was rejected, key trade-offs. No markdown.",
+    "rationale": "...",
+    "tags": ["service-mesh", "linkerd"]
+  }
+]
+```
+
+❌ **Wrong** (wrapper shape — every item rejected as `error`):
+
+```json
+[
+  {"text": "...", "extracted": {"title": "Adopt Linkerd over Istio", "reusable_insight": "..."}}
+]
+```

--- a/agents/codex/scribe.md
+++ b/agents/codex/scribe.md
@@ -78,7 +78,6 @@ Use one of: `architecture`, `security`, `product`, `exec`, `ops`, `design`, `dat
 For a single, self-contained decision:
 ```json
 {
-  "tier2": {"capture": true, "reason": "one sentence why", "domain": "<domain>"},
   "title": "Short decision title (5-60 chars)",
   "reusable_insight": "Dense natural-language paragraph (256-768 tokens) capturing the core knowledge. No markdown. Self-contained. Must answer: 'If someone in 6 months asks about this topic, what do they need to know?' Include what was decided, why, what was rejected, and key trade-offs.",
   "rationale": "The reasoning behind the decision",
@@ -103,7 +102,6 @@ For a single, self-contained decision:
 For a long reasoning process with multiple sequential conclusions:
 ```json
 {
-  "tier2": {"capture": true, "reason": "...", "domain": "<domain>"},
   "group_title": "Overall title for the reasoning chain",
   "group_type": "phase_chain",
   "reusable_insight": "Dense natural-language paragraph (256-768 tokens) capturing the core knowledge of the entire chain. No markdown. Self-contained.",
@@ -137,7 +135,6 @@ For a long reasoning process with multiple sequential conclusions:
 For a single decision with rich supporting detail:
 ```json
 {
-  "tier2": {"capture": true, "reason": "...", "domain": "<domain>"},
   "group_title": "Auth Strategy Decision",
   "group_type": "bundle",
   "reusable_insight": "Dense natural-language paragraph (256-768 tokens) capturing the core knowledge of the bundle. No markdown. Self-contained.",
@@ -171,7 +168,6 @@ For a single decision with rich supporting detail:
 For code-heavy discoveries, use bundle format with evidence at phase level:
 ```json
 {
-  "tier2": {"capture": true, "reason": "...", "domain": "debugging"},
   "group_title": "Short insight title",
   "group_type": "bundle",
   "evidence_type": "code_change",
@@ -212,14 +208,6 @@ For code-heavy discoveries, use bundle format with evidence at phase level:
 }
 ```
 Phases may include `evidence_snippet` (up to 50 lines each). Use 2-5 phases.
-
-### Rejection Format
-When Step 1 determines the message should NOT be captured:
-```json
-{
-  "tier2": {"capture": false, "reason": "Casual discussion without decision", "domain": "general"}
-}
-```
 
 ### Field Guidelines
 - **title / group_title**: 5-60 chars, concise and descriptive
@@ -276,7 +264,7 @@ When the conversation is ending or the user is wrapping up a task:
 
 **batch_capture parameters** (each is a separate tool parameter, NOT a single JSON):
 
-- `items`: JSON **array string** where **each element is a flat extracted object** — exactly the object you would pass as the `extracted` parameter to single `capture` (top-level `tier2`, `title`, `reusable_insight`, `rationale`, `tags`, …, or the `group_title`/`phases` multi-phase shape).
+- `items`: JSON **array string** where **each element is a flat extracted object** — exactly the object you would pass as the `extracted` parameter to single `capture` (top-level `title`, `reusable_insight`, `rationale`, `tags`, …, or the `group_title`/`phases` multi-phase shape).
 - `source`: `"codex_agent"` (optional, defaults to `"claude_agent"`)
 
 ⚠️ **CRITICAL — do NOT wrap each item as `{"text": ..., "extracted": {...}}`.** Single `capture` takes `text` and `extracted` as *two separate tool parameters*; a batch item is **just the `extracted` object by itself**. If you nest the fields under an `extracted` key (or under `text`), the server's top-level lookup for `reusable_insight`/`title`/`group_title` finds nothing and the item is rejected with status `error`. Each item **must** carry at least a top-level `reusable_insight`, `title`, or `group_title` (the multi-phase shape supplies `group_title`).
@@ -286,7 +274,6 @@ When the conversation is ending or the user is wrapping up a task:
 ```json
 [
   {
-    "tier2": {"capture": true, "reason": "...", "domain": "architecture"},
     "title": "Adopt Linkerd over Istio",
     "reusable_insight": "Dense self-contained paragraph: what was decided, why, what was rejected, key trade-offs. No markdown.",
     "rationale": "...",

--- a/agents/codex/scribe.md
+++ b/agents/codex/scribe.md
@@ -279,7 +279,7 @@ When the conversation is ending or the user is wrapping up a task:
 - `items`: JSON **array string** where **each element is a flat extracted object** — exactly the object you would pass as the `extracted` parameter to single `capture` (top-level `tier2`, `title`, `reusable_insight`, `rationale`, `tags`, …, or the `group_title`/`phases` multi-phase shape).
 - `source`: `"codex_agent"` (optional, defaults to `"claude_agent"`)
 
-⚠️ **CRITICAL — do NOT wrap each item as `{"text": ..., "extracted": {...}}`.** Single `capture` takes `text` and `extracted` as *two separate tool parameters*; a batch item is **just the `extracted` object by itself**. If you nest the fields under an `extracted` key (or under `text`), the server's top-level lookup for `reusable_insight`/`title` finds nothing and the item is rejected with status `error`. Each item **must** carry at least a top-level `reusable_insight` or `title`.
+⚠️ **CRITICAL — do NOT wrap each item as `{"text": ..., "extracted": {...}}`.** Single `capture` takes `text` and `extracted` as *two separate tool parameters*; a batch item is **just the `extracted` object by itself**. If you nest the fields under an `extracted` key (or under `text`), the server's top-level lookup for `reusable_insight`/`title`/`group_title` finds nothing and the item is rejected with status `error`. Each item **must** carry at least a top-level `reusable_insight`, `title`, or `group_title` (the multi-phase shape supplies `group_title`).
 
 ✅ **Correct `items` shape** (array of flat extracted objects):
 

--- a/agents/gemini/scribe.md
+++ b/agents/gemini/scribe.md
@@ -279,7 +279,7 @@ When the conversation is ending or the user is wrapping up a task:
 - `items`: JSON **array string** where **each element is a flat extracted object** — exactly the object you would pass as the `extracted` parameter to single `capture` (top-level `tier2`, `title`, `reusable_insight`, `rationale`, `tags`, …, or the `group_title`/`phases` multi-phase shape).
 - `source`: `"gemini_agent"` (optional, defaults to `"claude_agent"`)
 
-⚠️ **CRITICAL — do NOT wrap each item as `{"text": ..., "extracted": {...}}`.** Single `capture` takes `text` and `extracted` as *two separate tool parameters*; a batch item is **just the `extracted` object by itself**. If you nest the fields under an `extracted` key (or under `text`), the server's top-level lookup for `reusable_insight`/`title` finds nothing and the item is rejected with status `error`. Each item **must** carry at least a top-level `reusable_insight` or `title`.
+⚠️ **CRITICAL — do NOT wrap each item as `{"text": ..., "extracted": {...}}`.** Single `capture` takes `text` and `extracted` as *two separate tool parameters*; a batch item is **just the `extracted` object by itself**. If you nest the fields under an `extracted` key (or under `text`), the server's top-level lookup for `reusable_insight`/`title`/`group_title` finds nothing and the item is rejected with status `error`. Each item **must** carry at least a top-level `reusable_insight`, `title`, or `group_title` (the multi-phase shape supplies `group_title`).
 
 ✅ **Correct `items` shape** (array of flat extracted objects):
 

--- a/agents/gemini/scribe.md
+++ b/agents/gemini/scribe.md
@@ -78,7 +78,6 @@ Use one of: `architecture`, `security`, `product`, `exec`, `ops`, `design`, `dat
 For a single, self-contained decision:
 ```json
 {
-  "tier2": {"capture": true, "reason": "one sentence why", "domain": "<domain>"},
   "title": "Short decision title (5-60 chars)",
   "reusable_insight": "Dense natural-language paragraph (256-768 tokens) capturing the core knowledge. No markdown. Self-contained. Must answer: 'If someone in 6 months asks about this topic, what do they need to know?' Include what was decided, why, what was rejected, and key trade-offs.",
   "rationale": "The reasoning behind the decision",
@@ -103,7 +102,6 @@ For a single, self-contained decision:
 For a long reasoning process with multiple sequential conclusions:
 ```json
 {
-  "tier2": {"capture": true, "reason": "...", "domain": "<domain>"},
   "group_title": "Overall title for the reasoning chain",
   "group_type": "phase_chain",
   "reusable_insight": "Dense natural-language paragraph (256-768 tokens) capturing the core knowledge of the entire chain. No markdown. Self-contained.",
@@ -137,7 +135,6 @@ For a long reasoning process with multiple sequential conclusions:
 For a single decision with rich supporting detail:
 ```json
 {
-  "tier2": {"capture": true, "reason": "...", "domain": "<domain>"},
   "group_title": "Auth Strategy Decision",
   "group_type": "bundle",
   "reusable_insight": "Dense natural-language paragraph (256-768 tokens) capturing the core knowledge of the bundle. No markdown. Self-contained.",
@@ -171,7 +168,6 @@ For a single decision with rich supporting detail:
 For code-heavy discoveries, use bundle format with evidence at phase level:
 ```json
 {
-  "tier2": {"capture": true, "reason": "...", "domain": "debugging"},
   "group_title": "Short insight title",
   "group_type": "bundle",
   "evidence_type": "code_change",
@@ -212,14 +208,6 @@ For code-heavy discoveries, use bundle format with evidence at phase level:
 }
 ```
 Phases may include `evidence_snippet` (up to 50 lines each). Use 2-5 phases.
-
-### Rejection Format
-When Step 1 determines the message should NOT be captured:
-```json
-{
-  "tier2": {"capture": false, "reason": "Casual discussion without decision", "domain": "general"}
-}
-```
 
 ### Field Guidelines
 - **title / group_title**: 5-60 chars, concise and descriptive
@@ -276,7 +264,7 @@ When the conversation is ending or the user is wrapping up a task:
 
 **batch_capture parameters** (each is a separate tool parameter, NOT a single JSON):
 
-- `items`: JSON **array string** where **each element is a flat extracted object** — exactly the object you would pass as the `extracted` parameter to single `capture` (top-level `tier2`, `title`, `reusable_insight`, `rationale`, `tags`, …, or the `group_title`/`phases` multi-phase shape).
+- `items`: JSON **array string** where **each element is a flat extracted object** — exactly the object you would pass as the `extracted` parameter to single `capture` (top-level `title`, `reusable_insight`, `rationale`, `tags`, …, or the `group_title`/`phases` multi-phase shape).
 - `source`: `"gemini_agent"` (optional, defaults to `"claude_agent"`)
 
 ⚠️ **CRITICAL — do NOT wrap each item as `{"text": ..., "extracted": {...}}`.** Single `capture` takes `text` and `extracted` as *two separate tool parameters*; a batch item is **just the `extracted` object by itself**. If you nest the fields under an `extracted` key (or under `text`), the server's top-level lookup for `reusable_insight`/`title`/`group_title` finds nothing and the item is rejected with status `error`. Each item **must** carry at least a top-level `reusable_insight`, `title`, or `group_title` (the multi-phase shape supplies `group_title`).
@@ -286,7 +274,6 @@ When the conversation is ending or the user is wrapping up a task:
 ```json
 [
   {
-    "tier2": {"capture": true, "reason": "...", "domain": "architecture"},
     "title": "Adopt Linkerd over Istio",
     "reusable_insight": "Dense self-contained paragraph: what was decided, why, what was rejected, key trade-offs. No markdown.",
     "rationale": "...",

--- a/agents/gemini/scribe.md
+++ b/agents/gemini/scribe.md
@@ -264,7 +264,7 @@ capture(
 When the conversation is ending or the user is wrapping up a task:
 
 1. Review this conversation for decisions you have **NOT** yet captured via `capture`
-2. For each uncaptured decision, prepare an extracted JSON (same format as single capture)
+2. For each uncaptured decision, prepare a **flat extracted object** — identical to the `extracted` parameter of single `capture` (see schema below)
 3. Submit all uncaptured decisions via `batch_capture` tool in **one call**
 4. Do NOT re-submit decisions you already captured during the conversation
    (the server's novelty check will catch duplicates, but avoid unnecessary calls)
@@ -276,5 +276,29 @@ When the conversation is ending or the user is wrapping up a task:
 
 **batch_capture parameters** (each is a separate tool parameter, NOT a single JSON):
 
-- `items`: JSON array string of extracted decision objects (same format as single capture's `extracted` parameter)
+- `items`: JSON **array string** where **each element is a flat extracted object** — exactly the object you would pass as the `extracted` parameter to single `capture` (top-level `tier2`, `title`, `reusable_insight`, `rationale`, `tags`, …, or the `group_title`/`phases` multi-phase shape).
 - `source`: `"gemini_agent"` (optional, defaults to `"claude_agent"`)
+
+⚠️ **CRITICAL — do NOT wrap each item as `{"text": ..., "extracted": {...}}`.** Single `capture` takes `text` and `extracted` as *two separate tool parameters*; a batch item is **just the `extracted` object by itself**. If you nest the fields under an `extracted` key (or under `text`), the server's top-level lookup for `reusable_insight`/`title` finds nothing and the item is rejected with status `error`. Each item **must** carry at least a top-level `reusable_insight` or `title`.
+
+✅ **Correct `items` shape** (array of flat extracted objects):
+
+```json
+[
+  {
+    "tier2": {"capture": true, "reason": "...", "domain": "architecture"},
+    "title": "Adopt Linkerd over Istio",
+    "reusable_insight": "Dense self-contained paragraph: what was decided, why, what was rejected, key trade-offs. No markdown.",
+    "rationale": "...",
+    "tags": ["service-mesh", "linkerd"]
+  }
+]
+```
+
+❌ **Wrong** (wrapper shape — every item rejected as `error`):
+
+```json
+[
+  {"text": "...", "extracted": {"title": "Adopt Linkerd over Istio", "reusable_insight": "..."}}
+]
+```


### PR DESCRIPTION
## Summary

The scribe agent docs are the only place that describes `batch_capture`'s `items` shape, and they did so ambiguously. This PR clarifies the contract and removes a field that no longer exists.

## Changes

### 1. Document the flat `batch_capture` item shape

The old text — *"`items`: JSON array string of extracted decision objects (same format as single capture's `extracted` parameter)"* — had no example and was easy to misread. Single `capture` takes `text` and `extracted` as **two separate tool parameters**, so the natural (wrong) move is to make each batch item `{"text": ..., "extracted": {...}}`. That wrapper nests the fields where the server's top-level lookup can't see them.

Across all three scribe variants (`claude`, `codex`, `gemini`):

- State explicitly that each array element is a **flat extracted object** (top-level `title`/`reusable_insight`/`rationale`/`tags`, or the `group_title`/`phases` multi-phase shape).
- Add copy-pasteable ✅ correct and ❌ wrong-wrapper examples.
- Require at least a top-level `reusable_insight`, `title`, **or `group_title`** per item (the `{group_title, phases}` shape supplies `group_title`).

With the companion server fix (CryptoLabInc/rune-mcp#8) such wrapper items are now rejected with status `error`; before that fix the entire batch was silently dropped as `near_duplicate` (`captured:0`).

### 2. Remove the dead `tier2` field

`tier2` was dropped from the extraction schema in **v0.3.1**; the scribe docs were the last thing still instructing agents to emit it. Removed across all three variants:

- the `"tier2": {...}` line from every extraction example (Formats A/B/C/C-variant + the new batch examples),
- `tier2` from the `items` parameter description,
- the **Rejection Format** section, which contained nothing but `{"tier2": {"capture": false, ...}}`.

The matching server-side dead-code removal is in CryptoLabInc/rune-mcp#8.

Docs-only; no code changes.

## Related

- Code fix that makes the failure explicit instead of silent, accepts `group_title`, and removes the server-side `tier2` dead code: CryptoLabInc/rune-mcp#8
