### PR TITLE
fix(bootstrap): verify and repair if previous installed binaries are corrupted

### DIFF
--- a/internal/bootstrap/audit.go
+++ b/internal/bootstrap/audit.go
@@ -21,10 +21,11 @@ type InstalledManifest struct {
 }
 
 type InstalledArtifact struct {
-	URL    string `json:"url"`
-	SHA256 string `json:"sha256"`
-	Path   string `json:"path"`
-	Size   int64  `json:"size,omitempty"`
+	URL        string `json:"url"`
+	SHA256     string `json:"sha256"`                // manifest spec hash (the archive hash for a tar.gz artifact)
+	DestSHA256 string `json:"dest_sha256,omitempty"` // installed raw binary sha256 (extracted file's hash for tarball)
+	Path       string `json:"path"`
+	Size       int64  `json:"size,omitempty"`
 }
 
 func WriteInstalledManifest(paths *Paths, manifestURL string, manifest *Manifest, artifacts map[string]InstalledArtifact) error {

--- a/internal/bootstrap/install.go
+++ b/internal/bootstrap/install.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 )
 
@@ -113,16 +114,24 @@ func Install(ctx context.Context, opts InstallOptions) (*Result, error) {
 		})
 	}
 
+	// Get previous installed info
+	recordedDestSHA := map[string]string{}
+	if prior, perr := ReadInstalledManifest(paths); perr == nil && prior != nil {
+		for step, a := range prior.Artifacts {
+			recordedDestSHA[step] = a.DestSHA256
+		}
+	}
+
 	for i, in := range installs {
 		stepNum := i + 2 // step 1: manifest
-		if !opts.Force {
-			if fileExists(in.dest) {
-				logf("[%d/%d] %s: skipped (already at %s)", stepNum, total, in.step, in.dest)
+		if !opts.Force && fileExists(in.dest) {
+			if skipExistingArtifact(in.step, in.spec, in.dest, recordedDestSHA[in.step], stepNum, total, logf) {
 				r.Completed = append(r.Completed, in.step)
 				r.Skipped = append(r.Skipped, in.step)
 
 				continue
 			}
+			// Corrupted or staled binary (SHA mismatch / unverifiable): re-install
 		}
 
 		logf("[%d/%d] %s (%d bytes): downloading...", stepNum, total, in.step, in.spec.Size)
@@ -152,6 +161,16 @@ func Install(ctx context.Context, opts InstallOptions) (*Result, error) {
 
 			if info, statErr := os.Stat(in.dest); statErr == nil {
 				entry.Size = info.Size()
+			}
+
+			entry.DestSHA256 = in.spec.SHA256 // record on-disk binary hash for later verification
+			if in.spec.Extract != "" {
+				if h, hErr := FileSHA256(in.dest); hErr == nil {
+					entry.DestSHA256 = h
+				} else {
+					entry.DestSHA256 = "" // leave as unverified
+					logf("warning: cannot hash %s for audit: %v", in.dest, hErr)
+				}
 			}
 
 			auditArtifacts[in.step] = entry
@@ -239,6 +258,30 @@ func installArtifact(ctx context.Context, paths *Paths, spec ArtifactSpec, dest 
 		return nil
 	default:
 		return fmt.Errorf("install: unsupported extract type %q", spec.Extract)
+	}
+}
+
+func skipExistingArtifact(step string, spec ArtifactSpec, dest, recordedDestSHA string, stepNum, total int, logf func(string, ...any)) bool {
+	expected, ref := spec.SHA256, "manifest" // installed from raw binary
+	if spec.Extract != "" {
+		expected, ref = recordedDestSHA, "installed.json" // installed from tarball artifact
+	}
+	if expected == "" {
+		logf("[%d/%d] %s: skipped (already at %s; no recorded sha256 to verify)", stepNum, total, step, dest)
+		return true
+	}
+
+	got, err := FileSHA256(dest)
+	switch {
+	case err != nil:
+		logf("[%d/%d] %s: cannot verify existing %s (%v); re-downloading", stepNum, total, step, dest, err)
+		return false
+	case !strings.EqualFold(got, expected):
+		logf("[%d/%d] %s: existing %s failed sha256 check vs %s (got %s, want %s); re-downloading", stepNum, total, step, dest, ref, got, expected)
+		return false
+	default:
+		logf("[%d/%d] %s: skipped (already at %s, sha256 verified vs %s)", stepNum, total, step, dest, ref)
+		return true
 	}
 }
 

--- a/internal/bootstrap/install_test.go
+++ b/internal/bootstrap/install_test.go
@@ -164,6 +164,186 @@ func TestInstall_Idempotent_SkipsExistingBinaries(t *testing.T) {
 	}
 }
 
+func TestInstall_RepairCorruptBinary(t *testing.T) {
+	rune, _ := setRealms(t)
+	fx := newFixture(t)
+
+	if _, err := Install(context.Background(), InstallOptions{ManifestURL: fx.manifestURL()}); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	// Simulate partial/stale rune-mcp
+	mcpPath := filepath.Join(rune, "bin", "rune-mcp")
+	if err := os.WriteFile(mcpPath, []byte("corrupt-truncated"), 0o755); err != nil {
+		t.Fatalf("corrupt rune-mcp: %v", err)
+	}
+	beforeMCP, beforeRuned := fx.hits["/rune-mcp"], fx.hits["/runed"]
+
+	// Non-force install detect sha mismatch and repair it
+	r, err := Install(context.Background(), InstallOptions{ManifestURL: fx.manifestURL()})
+	if err != nil {
+		t.Fatalf("repair install: %v", err)
+	}
+	if !r.OK {
+		t.Errorf("Result.OK = false, want true (r=%+v)", r)
+	}
+
+	if fx.hits["/rune-mcp"] != beforeMCP+1 {
+		t.Errorf("rune-mcp not re-downloaded: hits=%d, want %d", fx.hits["/rune-mcp"], beforeMCP+1)
+	}
+	if got, _ := os.ReadFile(mcpPath); string(got) != string(fx.runeMCP) {
+		t.Errorf("rune-mcp not repaired: on-disk=%q, want %q", got, fx.runeMCP)
+	}
+
+	// Skip healthy runed binary
+	if fx.hits["/runed"] != beforeRuned {
+		t.Errorf("healthy runed re-downloaded: hits=%d, want %d", fx.hits["/runed"], beforeRuned)
+	}
+
+	skipped := map[string]bool{}
+	for _, s := range r.Skipped {
+		skipped[s] = true
+	}
+	if !skipped[StepRuned] {
+		t.Errorf("Skipped missing %s: %v", StepRuned, r.Skipped)
+	}
+	if skipped[StepRuneMCP] {
+		t.Errorf("corrupt %s should have been repaired, but not skipped: %v", StepRuneMCP, r.Skipped)
+	}
+}
+
+func TestInstall_SkipVerifiedTarball(t *testing.T) {
+	setRealms(t)
+	paths, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	runedTar := tarGz(t, filepath.Base(paths.RunedBinary), []byte("RUNED"))
+	mcpTar := tarGz(t, filepath.Base(paths.RuneMCPBinary), []byte("RUNE-MCP"))
+	url := tarballManifestServer(t, runedTar, mcpTar)
+
+	if _, err := Install(context.Background(), InstallOptions{ManifestURL: url}); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	r, err := Install(context.Background(), InstallOptions{ManifestURL: url})
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if r.Status != "no_op" {
+		t.Errorf("Status=%q, want no_op (both tar.gz artifacts verified and skipped)", r.Status)
+	}
+	if len(r.Installed) != 0 {
+		t.Errorf("Installed=%v, want empty (nothing re-extracted)", r.Installed)
+	}
+}
+
+func TestInstall_RepairCorruptTarball(t *testing.T) {
+	setRealms(t)
+	paths, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	runedTar := tarGz(t, filepath.Base(paths.RunedBinary), []byte("RUNED"))
+	mcpTar := tarGz(t, filepath.Base(paths.RuneMCPBinary), []byte("RUNE-MCP"))
+	url := tarballManifestServer(t, runedTar, mcpTar)
+
+	if _, err := Install(context.Background(), InstallOptions{ManifestURL: url}); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	// Make extracted runed binary as corrupted
+	if err := os.WriteFile(paths.RunedBinary, []byte("corrupt"), 0o755); err != nil {
+		t.Fatalf("corrupt runed: %v", err)
+	}
+
+	r, err := Install(context.Background(), InstallOptions{ManifestURL: url})
+	if err != nil {
+		t.Fatalf("repair install: %v", err)
+	}
+	if !r.OK {
+		t.Errorf("Result.OK = false, want true (r=%+v)", r)
+	}
+
+	// Corrupted runed should be re-installed
+	if got, _ := os.ReadFile(paths.RunedBinary); string(got) != "RUNED" {
+		t.Errorf("runed not repaired: on-disk=%q, want %q", got, "RUNED")
+	}
+
+	skipped := map[string]bool{}
+	for _, s := range r.Skipped {
+		skipped[s] = true
+	}
+	if skipped[StepRuned] {
+		t.Errorf("corrupt %s should have been repaired, but skipped: %v", StepRuned, r.Skipped)
+	}
+	if !skipped[StepRuneMCP] {
+		t.Errorf("healthy %s should be skipped: %v", StepRuneMCP, r.Skipped)
+	}
+}
+
+func TestInstall_TarballNoRecordedHash(t *testing.T) {
+	// tar.gz repair is conditional on a recorded dest hash. When installed.json
+	// has no hash for the step (a prior audit that couldn't hash the extracted
+	// file, or a missing/partial record), the skip path degrades to
+	// existence-only: a corrupt binary is reused, not repaired. This pins that
+	// documented fallback so it can't silently change.
+	setRealms(t)
+	paths, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	runedTar := tarGz(t, filepath.Base(paths.RunedBinary), []byte("RUNED"))
+	mcpTar := tarGz(t, filepath.Base(paths.RuneMCPBinary), []byte("RUNE-MCP"))
+	url := tarballManifestServer(t, runedTar, mcpTar)
+
+	if _, err := Install(context.Background(), InstallOptions{ManifestURL: url}); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	rec, err := ReadInstalledManifest(paths)
+	if err != nil {
+		t.Fatalf("read installed.json: %v", err)
+	}
+
+	a := rec.Artifacts[StepRuned]
+	a.DestSHA256 = "" // extracted runed binary is not hashed
+	rec.Artifacts[StepRuned] = a
+
+	data, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal installed.json: %v", err)
+	}
+	if err := os.WriteFile(paths.InstalledManifest, data, 0o600); err != nil {
+		t.Fatalf("rewrite installed.json: %v", err)
+	}
+
+	// Make runed as corrupted
+	if err := os.WriteFile(paths.RunedBinary, []byte("corrupt"), 0o755); err != nil {
+		t.Fatalf("corrupt runed: %v", err)
+	}
+
+	r, err := Install(context.Background(), InstallOptions{ManifestURL: url})
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// 'runed' is not repaired if hash is not recorded
+	skipped := map[string]bool{}
+	for _, s := range r.Skipped {
+		skipped[s] = true
+	}
+	if !skipped[StepRuned] {
+		t.Errorf("with no recorded hash, runed re-install should be skipped; Skipped=%v", r.Skipped)
+	}
+	if got, _ := os.ReadFile(paths.RunedBinary); string(got) != "corrupt" {
+		t.Errorf("repair should be skipped; runed on-disk=%q, want %q", got, "corrupt")
+	}
+}
+
 func TestInstall_Force_ReDownloadsAllBinaries(t *testing.T) {
 	setRealms(t)
 	fx := newFixture(t)


### PR DESCRIPTION
Previously install is skipped if there already exist pre-installed binaries at the same path without verification.
Now we also verify them and repair if they are corrupted or staled.