### PR TITLE
fix(bootstrap): classify deterministic failure as real error 

### DIFF
--- a/cmd/rune/mcpserver.go
+++ b/cmd/rune/mcpserver.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -41,9 +42,16 @@ func runMCPServer(ctx context.Context, args []string, stderr io.Writer) int {
 			},
 		})
 		if instErr != nil {
+			// If error is not ErrInstalINProgress, it is unavoidable error
+			if !errors.Is(instErr, bootstrap.ErrInstallInProgress) {
+				fmt.Fprintf(stderr, "rune: cannot install rune-mcp: %v\n", instErr)
+				return 1
+			}
+
+			// Another session hold lock
 			if !waitForFile(healCtx, paths.RuneMCPBinary, mcpSelfhealBudget) {
-				fmt.Fprintf(stderr, "rune: failed to install rune-mcp within %s: %v\n", mcpSelfhealBudget, instErr)
-				fmt.Fprintln(stderr, "     another session may still be installing it; reconnect via /mcp once it completes")
+				fmt.Fprintf(stderr, "rune: rune-mcp install still in progress after %s: %v\n", mcpSelfhealBudget, instErr)
+				fmt.Fprintln(stderr, "     another session is installing it; reconnect via /mcp once it completes")
 				return 1
 			}
 

--- a/cmd/rune/mcpserver.go
+++ b/cmd/rune/mcpserver.go
@@ -42,7 +42,7 @@ func runMCPServer(ctx context.Context, args []string, stderr io.Writer) int {
 			},
 		})
 		if instErr != nil {
-			// If error is not ErrInstalINProgress, it is unavoidable error
+			// If error is not ErrInstallInProgress, it is unavoidable error
 			if !errors.Is(instErr, bootstrap.ErrInstallInProgress) {
 				fmt.Fprintf(stderr, "rune: cannot install rune-mcp: %v\n", instErr)
 				return 1

--- a/internal/bootstrap/install.go
+++ b/internal/bootstrap/install.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -9,6 +10,8 @@ import (
 	"slices"
 	"time"
 )
+
+var ErrInstallInProgress = errors.New("install: another install in progress")
 
 type InstallOptions struct {
 	ManifestURL string

--- a/internal/bootstrap/lock_unix.go
+++ b/internal/bootstrap/lock_unix.go
@@ -34,15 +34,16 @@ func acquireInstallLock(ctx context.Context, lockPath string, timeout time.Durat
 			_ = f.Close()
 			return nil, fmt.Errorf("flock %s: %w", lockPath, err)
 		}
+
 		if !time.Now().Before(deadline) {
 			_ = f.Close()
-			return nil, fmt.Errorf("install lock %s: another install in progress (waited %s)", lockPath, timeout)
+			return nil, fmt.Errorf("%w: lock %s held (waited %s)", ErrInstallInProgress, lockPath, timeout)
 		}
 
 		select {
 		case <-ctx.Done():
 			_ = f.Close()
-			return nil, ctx.Err()
+			return nil, fmt.Errorf("%w: %w", ErrInstallInProgress, ctx.Err())
 		case <-time.After(installLockPollInterval):
 		}
 	}


### PR DESCRIPTION
Deterministic errors such as bad manifest, checksum mismatch, or no artifact must be considered as fail-fast real errors rather than consuming waiting time budget.