### PR TITLE
chore(pins): bump rune-mcp to v0.1.0-alpha.4

### DIFF
--- a/.release-pins.yaml
+++ b/.release-pins.yaml
@@ -1,2 +1,2 @@
-rune_mcp_version: v0.1.0-alpha.3
+rune_mcp_version: v0.1.0-alpha.4
 runed_version: v0.1.0-alpha.5


### PR DESCRIPTION
Bumps `rune_mcp_version` in `.release-pins.yaml`: `v0.1.0-alpha.3` → `v0.1.0-alpha.4`.

Picks up the `/rune:activate` resume fix from **CryptoLabInc/rune-mcp#12** — `/rune:deactivate` persists `user_deactivated` to `config.json`, but `Activate()` never cleared it, so `/rune:activate` was a no-op and the daemon stayed dormant until `config.json` was hand-edited. alpha.4 will be the first release containing that fix.

## ⚠️ Do not merge until rune-mcp v0.1.0-alpha.4 is released

The rune release workflow's **"Verify pinned releases existency"** step runs `gh release view v0.1.0-alpha.4 --repo CryptoLabInc/rune-mcp`. Until that release exists this pin is dangling and tagging rune would fail the release job. Sequence:

1. Merge & release rune-mcp#12 as `v0.1.0-alpha.4`.
2. Mark this PR ready and merge.

Kept as a **draft** for that reason. `runed_version` is unchanged.