### PR TITLE
feat: minor updates for future works

### DIFF
--- a/cmd/rune/main_test.go
+++ b/cmd/rune/main_test.go
@@ -16,6 +16,10 @@ func TestRunVersion_PrintConstants(t *testing.T) {
 	manifestURL = "https://example/manifest.json"
 	defer func() { manifestURL = saved }()
 
+	dir := t.TempDir()
+	t.Setenv("RUNE_HOME", filepath.Join(dir, "rune"))
+	t.Setenv("RUNED_HOME", filepath.Join(dir, "runed"))
+
 	var buf bytes.Buffer
 	if code := runVersion(&buf); code != 0 {
 		t.Errorf("exit = %d, want 0", code)
@@ -35,6 +39,10 @@ func TestRunVersion_EmptyManifest(t *testing.T) {
 	defer func() { manifestURL = saved }()
 	t.Setenv("RUNE_MANIFEST", "")
 
+	dir := t.TempDir()
+	t.Setenv("RUNE_HOME", filepath.Join(dir, "rune"))
+	t.Setenv("RUNED_HOME", filepath.Join(dir, "runed"))
+
 	var buf bytes.Buffer
 	_ = runVersion(&buf)
 	// Match the actual "manifest missing" copy in version.go's empty
@@ -42,6 +50,62 @@ func TestRunVersion_EmptyManifest(t *testing.T) {
 	// require keeping two strings in lockstep.
 	if !strings.Contains(buf.String(), "manifest missing") {
 		t.Errorf("empty manifest should be flagged; got %q", buf.String())
+	}
+}
+
+func TestRunVersion_ShowsInstalledVersion(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RUNE_HOME", filepath.Join(dir, "rune"))
+	t.Setenv("RUNED_HOME", filepath.Join(dir, "runed"))
+
+	paths, err := bootstrap.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if err := paths.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	m := &bootstrap.Manifest{Version: 1, RuneMCPVersion: "v0.1.1", RunedVersion: "v0.1.3"}
+	arts := map[string]bootstrap.InstalledArtifact{
+		bootstrap.StepRuneMCP: {Path: paths.RuneMCPBinary, SHA256: "aaa"},
+		bootstrap.StepRuned:   {Path: paths.RunedBinary, SHA256: "bbb"},
+	}
+
+	if err := bootstrap.WriteInstalledManifest(paths, "https://example/manifest.json", m, arts); err != nil {
+		t.Fatalf("WriteInstalledManifest: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if code := runVersion(&buf); code != 0 {
+		t.Errorf("exit = %d, want 0", code)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "v0.1.1") {
+		t.Errorf("missing installed rune-mcp version: %q", out)
+	}
+	if !strings.Contains(out, "v0.1.3") {
+		t.Errorf("missing installed runed version: %q", out)
+	}
+}
+
+func TestRunVersion_NoInstalledManifest(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RUNE_HOME", filepath.Join(dir, "rune"))
+	t.Setenv("RUNED_HOME", filepath.Join(dir, "runed"))
+
+	var buf bytes.Buffer
+	if code := runVersion(&buf); code != 0 {
+		t.Errorf("exit = %d, want 0", code)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "rune ") {
+		t.Errorf("CLI version line must be printed: %q", out)
+	}
+	if strings.Contains(out, "rune-mcp:") || strings.Contains(out, "runed:") {
+		t.Errorf("should not print installed versions when installed.json is absent: %q", out)
 	}
 }
 
@@ -196,6 +260,9 @@ func TestRunVersion_CheckManifestEnv(t *testing.T) {
 	defer func() { manifestURL = saved }()
 
 	t.Setenv("RUNE_MANIFEST", "https://example.invalid/m.json")
+	dir := t.TempDir()
+	t.Setenv("RUNE_HOME", filepath.Join(dir, "rune"))
+	t.Setenv("RUNED_HOME", filepath.Join(dir, "runed"))
 
 	var buf bytes.Buffer
 	if code := runVersion(&buf); code != 0 {

--- a/cmd/rune/runed.go
+++ b/cmd/rune/runed.go
@@ -62,7 +62,11 @@ func runRuned(ctx context.Context, args []string, stderr io.Writer) int {
 		RunedArgs:   forwardedArgs,
 		LogPath:     paths.DaemonLog,
 		LockPath:    paths.SupervisorLock,
+		PIDPath:     paths.SupervisorPID,
 	}
+
+	// If supervisor mode exit with 0, it indciates "success to try spwaning supervisor",
+	// not "supervisor daemon healthy"
 	if err := supervisor.RunDetached(ctx, cfg); err != nil {
 		fmt.Fprintf(stderr, "rune: supervisor: %v\n", err)
 		return 1

--- a/cmd/rune/version.go
+++ b/cmd/rune/version.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/CryptoLabInc/rune-cli/internal/bootstrap"
 )
 
 func runVersion(w io.Writer) int {
@@ -17,6 +19,21 @@ func runVersion(w io.Writer) int {
 		fmt.Fprintf(w, "manifest: %s\n", manifest)
 	} else {
 		fmt.Fprintln(w, "manifest missing: supply --manifest-url or RUNE_MANIFEST")
+	}
+
+	// Show latest installed rune-mcp/runed (skip if not installed yet)
+	if paths, err := bootstrap.Resolve(); err == nil {
+		if rec, rerr := bootstrap.ReadInstalledManifest(paths); rerr == nil && rec != nil {
+			if rec.RuneMCPVersion != "" {
+				fmt.Fprintf(w, "rune-mcp: %s\n", rec.RuneMCPVersion)
+			}
+			if rec.RunedVersion != "" {
+				fmt.Fprintf(w, "runed: %s\n", rec.RunedVersion)
+			}
+			if rec.InstalledAt != "" {
+				fmt.Fprintf(w, "installed: %s\n", rec.InstalledAt)
+			}
+		}
 	}
 
 	return 0

--- a/internal/bootstrap/paths.go
+++ b/internal/bootstrap/paths.go
@@ -53,6 +53,7 @@ type Paths struct {
 	LlamaServer    string // ~/.runed/bin/llama-server (extracted from runed tarball; RUNED_LLAMA_SERVER env points here)
 	InstallLock    string // ~/.runed/install.lock
 	SupervisorLock string // ~/.runed/supervisor.lock (`rune runed --detach` hold it during lifetime)
+	SupervisorPID  string // ~/.runed/supervisor.pid (PID of the running supervisor; removed on exit but SIGKILLed supervisor might leave it)
 	DaemonLog      string // ~/.runed/logs/daemon.log
 	Cache          string // ~/.runed/cache
 }
@@ -109,6 +110,7 @@ func newPaths(runeHome, runedHome string) *Paths {
 		LlamaServer:    filepath.Join(runedBin, "llama-server"),
 		InstallLock:    filepath.Join(runedHome, "install.lock"),
 		SupervisorLock: filepath.Join(runedHome, "supervisor.lock"),
+		SupervisorPID:  filepath.Join(runedHome, "supervisor.pid"),
 		DaemonLog:      filepath.Join(runedHome, "logs", "daemon.log"),
 		Cache:          filepath.Join(runedHome, "cache"),
 	}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"time"
 )
@@ -17,6 +18,7 @@ type Config struct {
 	RunedArgs   []string
 	LogPath     string // default: ~/.runed/logs/daemon.log
 	LockPath    string // default: ~/.runed/supervisor.lock
+	PIDPath     string // ~/.runed/supervisor.pid; removed on exit
 
 	BackoffSchedule []time.Duration // nil for DefaultBackoff
 	MaxCrashes      int             // 0 for DefaultMaxCrashes
@@ -99,6 +101,15 @@ func runSupervisor(ctx context.Context, cfg Config) error {
 // machinery.
 func runWatcher(ctx context.Context, cfg Config) error {
 	cfg = applyDefaults(cfg)
+
+	// Record supervisor's PID so other process can stop / check liveness later
+	if cfg.PIDPath != "" {
+		if err := os.WriteFile(cfg.PIDPath, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o600); err != nil {
+			fmt.Fprintf(os.Stderr, "supervisor: cannot write pid file %s: %v\n", cfg.PIDPath, err) // not error
+		} else {
+			defer os.Remove(cfg.PIDPath)
+		}
+	}
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -220,6 +221,49 @@ func TestWatcher_ForwardSignalToChild(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("runWatcher did not return after SIGTERM - signal not forwarded")
+	}
+}
+
+func TestWatcher_CheckPIDFile(t *testing.T) {
+	t.Setenv(fakeRunedEnv, "sleep")
+	cfg := testWatcherConfig(t)
+	cfg.PIDPath = filepath.Join(t.TempDir(), "supervisor.pid")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runWatcher(ctx, cfg) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(cfg.PIDPath); err == nil {
+			break
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatal("pid file not written")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	data, err := os.ReadFile(cfg.PIDPath)
+	if err != nil {
+		t.Fatalf("read pid file: %v", err)
+	}
+
+	if got := strings.TrimSpace(string(data)); got != strconv.Itoa(os.Getpid()) {
+		t.Errorf("pid file = %q, want %d (supervisor's PID)", got, os.Getpid())
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not exit after cancel")
+	}
+
+	if _, err := os.Stat(cfg.PIDPath); !os.IsNotExist(err) {
+		t.Errorf("pid file should be removed on exit; stat err = %v", err)
 	}
 }
 


### PR DESCRIPTION
- `rune version` also shows installed version of `rune-mcp` and `runed`
- `runed` watcher writes it's PID which makes supervisor addressable; we can utilize this for future updates such as `/rune:update`