### PR TITLE
chore: bump release pins (rune-mcp alpha.3, runed alpha.5)

### DIFF
--- a/.release-pins.yaml
+++ b/.release-pins.yaml
@@ -1,2 +1,2 @@
-rune_mcp_version: v0.1.0-alpha.2
-runed_version: v0.1.0-alpha.3
+rune_mcp_version: v0.1.0-alpha.3
+runed_version: v0.1.0-alpha.5


### PR DESCRIPTION
`.release-pins.yaml` 버전 업데이트.

| pin | before | after |
|-----|--------|-------|
| `rune_mcp_version` | v0.1.0-alpha.2 | v0.1.0-alpha.3 |
| `runed_version` | v0.1.0-alpha.3 | v0.1.0-alpha.5 |