### PR TITLE
feat: support in-place update for Rune runtime binaries (`rune-mcp`, `runed`)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -241,6 +241,37 @@ branch on `diagnostics.vault.last_boot_error`.)
    to Dormant on the next reload because no config means no Vault dial)
 3. Show reconfiguration instructions
 
+### `/rune:update`
+(or `$rune update` for Codex CLI)
+
+**Purpose**: Update the runtime binaries (rune-mcp, runed) in place to the
+versions in the published manifest — no plugin uninstall/reinstall. Plugin
+*assets* (commands, agents, SKILL.md) still need the host's plugin-update
+mechanism; they are not covered here.
+
+Non-destructive; no confirmation prompt and no activation-state gate (works
+whether Active or Dormant). The agent runs the CLI — the user never types it.
+
+**Steps**:
+1. Run `~/.rune/bin/rune update` (fall back to
+   `bash -c "${CLAUDE_PLUGIN_ROOT}/bin/rune update"` only if the installed
+   binary is absent). Append `--check` to report without applying when the
+   user asks to check.
+2. Relay output verbatim, then interpret:
+   - `all binaries are up to date` → nothing to do.
+   - `updated rune_mcp: … (applies on the next session; run /mcp to reconnect
+     now)` → applies in a new session automatically; `/mcp` reconnect applies
+     it now.
+   - `updated runed: … (daemon reloaded)` → live daemon restarted onto the
+     new binary; a brief embedder blip is expected.
+   - `updated runed: … (staged; applies on next daemon start)` → no supervisor
+     was running; run `/rune:activate` to start it now.
+3. On a failed runed reload (exit 1, `supervisor reload …`): the daemon may be
+   down and the recorded version was **not** advanced. Relay the recovery hint
+   verbatim and suggest `/rune:activate`. On `no manifest URL configured`
+   (exit 2): this build has no update channel wired — report plainly, not a
+   misconfiguration. Do not retry or loop.
+
 ## Boot Failure — Fast-Fail Rule
 
 When `diagnostics.vault.last_boot_error` is present, that field is the boot

--- a/SKILL.md
+++ b/SKILL.md
@@ -253,10 +253,11 @@ Non-destructive; no confirmation prompt and no activation-state gate (works
 whether Active or Dormant). The agent runs the CLI — the user never types it.
 
 **Steps**:
-1. Run `~/.rune/bin/rune update` (fall back to
-   `bash -c "${CLAUDE_PLUGIN_ROOT}/bin/rune update"` only if the installed
-   binary is absent). Append `--check` to report without applying when the
-   user asks to check.
+1. Run `~/.rune/bin/rune update --plugin-root "${CLAUDE_PLUGIN_ROOT}"` (fall
+   back to `bash -c "${CLAUDE_PLUGIN_ROOT}/bin/rune update --plugin-root
+   ${CLAUDE_PLUGIN_ROOT}"` only if the installed binary is absent). Append
+   `--check` to report without applying when the user asks to check. The
+   `--plugin-root` lets the CLI flag plugin/binary version outdated (step 4).
 2. Relay output verbatim, then interpret:
    - `all binaries are up to date` → nothing to do.
    - `updated rune_mcp: … (applies on the next session; run /mcp to reconnect
@@ -271,6 +272,16 @@ whether Active or Dormant). The agent runs the CLI — the user never types it.
    verbatim and suggest `/rune:activate`. On `no manifest URL configured`
    (exit 2): this build has no update channel wired — report plainly, not a
    misconfiguration. Do not retry or loop.
+4. **Plugin-version outdated** (binaries update, but plugin assets — commands,
+   agents, SKILL.md — can only be updated by the host):
+   - `note: plugin package is X; these binaries expect Y` (exit 0) → the update
+     succeeded; suggest `claude plugin update rune` when convenient. No urgency.
+   - `refusing to apply: plugin package X is below the minimum Y` (exit 1) →
+     nothing applied; tell the user to update the plugin first, then re-run.
+     `--allow-plugin-outdated` forces it but can break the assets — only on explicit
+     insistence.
+   - `--check`'s `plugin outdated: … BELOW the minimum …` → report; update the
+     plugin before applying.
 
 ## Boot Failure — Fast-Fail Rule
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -252,6 +252,12 @@ mechanism; they are not covered here.
 Non-destructive; no confirmation prompt and no activation-state gate (works
 whether Active or Dormant). The agent runs the CLI — the user never types it.
 
+`rune mcp-server` also runs a throttled, non-blocking background check at
+session start that stages a newer **rune-mcp** for the next session (silent;
+never touches runed). `/rune:update` is the explicit, immediate path. Disable
+the background check with `RUNE_NO_AUTO_UPDATE=1` (does not affect
+`/rune:update`).
+
 **Steps**:
 1. Run `~/.rune/bin/rune update --plugin-root "${CLAUDE_PLUGIN_ROOT}"` (fall
    back to `bash -c "${CLAUDE_PLUGIN_ROOT}/bin/rune update --plugin-root

--- a/cmd/rune/detachstub.go
+++ b/cmd/rune/detachstub.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package main
+
+import "os/exec"
+
+func setDetached(*exec.Cmd) bool { return false } // no-op on non-unix platforms

--- a/cmd/rune/detachunix.go
+++ b/cmd/rune/detachunix.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func setDetached(cmd *exec.Cmd) bool {
+	// Make child as own session
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setsid = true
+
+	return true
+}

--- a/cmd/rune/main.go
+++ b/cmd/rune/main.go
@@ -101,6 +101,8 @@ Usage:
         ~/.runed/logs/daemon.log + auto-restart on crash
   rune runed --status
         query running supervisor
+  rune runed --reload
+        ask supervisor to restart runed with on-disk binary
 
 Environment:
   RUNE_HOME       override ~/.rune/  (rune plugin realm: config + rune-mcp)

--- a/cmd/rune/mcpserver.go
+++ b/cmd/rune/mcpserver.go
@@ -71,7 +71,7 @@ func runMCPServer(ctx context.Context, args []string, stderr io.Writer) int {
 	return execInstalledBinary(ctx, paths.RuneBin, "rune-mcp", args, nil, stderr)
 }
 
-var spawnUpdateFn = spawnDetachedUpdate // backgorund update launcher
+var spawnUpdateFn = spawnDetachedUpdate // background update launcher
 
 var errBackgroundUnsupported = errors.New("detached background update not supported on this platform")
 
@@ -120,7 +120,7 @@ func spawnDetachedUpdate(paths *bootstrap.Paths, manifest string) error {
 	}
 	defer logFile.Close()
 
-	// Runed is excluded since mcp server does not handle it's lifecycle
+	// Runed is excluded since mcp server does not handle its lifecycle
 	cmd := exec.Command(exe, "update", "--only", bootstrap.StepRuneMCP, "--manifest-url", manifest)
 	cmd.Stdin = nil
 	cmd.Stdout = logFile

--- a/cmd/rune/mcpserver.go
+++ b/cmd/rune/mcpserver.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"time"
 
 	"github.com/CryptoLabInc/rune-cli/internal/bootstrap"
@@ -23,7 +25,9 @@ func runMCPServer(ctx context.Context, args []string, stderr io.Writer) int {
 	// Fresh `claude plugin install rune` try to spawn MCP server via
 	// "${CLAUDE_PLUGIN_ROOT}/bin/rune mcp-server" which does not exist yet.
 	// Self-install rune-mcp itself in this case.
+	justInstalled := false
 	if _, statErr := os.Stat(paths.RuneMCPBinary); statErr != nil {
+		justInstalled = true
 		fmt.Fprintln(stderr, "rune: rune-mcp not installed yet; fetching before launch...")
 		manifest := manifestURL
 		if env := os.Getenv("RUNE_MANIFEST"); env != "" {
@@ -59,7 +63,78 @@ func runMCPServer(ctx context.Context, args []string, stderr io.Writer) int {
 		}
 	}
 
+	if !justInstalled {
+		tryAutoCheck(paths, stderr)
+	}
+
 	return execInstalledBinary(ctx, paths.RuneBin, "rune-mcp", args, nil, stderr)
+}
+
+var spawnUpdateFn = spawnDetachedUpdate // backgorund update launcher
+
+var errBackgroundUnsupported = errors.New("detached background update not supported on this platform")
+
+func resolvedManifest() string {
+	m := manifestURL
+	if env := os.Getenv("RUNE_MANIFEST"); env != "" {
+		m = env
+	}
+	return m
+}
+
+func tryAutoCheck(paths *bootstrap.Paths, stderr io.Writer) {
+	if bootstrap.AutoUpdateDisabled() {
+		return
+	}
+
+	manifest := resolvedManifest()
+	if manifest == "" {
+		return
+	}
+	if !bootstrap.ShouldAutoCheck(paths.AutoCheckStamp, bootstrap.AutoCheckInterval(), time.Now()) {
+		return
+	}
+
+	// Record first to prevent re-spawn on reconnection
+	if err := bootstrap.RecordAutoCheck(paths.AutoCheckStamp, time.Now()); err != nil {
+		return
+	}
+	if err := spawnUpdateFn(paths, manifest); err != nil {
+		fmt.Fprintf(stderr, "rune: background update check not started: %v\n", err)
+	}
+}
+
+func spawnDetachedUpdate(paths *bootstrap.Paths, manifest string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(paths.UpdateLog), 0o700); err != nil {
+		return err
+	}
+	logFile, err := os.OpenFile(paths.UpdateLog, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o600)
+	if err != nil {
+		return err
+	}
+	defer logFile.Close()
+
+	// Runed is excluded since mcp server does not handle it's lifecycle
+	cmd := exec.Command(exe, "update", "--only", bootstrap.StepRuneMCP, "--manifest-url", manifest)
+	cmd.Stdin = nil
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if !setDetached(cmd) {
+		return errBackgroundUnsupported
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	go func() { _ = cmd.Wait() }() // child exit
+
+	return nil
 }
 
 func waitForFile(ctx context.Context, path string, timeout time.Duration) bool {

--- a/cmd/rune/mcpserver.go
+++ b/cmd/rune/mcpserver.go
@@ -27,7 +27,6 @@ func runMCPServer(ctx context.Context, args []string, stderr io.Writer) int {
 	// Self-install rune-mcp itself in this case.
 	justInstalled := false
 	if _, statErr := os.Stat(paths.RuneMCPBinary); statErr != nil {
-		justInstalled = true
 		fmt.Fprintln(stderr, "rune: rune-mcp not installed yet; fetching before launch...")
 		manifest := manifestURL
 		if env := os.Getenv("RUNE_MANIFEST"); env != "" {
@@ -61,6 +60,8 @@ func runMCPServer(ctx context.Context, args []string, stderr io.Writer) int {
 
 			fmt.Fprintln(stderr, "rune: rune-mcp installed by a concurrent session")
 		}
+
+		justInstalled = true
 	}
 
 	if !justInstalled {

--- a/cmd/rune/mcpserver_test.go
+++ b/cmd/rune/mcpserver_test.go
@@ -151,3 +151,91 @@ func TestWaitForFile_Timeout(t *testing.T) {
 		t.Errorf("returned %s before the 200ms timeout", elapsed)
 	}
 }
+
+// Background update launcher for test
+func stubSpawn(t *testing.T) *int {
+	t.Helper()
+
+	n := 0
+	prev := spawnUpdateFn
+	spawnUpdateFn = func(_ *bootstrap.Paths, _ string) error {
+		n++
+		return nil
+	}
+
+	t.Cleanup(func() { spawnUpdateFn = prev })
+
+	return &n
+}
+
+func TestTryAutoCheck_Due(t *testing.T) {
+	paths := setTestEnv(t)
+	t.Setenv("RUNE_MANIFEST", "http://example.invalid/manifest.json")
+	t.Setenv("RUNE_NO_AUTO_UPDATE", "")
+
+	calls := stubSpawn(t)
+
+	var stderr bytes.Buffer
+	tryAutoCheck(paths, &stderr)
+
+	if *calls != 1 {
+		t.Errorf("spawn calls = %d, want 1 when a check is due", *calls)
+	}
+
+	if _, err := os.Stat(paths.AutoCheckStamp); err != nil {
+		t.Errorf("expected the auto-check stamp to be recorded before spawning: %v", err)
+	}
+}
+
+func TestTryAutoCheck_Disabled(t *testing.T) {
+	paths := setTestEnv(t)
+	t.Setenv("RUNE_MANIFEST", "http://example.invalid/manifest.json")
+	t.Setenv("RUNE_NO_AUTO_UPDATE", "1")
+
+	calls := stubSpawn(t)
+
+	var stderr bytes.Buffer
+	tryAutoCheck(paths, &stderr)
+
+	if *calls != 0 {
+		t.Errorf("spawn calls = %d, want 0 when disabled", *calls)
+	}
+
+	if _, err := os.Stat(paths.AutoCheckStamp); err == nil {
+		t.Error("disabled run must not write the stamp")
+	}
+}
+
+func TestTryAutoCheck_Throttled(t *testing.T) {
+	paths := setTestEnv(t)
+	t.Setenv("RUNE_MANIFEST", "http://example.invalid/manifest.json")
+	t.Setenv("RUNE_NO_AUTO_UPDATE", "")
+
+	if err := bootstrap.RecordAutoCheck(paths.AutoCheckStamp, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := stubSpawn(t)
+
+	var stderr bytes.Buffer
+	tryAutoCheck(paths, &stderr)
+
+	if *calls != 0 {
+		t.Errorf("spawn calls = %d, want 0 within the throttle window", *calls)
+	}
+}
+
+func TestTryAutoCheck_NoManifest(t *testing.T) {
+	paths := setTestEnv(t)
+	t.Setenv("RUNE_MANIFEST", "")
+	t.Setenv("RUNE_NO_AUTO_UPDATE", "")
+
+	calls := stubSpawn(t)
+
+	var stderr bytes.Buffer
+	tryAutoCheck(paths, &stderr)
+
+	if *calls != 0 {
+		t.Errorf("spawn calls = %d, want 0 with no manifest configured", *calls)
+	}
+}

--- a/cmd/rune/runed.go
+++ b/cmd/rune/runed.go
@@ -29,6 +29,11 @@ func runRuned(ctx context.Context, args []string, stdout, stderr io.Writer) int 
 		return runedStatus(paths, stdout)
 	}
 
+	// `rune runed --reload`: ask supervisor to restart runed
+	if hasFlag(args, "--reload") {
+		return runedReload(paths, stdout)
+	}
+
 	// If a llama-server is present in ~/.runed/bin, point runed at it so it skips
 	// re-download. When it's absent, leave the env UNSET so runed
 	// self-bootstraps llama-server on first boot. Set on the process env (rather
@@ -112,6 +117,22 @@ func runedStatus(paths *bootstrap.Paths, stdout io.Writer) int {
 	}
 
 	fmt.Fprintf(stdout, "runed supervisor: running (pid %d)\n", resp.PID)
+
+	return 0
+}
+
+func runedReload(paths *bootstrap.Paths, stdout io.Writer) int {
+	resp, err := supervisor.SupervisorRequest(paths.SupervisorSock, supervisor.Request{Cmd: "reload"})
+	if err != nil {
+		fmt.Fprintln(stdout, "runed supervisor: not running (nothing to reload)")
+		return 1
+	}
+	if !resp.OK {
+		fmt.Fprintf(stdout, "runed reload failed: %s\n", resp.Error)
+		return 1
+	}
+
+	fmt.Fprintln(stdout, "runed reloaded")
 
 	return 0
 }

--- a/cmd/rune/runed_test.go
+++ b/cmd/rune/runed_test.go
@@ -95,6 +95,46 @@ func TestRunRuned_StatusNotRunning(t *testing.T) {
 	}
 }
 
+func TestRunRuned_ReloadNotRunning(t *testing.T) {
+	runedEnv(t) // no supervisor listening
+
+	var stdout, stderr bytes.Buffer
+	if code := runRuned(context.Background(), []string{"--reload"}, &stdout, &stderr); code != 1 {
+		t.Errorf("exit = %d, want 1 (no supervisor to reload)", code)
+	}
+	if !strings.Contains(stdout.String(), "not running") {
+		t.Errorf("stdout = %q", stdout.String())
+	}
+}
+
+func TestRunRuned_ReloadFailed(t *testing.T) {
+	paths := runedEnv(t)
+
+	ln, err := net.Listen("unix", paths.SupervisorSock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var req map[string]any
+		_ = json.NewDecoder(conn).Decode(&req)
+		_ = json.NewEncoder(conn).Encode(map[string]any{"ok": false, "error": "restart failed to start"})
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if code := runRuned(context.Background(), []string{"--reload"}, &stdout, &stderr); code != 1 {
+		t.Errorf("exit = %d, want 1 (reload reported failure)", code)
+	}
+	if !strings.Contains(stdout.String(), "reload failed") {
+		t.Errorf("stdout = %q, want 'reload failed'", stdout.String())
+	}
+}
+
 func TestRunRuned_StatusRunning(t *testing.T) {
 	paths := runedEnv(t)
 

--- a/cmd/rune/update.go
+++ b/cmd/rune/update.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/CryptoLabInc/rune-cli/internal/bootstrap"
 	"github.com/CryptoLabInc/rune-cli/internal/supervisor"
@@ -22,11 +23,18 @@ func runUpdate(ctx context.Context, args []string, stdout, stderr io.Writer) int
 	manifest := fs.String("manifest-url", manifestURL, "override manifest URL")
 	pluginRoot := fs.String("plugin-root", "", "plugin root for the plugin version check (defaults to $CLAUDE_PLUGIN_ROOT)")
 	allowOutdated := fs.Bool("allow-plugin-outdated", false, "apply even if the plugin package is older than the binaries require")
+	only := fs.String("only", "", "restrict to a comma-separated set of artifacts: rune_mcp, runed")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 	if fs.NArg() > 0 {
 		fmt.Fprintf(stderr, "rune update: unexpected argument: %v\n", fs.Args())
+		return 2
+	}
+
+	onlySteps, err := parseOnly(*only)
+	if err != nil {
+		fmt.Fprintf(stderr, "rune update: %v\n", err)
 		return 2
 	}
 
@@ -51,6 +59,9 @@ func runUpdate(ctx context.Context, args []string, stdout, stderr io.Writer) int
 	if err != nil {
 		fmt.Fprintf(stderr, "rune update: %v\n", err)
 		return 1
+	}
+	if len(onlySteps) > 0 {
+		plan = filterPlan(plan, onlySteps)
 	}
 
 	pv, verr := bootstrap.InstalledPluginVersion(*pluginRoot)
@@ -226,4 +237,36 @@ func applyUpdate(ctx context.Context, manifest string, plan *bootstrap.UpdateLis
 
 func runedRecoveryHint(paths *bootstrap.Paths) string {
 	return fmt.Sprintf("the daemon may be down - run `%s runed --detach` (or /rune:activate) to restart it", paths.RuneCLIBinary)
+}
+
+func parseOnly(only string) (map[string]bool, error) {
+	set := map[string]bool{}
+	for _, tok := range strings.Split(only, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		if tok != bootstrap.StepRuneMCP && tok != bootstrap.StepRuned {
+			return nil, fmt.Errorf("--only: unknown artifact %q (want %s or %s)", tok, bootstrap.StepRuneMCP, bootstrap.StepRuned)
+		}
+
+		set[tok] = true
+	}
+
+	if strings.TrimSpace(only) != "" && len(set) == 0 {
+		return nil, fmt.Errorf("--only: no valid artifacts in %q", only)
+	}
+
+	return set, nil
+}
+
+func filterPlan(plan *bootstrap.UpdateList, want map[string]bool) *bootstrap.UpdateList {
+	out := &bootstrap.UpdateList{}
+	for _, a := range plan.Artifacts {
+		if want[a.Step] {
+			out.Artifacts = append(out.Artifacts, a)
+		}
+	}
+
+	return out
 }

--- a/cmd/rune/update.go
+++ b/cmd/rune/update.go
@@ -20,6 +20,8 @@ func runUpdate(ctx context.Context, args []string, stdout, stderr io.Writer) int
 	check := fs.Bool("check", false, "report available updates without applying")
 	jsonOut := fs.Bool("json", false, "emit JSON")
 	manifest := fs.String("manifest-url", manifestURL, "override manifest URL")
+	pluginRoot := fs.String("plugin-root", "", "plugin root for the plugin version check (defaults to $CLAUDE_PLUGIN_ROOT)")
+	allowOutdated := fs.Bool("allow-plugin-outdated", false, "apply even if the plugin package is older than the binaries require")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -39,20 +41,32 @@ func runUpdate(ctx context.Context, args []string, stdout, stderr io.Writer) int
 		return 2
 	}
 
-	plan, err := bootstrap.CheckUpdate(ctx, *manifest, nil)
+	mf, err := bootstrap.FetchManifest(ctx, *manifest, nil)
 	if err != nil {
 		fmt.Fprintf(stderr, "rune update: %v\n", err)
 		return 1
 	}
 
-	if *check {
-		return reportUpdatePlan(stdout, plan, *jsonOut)
+	plan, err := bootstrap.PlanFromManifest(mf)
+	if err != nil {
+		fmt.Fprintf(stderr, "rune update: %v\n", err)
+		return 1
 	}
 
-	return applyUpdate(ctx, *manifest, plan, stdout, stderr, *jsonOut)
+	pv, verr := bootstrap.InstalledPluginVersion(*pluginRoot)
+	compat := bootstrap.EvaluatePluginCompatibility(pv, mf)
+	if verr != nil && mf.MinPluginVersion != "" && !*jsonOut {
+		fmt.Fprintf(stderr, "rune update: note: could not read the installed plugin version (%v); skipping the plugin-compatibility check; pass --plugin-root\n", verr)
+	}
+
+	if *check {
+		return reportUpdatePlan(stdout, plan, compat, *jsonOut)
+	}
+
+	return applyUpdate(ctx, *manifest, plan, compat, *allowOutdated, stdout, stderr, *jsonOut)
 }
 
-func reportUpdatePlan(w io.Writer, plan *bootstrap.UpdateList, jsonOut bool) int {
+func reportUpdatePlan(w io.Writer, plan *bootstrap.UpdateList, compat bootstrap.PluginCompatibility, jsonOut bool) int {
 	if jsonOut {
 		_ = json.NewEncoder(w).Encode(plan)
 		return 0
@@ -60,21 +74,31 @@ func reportUpdatePlan(w io.Writer, plan *bootstrap.UpdateList, jsonOut bool) int
 
 	if !plan.HasUpdates() {
 		fmt.Fprintln(w, "rune: all binaries are up to date")
-		return 0
+	} else {
+		fmt.Fprintln(w, "Available updates:")
+		for _, a := range plan.Outdated() {
+			fmt.Fprintf(w, "  %s: %s -> %s\n", a.Step, a.Installed, a.Available)
+		}
 	}
 
-	fmt.Fprintln(w, "Available updates:")
-	for _, a := range plan.Outdated() {
-		fmt.Fprintf(w, "  %s: %s -> %s\n", a.Step, a.Installed, a.Available)
-	}
-
+	reportPluginOutdated(w, compat)
 	return 0
 }
 
+func reportPluginOutdated(w io.Writer, compat bootstrap.PluginCompatibility) {
+	switch {
+	case compat.BelowMinimum:
+		fmt.Fprintf(w, "plugin outdated: installed %s is BELOW the minimum %s required by these binaries - update the plugin before applying\n", compat.Installed, compat.Minimum)
+	case compat.Behind:
+		fmt.Fprintf(w, "plugin update available: installed %s, binaries expect %s\n", compat.Installed, compat.Expected)
+	}
+}
+
 type updateSummary struct {
-	Applied  []appliedUpdate `json:"applied"`
-	Deferred []string        `json:"deferred,omitempty"`
-	Error    string          `json:"error,omitempty"`
+	Applied  []appliedUpdate                `json:"applied"`
+	Deferred []string                       `json:"deferred,omitempty"`
+	Error    string                         `json:"error,omitempty"`
+	Plugin   *bootstrap.PluginCompatibility `json:"plugin,omitempty"`
 }
 
 type appliedUpdate struct {
@@ -83,8 +107,11 @@ type appliedUpdate struct {
 	To   string `json:"to"`
 }
 
-func applyUpdate(ctx context.Context, manifest string, plan *bootstrap.UpdateList, stdout, stderr io.Writer, jsonOut bool) int {
+func applyUpdate(ctx context.Context, manifest string, plan *bootstrap.UpdateList, compat bootstrap.PluginCompatibility, allowOutdated bool, stdout, stderr io.Writer, jsonOut bool) int {
 	out := updateSummary{Applied: []appliedUpdate{}}
+	if compat.Known {
+		out.Plugin = &compat
+	}
 
 	logf := func(string, ...any) {}
 	if !jsonOut {
@@ -96,8 +123,22 @@ func applyUpdate(ctx context.Context, manifest string, plan *bootstrap.UpdateLis
 			_ = json.NewEncoder(stdout).Encode(out)
 		} else {
 			fmt.Fprintln(stdout, "rune: all binaries are up to date")
+			reportPluginOutdated(stdout, compat)
 		}
 		return 0
+	}
+
+	if compat.BelowMinimum && !allowOutdated {
+		msg := fmt.Sprintf("plugin package %s is below the minimum %s required by the new binaries", compat.Installed, compat.Minimum)
+		out.Error = msg
+		if jsonOut {
+			_ = json.NewEncoder(stdout).Encode(out)
+		} else {
+			fmt.Fprintf(stderr, "rune update: refusing to apply: %s.\n", msg)
+			fmt.Fprintf(stderr, "  Update the plugin first then re-run.\n")
+			fmt.Fprintf(stderr, "  Ignore with --allow-plugin-outdated\n")
+		}
+		return 1
 	}
 
 	paths, err := bootstrap.Resolve()
@@ -164,6 +205,15 @@ func applyUpdate(ctx context.Context, manifest string, plan *bootstrap.UpdateLis
 					fmt.Fprintf(stdout, "updated %s: %s -> %s (staged; applies on next daemon start)\n", a.Step, a.Installed, to)
 				}
 			}
+		}
+	}
+
+	if !jsonOut {
+		switch {
+		case compat.BelowMinimum && allowOutdated:
+			fmt.Fprintf(stderr, "warning: applied with --allow-plugin-outdated; plugin %s is below the required %s - update the plugin.\n", compat.Installed, compat.Minimum)
+		case compat.Behind:
+			fmt.Fprintf(stdout, "note: plugin package is %s; these binaries expect %s. Update plugin to keep commands/agents/SKILL.md in sync best.\n", compat.Installed, compat.Expected)
 		}
 	}
 

--- a/cmd/rune/update.go
+++ b/cmd/rune/update.go
@@ -3,12 +3,14 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/CryptoLabInc/rune-cli/internal/bootstrap"
+	"github.com/CryptoLabInc/rune-cli/internal/supervisor"
 )
 
 func runUpdate(ctx context.Context, args []string, stdout, stderr io.Writer) int {
@@ -98,11 +100,17 @@ func applyUpdate(ctx context.Context, manifest string, plan *bootstrap.UpdateLis
 		return 0
 	}
 
+	paths, err := bootstrap.Resolve()
+	if err != nil {
+		fmt.Fprintf(stderr, "rune update: %v\n", err)
+		return 1
+	}
+
 	exit := 0
 	for _, a := range plan.Outdated() {
 		switch a.Step {
 		case bootstrap.StepRuneMCP:
-			to, err := bootstrap.UpdateArtifact(ctx, manifest, a.Step, logf)
+			to, err := bootstrap.UpdateArtifact(ctx, manifest, a.Step, nil, logf)
 			if err != nil {
 				out.Error = err.Error()
 				exit = 1
@@ -119,10 +127,42 @@ func applyUpdate(ctx context.Context, manifest string, plan *bootstrap.UpdateLis
 				fmt.Fprintf(stdout, "updated %s: %s -> %s (applies on the next session; run /mcp to reconnect now)\n", a.Step, a.Installed, to)
 			}
 		case bootstrap.StepRuned:
-			// TODO: send reload request to restart updated runed
-			out.Deferred = append(out.Deferred, a.Step)
+			// Request supervisor to restart with new binary
+			reloaded := false
+			reload := func() error {
+				resp, rerr := supervisor.SupervisorRequest(paths.SupervisorSock, supervisor.Request{Cmd: "reload"})
+				switch {
+				case errors.Is(rerr, supervisor.ErrNoSupervisor):
+					logf("runed staged; no supervisor running - applies on next daemon start")
+					return nil
+				case rerr != nil:
+					return fmt.Errorf("supervisor reload: %v; %s", rerr, runedRecoveryHint(paths))
+				case !resp.OK:
+					return fmt.Errorf("supervisor reload failed: %s; %s", resp.Error, runedRecoveryHint(paths))
+				}
+				reloaded = true
+				return nil
+			}
+
+			to, err := bootstrap.UpdateArtifact(ctx, manifest, a.Step, reload, logf)
+			if err != nil {
+				out.Error = err.Error()
+				exit = 1
+
+				if !jsonOut {
+					fmt.Fprintf(stderr, "rune update: %s: %v\n", a.Step, err)
+				}
+
+				continue
+			}
+
+			out.Applied = append(out.Applied, appliedUpdate{Step: a.Step, From: a.Installed, To: to})
 			if !jsonOut {
-				fmt.Fprintf(stdout, "%s: %s -> %s available (not applied; live daemon update not yet implemented)\n", a.Step, a.Installed, a.Available)
+				if reloaded {
+					fmt.Fprintf(stdout, "updated %s: %s -> %s (daemon reloaded)\n", a.Step, a.Installed, to)
+				} else {
+					fmt.Fprintf(stdout, "updated %s: %s -> %s (staged; applies on next daemon start)\n", a.Step, a.Installed, to)
+				}
 			}
 		}
 	}
@@ -132,4 +172,8 @@ func applyUpdate(ctx context.Context, manifest string, plan *bootstrap.UpdateLis
 	}
 
 	return exit
+}
+
+func runedRecoveryHint(paths *bootstrap.Paths) string {
+	return fmt.Sprintf("the daemon may be down - run `%s runed --detach` (or /rune:activate) to restart it", paths.RuneCLIBinary)
 }

--- a/cmd/rune/update_test.go
+++ b/cmd/rune/update_test.go
@@ -621,3 +621,57 @@ func TestRunUpdate_RefuseBelowFloorJSON(t *testing.T) {
 		t.Error("refused update must not swap the binary (JSON mode)")
 	}
 }
+
+// '--only'
+func TestRunUpdate_OnlyRuneMCP(t *testing.T) {
+	paths := setTestEnv(t)
+	mcp := []byte("only-mcp")
+	url := dummyUpdateServer(t, mcp, "v0.2.0", "v0.2.0")
+	t.Setenv("RUNE_MANIFEST", url)
+	writeAudit(t, paths, url, "v0.1.0", "v0.1.0")
+
+	var stdout, stderr bytes.Buffer
+	if code := runUpdate(context.Background(), []string{"--only", "rune_mcp"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+
+	if b, _ := os.ReadFile(paths.RuneMCPBinary); string(b) != string(mcp) {
+		t.Errorf("rune-mcp should be swapped, got %q", b)
+	}
+
+	if strings.Contains(stdout.String(), "runed") {
+		t.Errorf("--only rune_mcp must not touch runed: %q", stdout.String())
+	}
+
+	after, _ := bootstrap.ReadInstalledManifest(paths)
+	if after.RuneMCPVersion != "v0.2.0" {
+		t.Errorf("rune-mcp audit = %q, want v0.2.0", after.RuneMCPVersion)
+	}
+	if after.RunedVersion != "v0.1.0" {
+		t.Errorf("runed audit must stay at v0.1.0 (not selected), got %q", after.RunedVersion)
+	}
+}
+
+func TestRunUpdate_OnlyUnknown(t *testing.T) {
+	t.Setenv("RUNE_MANIFEST", "http://example.invalid/manifest.json")
+
+	var stdout, stderr bytes.Buffer
+	if code := runUpdate(context.Background(), []string{"--only", "bogus"}, &stdout, &stderr); code != 2 {
+		t.Errorf("exit = %d, want 2 for an unknown --only artifact", code)
+	}
+	if !strings.Contains(stderr.String(), "unknown artifact") {
+		t.Errorf("stderr = %q, want an --only validation error", stderr.String())
+	}
+}
+
+func TestRunUpdate_OnlyDegenerate(t *testing.T) {
+	t.Setenv("RUNE_MANIFEST", "http://example.invalid/manifest.json")
+
+	var stdout, stderr bytes.Buffer
+	if code := runUpdate(context.Background(), []string{"--only", " , "}, &stdout, &stderr); code != 2 {
+		t.Errorf("exit = %d, want 2 for a degenerate --only value", code)
+	}
+	if !strings.Contains(stderr.String(), "no valid artifacts") {
+		t.Errorf("stderr = %q, want a 'no valid artifacts' error", stderr.String())
+	}
+}

--- a/cmd/rune/update_test.go
+++ b/cmd/rune/update_test.go
@@ -329,7 +329,7 @@ func fakeSupervisorHangup(t *testing.T, sockPath string) {
 	}
 	t.Cleanup(func() { _ = ln.Close() })
 
-	// Simluate superviosr which dropped during reload
+	// Simulate supervisor which dropped during reload
 	go func() {
 		for {
 			conn, err := ln.Accept()

--- a/cmd/rune/update_test.go
+++ b/cmd/rune/update_test.go
@@ -439,3 +439,185 @@ func TestRunUpdate_RunedReloadFail(t *testing.T) {
 		t.Errorf("runed audit must stay at v0.1.0 when reload failed, got %q", after.RunedVersion)
 	}
 }
+
+func pluginOutdatedServer(t *testing.T, mcpBytes []byte, mcpVer, runedVer, pluginVer, minVer string) string {
+	t.Helper()
+	sum := sha256.Sum256(mcpBytes)
+	mcpSHA := hex.EncodeToString(sum[:])
+
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/manifest.json", func(w http.ResponseWriter, r *http.Request) {
+		m := map[string]any{
+			"version":            1,
+			"rune_mcp_version":   mcpVer,
+			"runed_version":      runedVer,
+			"plugin_version":     pluginVer,
+			"min_plugin_version": minVer,
+			"platforms": map[string]any{
+				bootstrap.PlatformTuple(): map[string]any{
+					"runed":    map[string]any{"url": srv.URL + "/runed", "sha256": "dummy-not-downloaded", "size": 1},
+					"rune_mcp": map[string]any{"url": srv.URL + "/rune-mcp", "sha256": mcpSHA, "size": len(mcpBytes)},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(m)
+	})
+	mux.HandleFunc("/rune-mcp", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(mcpBytes)))
+		_, _ = w.Write(mcpBytes)
+	})
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv.URL + "/manifest.json"
+}
+
+func writePluginRoot(t *testing.T, version string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	dir := filepath.Join(root, ".claude-plugin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	body := fmt.Sprintf(`{"name":"rune","version":%q}`, version)
+	if err := os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	return root
+}
+
+func TestRunUpdate_RefusesBelowPluginFloor(t *testing.T) {
+	paths := setTestEnv(t)
+	mcp := []byte("new-mcp-should-not-land")
+	url := pluginOutdatedServer(t, mcp, "v0.2.0", "v0.1.0", "0.5.0", "0.5.0")
+	t.Setenv("RUNE_MANIFEST", url)
+
+	writeAudit(t, paths, url, "v0.1.0", "v0.1.0") // rune-mcp outdated, runed current
+	root := writePluginRoot(t, "0.4.1")
+
+	var stdout, stderr bytes.Buffer
+	if code := runUpdate(context.Background(), []string{"--plugin-root", root}, &stdout, &stderr); code != 1 {
+		t.Fatalf("exit = %d, want 1 (refused below plugin floor); stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "refusing to apply") || !strings.Contains(stderr.String(), "0.5.0") {
+		t.Errorf("expected a refusal naming the floor, got %q", stderr.String())
+	}
+	if b, _ := os.ReadFile(paths.RuneMCPBinary); string(b) == string(mcp) {
+		t.Error("rune-mcp must NOT be swapped when the update is refused")
+	}
+	after, _ := bootstrap.ReadInstalledManifest(paths)
+	if after.RuneMCPVersion != "v0.1.0" {
+		t.Errorf("audit must stay at v0.1.0 when refused, got %q", after.RuneMCPVersion)
+	}
+}
+
+func TestRunUpdate_AllowOutdatedBypass(t *testing.T) {
+	paths := setTestEnv(t)
+	mcp := []byte("bypassed-mcp")
+	url := pluginOutdatedServer(t, mcp, "v0.2.0", "v0.1.0", "0.5.0", "0.5.0")
+	t.Setenv("RUNE_MANIFEST", url)
+
+	writeAudit(t, paths, url, "v0.1.0", "v0.1.0")
+	root := writePluginRoot(t, "0.4.1")
+
+	var stdout, stderr bytes.Buffer
+	if code := runUpdate(context.Background(), []string{"--plugin-root", root, "--allow-plugin-outdated"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, want 0 (bypassed); stderr=%q", code, stderr.String())
+	}
+	if b, _ := os.ReadFile(paths.RuneMCPBinary); string(b) != string(mcp) {
+		t.Errorf("rune-mcp should be swapped under --allow-plugin-outdated, got %q", b)
+	}
+	if !strings.Contains(stderr.String(), "allow-plugin-outdated") {
+		t.Errorf("expect outdated warning, got %q", stderr.String())
+	}
+	after, _ := bootstrap.ReadInstalledManifest(paths)
+	if after.RuneMCPVersion != "v0.2.0" {
+		t.Errorf("audit should be bumped under bypass, got %q", after.RuneMCPVersion)
+	}
+}
+
+func TestRunUpdate_PluginBehindAdvisory(t *testing.T) {
+	paths := setTestEnv(t)
+	mcp := []byte("advisory-mcp")
+
+	url := pluginOutdatedServer(t, mcp, "v0.2.0", "v0.1.0", "0.6.0", "0.4.0")
+	t.Setenv("RUNE_MANIFEST", url)
+	writeAudit(t, paths, url, "v0.1.0", "v0.1.0")
+	root := writePluginRoot(t, "0.4.1")
+
+	var stdout, stderr bytes.Buffer
+	if code := runUpdate(context.Background(), []string{"--plugin-root", root}, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, want 0 (advisory only); stderr=%q", code, stderr.String())
+	}
+	if b, _ := os.ReadFile(paths.RuneMCPBinary); string(b) != string(mcp) {
+		t.Errorf("rune-mcp should be swapped when only an advisory applies, got %q", b)
+	}
+	if !strings.Contains(stdout.String(), "plugin package is 0.4.1") || !strings.Contains(stdout.String(), "0.6.0") {
+		t.Errorf("expected a plugin advisory note, got %q", stdout.String())
+	}
+}
+
+func TestRunUpdate_CheckReportPluginOutdated(t *testing.T) {
+	paths := setTestEnv(t)
+	mcp := []byte("irrelevant-not-applied-in-check")
+	url := pluginOutdatedServer(t, mcp, "v0.2.0", "v0.1.0", "0.5.0", "0.5.0")
+	t.Setenv("RUNE_MANIFEST", url)
+
+	writeAudit(t, paths, url, "v0.1.0", "v0.1.0")
+	root := writePluginRoot(t, "0.4.1")
+
+	var stdout, stderr bytes.Buffer
+	if code := runUpdate(context.Background(), []string{"--check", "--plugin-root", root}, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, want 0 (check is read-only); stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "plugin outdated") || !strings.Contains(stdout.String(), "0.5.0") {
+		t.Errorf("expected --check to report the plugin outdated, got %q", stdout.String())
+	}
+	if b, _ := os.ReadFile(paths.RuneMCPBinary); string(b) == string(mcp) {
+		t.Error("--check must not swap the binary")
+	}
+}
+
+func TestRunUpdate_RefuseBelowFloorJSON(t *testing.T) {
+	paths := setTestEnv(t)
+	mcp := []byte("json-refuse-mcp")
+	url := pluginOutdatedServer(t, mcp, "v0.2.0", "v0.1.0", "0.5.0", "0.5.0")
+	t.Setenv("RUNE_MANIFEST", url)
+
+	writeAudit(t, paths, url, "v0.1.0", "v0.1.0")
+	root := writePluginRoot(t, "0.4.1")
+
+	var stdout, stderr bytes.Buffer
+	if code := runUpdate(context.Background(), []string{"--json", "--plugin-root", root}, &stdout, &stderr); code != 1 {
+		t.Fatalf("exit = %d, want 1 (refused, JSON); stderr=%q", code, stderr.String())
+	}
+
+	var sum struct {
+		Applied []appliedUpdate `json:"applied"`
+		Error   string          `json:"error"`
+		Plugin  *struct {
+			Installed    string `json:"installed"`
+			Minimum      string `json:"minimum"`
+			BelowMinimum bool   `json:"below_minimum"`
+		} `json:"plugin"`
+	}
+
+	if err := json.Unmarshal(stdout.Bytes(), &sum); err != nil {
+		t.Fatalf("stdout is not a valid update summary JSON: %v\n%s", err, stdout.String())
+	}
+	if sum.Error == "" || len(sum.Applied) != 0 {
+		t.Errorf("want non-empty error and empty applied, got error=%q applied=%+v", sum.Error, sum.Applied)
+	}
+	if sum.Plugin == nil || !sum.Plugin.BelowMinimum || sum.Plugin.Installed != "0.4.1" || sum.Plugin.Minimum != "0.5.0" {
+		t.Errorf("plugin compat not reported correctly in JSON: %+v", sum.Plugin)
+	}
+	if b, _ := os.ReadFile(paths.RuneMCPBinary); string(b) == string(mcp) {
+		t.Error("refused update must not swap the binary (JSON mode)")
+	}
+}

--- a/cmd/rune/update_test.go
+++ b/cmd/rune/update_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -260,17 +261,181 @@ func TestRunUpdate_ApplyJSON(t *testing.T) {
 	}
 }
 
-func TestRunUpdate_RunedOutdated(t *testing.T) {
+func runedUpdateServer(t *testing.T, runedBytes []byte, runedVer, mcpVer string) string {
+	t.Helper()
+	sum := sha256.Sum256(runedBytes)
+	runedSHA := hex.EncodeToString(sum[:])
+
+	// Serve runed as a real binary
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/manifest.json", func(w http.ResponseWriter, r *http.Request) {
+		m := map[string]any{
+			"version":          1,
+			"rune_mcp_version": mcpVer,
+			"runed_version":    runedVer,
+			"platforms": map[string]any{
+				bootstrap.PlatformTuple(): map[string]any{
+					"runed":    map[string]any{"url": srv.URL + "/runed", "sha256": runedSHA, "size": len(runedBytes)},
+					"rune_mcp": map[string]any{"url": "http://example.invalid/rune-mcp", "sha256": "bb", "size": 1},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(m)
+	})
+	mux.HandleFunc("/runed", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(runedBytes)))
+		_, _ = w.Write(runedBytes)
+	})
+
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv.URL + "/manifest.json"
+}
+
+func fakeSupervisor(t *testing.T, sockPath, respJSON string) {
+	t.Helper()
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen supervisor sock: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				var req map[string]any
+				_ = json.NewDecoder(c).Decode(&req)
+				_, _ = c.Write([]byte(respJSON))
+			}(conn)
+		}
+	}()
+}
+
+func fakeSupervisorHangup(t *testing.T, sockPath string) {
+	t.Helper()
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen supervisor sock: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	// Simluate superviosr which dropped during reload
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				var req map[string]any
+				_ = json.NewDecoder(c).Decode(&req)
+				_ = c.Close() // hang up without a response
+			}(conn)
+		}
+	}()
+}
+
+func TestRunUpdate_RunedReloadRoundTripFails(t *testing.T) {
 	paths := setTestEnv(t)
-	url := updateManifestServer(t, "v0.2.0", "v0.2.0")
+	runed := []byte("staged-runed")
+	url := runedUpdateServer(t, runed, "v0.2.0", "v0.2.0")
+
+	t.Setenv("RUNE_MANIFEST", url)
+	writeAudit(t, paths, url, "v0.2.0", "v0.1.0")
+	fakeSupervisorHangup(t, paths.SupervisorSock)
+
+	var stdout, stderr bytes.Buffer
+	if code := runUpdate(context.Background(), nil, &stdout, &stderr); code != 1 {
+		t.Errorf("exit = %d, want 1 (reload round-trip failed)", code)
+	}
+	if strings.Contains(stdout.String(), "staged") {
+		t.Errorf("supervisor failure after connection must not report 'staged': %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "daemon may be down") {
+		t.Errorf("expected a recovery hint on reload failure, got %q", stderr.String())
+	}
+
+	after, _ := bootstrap.ReadInstalledManifest(paths)
+	if after.RunedVersion != "v0.1.0" {
+		t.Errorf("audit must stay at v0.1.0 when reload failed, got %q", after.RunedVersion)
+	}
+}
+
+func TestRunUpdate_ApplyRunedReload(t *testing.T) {
+	paths := setTestEnv(t)
+	runed := []byte("freshly-updated-runed")
+	url := runedUpdateServer(t, runed, "v0.2.0", "v0.2.0")
+
 	t.Setenv("RUNE_MANIFEST", url)
 	writeAudit(t, paths, url, "v0.2.0", "v0.1.0") // rune-mcp current, runed old
+	fakeSupervisor(t, paths.SupervisorSock, `{"ok":true,"pid":123}`)
 
 	var stdout, stderr bytes.Buffer
 	if code := runUpdate(context.Background(), nil, &stdout, &stderr); code != 0 {
-		t.Fatalf("exit = %d, want 0 (runed deferral, stderr=%q)", code, stderr.String())
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "not applied") {
-		t.Errorf("expected runed deferral message, got %q", stdout.String())
+	if b, _ := os.ReadFile(paths.RunedBinary); string(b) != string(runed) {
+		t.Errorf("runed not swapped on disk: got %q", b)
+	}
+	if !strings.Contains(stdout.String(), "reloaded") {
+		t.Errorf("expected 'daemon reloaded', got %q", stdout.String())
+	}
+
+	after, _ := bootstrap.ReadInstalledManifest(paths)
+	if after.RunedVersion != "v0.2.0" {
+		t.Errorf("runed audit not bumped after reload: %q", after.RunedVersion)
+	}
+}
+
+func TestRunUpdate_RunedNoSupervisor(t *testing.T) {
+	paths := setTestEnv(t)
+	runed := []byte("staged-runed")
+	url := runedUpdateServer(t, runed, "v0.2.0", "v0.2.0")
+
+	t.Setenv("RUNE_MANIFEST", url)
+	writeAudit(t, paths, url, "v0.2.0", "v0.1.0")
+	// no supervisor listening
+
+	var stdout, stderr bytes.Buffer
+	if code := runUpdate(context.Background(), nil, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "staged") {
+		t.Errorf("expected 'staged; applies on next daemon start', got %q", stdout.String())
+	}
+
+	after, _ := bootstrap.ReadInstalledManifest(paths)
+	if after.RunedVersion != "v0.2.0" {
+		t.Errorf("runed audit should be bumped after staging: %q", after.RunedVersion)
+	}
+}
+
+func TestRunUpdate_RunedReloadFail(t *testing.T) {
+	paths := setTestEnv(t)
+	runed := []byte("bad-runed")
+	url := runedUpdateServer(t, runed, "v0.2.0", "v0.2.0")
+
+	t.Setenv("RUNE_MANIFEST", url)
+	writeAudit(t, paths, url, "v0.2.0", "v0.1.0")
+	fakeSupervisor(t, paths.SupervisorSock, `{"ok":false,"error":"restart failed to start"}`)
+
+	var stdout, stderr bytes.Buffer
+	if code := runUpdate(context.Background(), nil, &stdout, &stderr); code != 1 {
+		t.Errorf("exit = %d, want 1 (reload failed)", code)
+	}
+
+	after, _ := bootstrap.ReadInstalledManifest(paths)
+	if after.RunedVersion != "v0.1.0" {
+		t.Errorf("runed audit must stay at v0.1.0 when reload failed, got %q", after.RunedVersion)
 	}
 }

--- a/cmd/rune/version.go
+++ b/cmd/rune/version.go
@@ -10,6 +10,9 @@ import (
 
 func runVersion(w io.Writer) int {
 	fmt.Fprintf(w, "rune %s\n", runeVersion)
+	if pv, _ := bootstrap.InstalledPluginVersion(""); pv != "" {
+		fmt.Fprintf(w, "plugin: %s\n", pv)
+	}
 	manifest := manifestURL
 	if manifest == "" {
 		manifest = os.Getenv("RUNE_MANIFEST")

--- a/commands/claude/update.md
+++ b/commands/claude/update.md
@@ -20,6 +20,13 @@ embedder daemon).
 No confirmation prompt and no activation-state gate: updating binaries is
 non-destructive and works whether Rune is Active or Dormant. Just run it.
 
+**Relationship to the automatic check:** `rune mcp-server` also runs a
+**throttled, non-blocking** background check at session start — it stages a
+newer **rune-mcp** for the next session (never touches runed) and is silent.
+`/rune:update` is the **explicit, immediate** path (checks all binaries now and
+applies in-session where possible). Users can disable the background check with
+`RUNE_NO_AUTO_UPDATE=1`; `/rune:update` still works regardless of it.
+
 ## Steps
 
 ### 1. Run the update

--- a/commands/claude/update.md
+++ b/commands/claude/update.md
@@ -25,15 +25,18 @@ non-destructive and works whether Rune is Active or Dormant. Just run it.
 ### 1. Run the update
 
 Prefer the installed CLI; fall back to the plugin's bundled wrapper only if the
-installed binary is absent:
+installed binary is absent. **Always pass `--plugin-root "${CLAUDE_PLUGIN_ROOT}"`**
+so the CLI can compare the installed plugin package against what the new
+binaries expect (the plugin-version outdated check in step 4):
 
-1. `~/.rune/bin/rune update`
-2. `bash -c "${CLAUDE_PLUGIN_ROOT}/bin/rune update"` — only if `~/.rune/bin/rune`
-   does not exist yet (the wrapper downloads the Go CLI, then runs `update`).
+1. `~/.rune/bin/rune update --plugin-root "${CLAUDE_PLUGIN_ROOT}"`
+2. `bash -c "${CLAUDE_PLUGIN_ROOT}/bin/rune update --plugin-root ${CLAUDE_PLUGIN_ROOT}"`
+   — only if `~/.rune/bin/rune` does not exist yet (the wrapper downloads the Go
+   CLI, then runs `update`).
 
 If the user asked to only *check* (e.g. `$ARGUMENTS` contains `check`), append
 `--check` to report available updates **without applying**:
-`~/.rune/bin/rune update --check`.
+`~/.rune/bin/rune update --check --plugin-root "${CLAUDE_PLUGIN_ROOT}"`.
 
 Surface the command output verbatim, then interpret it per step 2. Do NOT loop
 or retry on failure — surface the result and stop.
@@ -78,6 +81,31 @@ not negate a binary that updated in the same run.
   channel wired (`RUNE_MANIFEST` unset and no baked manifest URL). This is
   expected on builds that predate the release-channel graduation; report it
   plainly and stop — it is not a user misconfiguration to fix.
+
+### 4. Plugin-version outdated (assets vs binaries)
+
+`rune update` only refreshes the **binaries**. The plugin *assets* (this command
+file, agents, SKILL.md) ship in the plugin tarball and can only be updated by
+the host's plugin-update mechanism (`claude plugin update rune`, or the
+equivalent for Codex/Gemini). When the manifest declares a plugin version, the
+CLI compares it against the installed plugin package and surfaces outdated:
+
+- **Advisory (stdout, exit 0): `note: plugin package is X; these binaries expect
+  Y`** — the update **succeeded**; the plugin is merely behind. Relay it and
+  suggest running `claude plugin update rune` when convenient to keep
+  commands/agents/SKILL.md in sync. No urgency.
+- **Refusal (stderr, exit 1): `refusing to apply: plugin package X is below the
+  minimum Y`** — the new binaries need a newer plugin than is installed, so
+  **nothing was applied**. Tell the user to update the plugin first (`claude
+  plugin update rune`), then re-run `/rune:update`. Mention `--allow-plugin-outdated`
+  exists to force it but **warn** it can break commands/agents/SKILL.md — only
+  suggest it if the user explicitly insists.
+- **`--check`: `plugin outdated: installed X is BELOW the minimum Y`** — report it;
+  the user should update the plugin before applying.
+
+If version can't be evaluated (no `${CLAUDE_PLUGIN_ROOT}`, or the manifest declares
+no plugin version), the CLI simply omits these lines — that's normal, not an
+error.
 
 Surface all output verbatim. The user never types `rune update` themselves —
 the agent runs it.

--- a/commands/claude/update.md
+++ b/commands/claude/update.md
@@ -1,0 +1,83 @@
+---
+description: Update Rune's runtime binaries (rune-mcp, runed) in place to the versions in the published manifest
+allowed-tools: Bash(~/.rune/bin/rune update:*), Bash(${CLAUDE_PLUGIN_ROOT}/bin/rune update:*)
+---
+
+# /rune:update — Update Runtime Binaries
+
+Refresh Rune's runtime binaries **in place** to the versions pinned by the
+current published manifest — no plugin uninstall/reinstall. This covers the two
+binaries fetched at runtime: **rune-mcp** (the MCP server) and **runed** (the
+embedder daemon).
+
+**Out of scope (cannot be hot-swapped here):**
+- Plugin *assets* — `commands/*.md`, `agents/*`, `SKILL.md`,
+  `.claude-plugin/plugin.json` — ship inside the plugin tarball and still need
+  the host's plugin-update / marketplace mechanism.
+- The `rune` CLI wrapper target itself is not manifest-tracked and is not
+  touched by this command.
+
+No confirmation prompt and no activation-state gate: updating binaries is
+non-destructive and works whether Rune is Active or Dormant. Just run it.
+
+## Steps
+
+### 1. Run the update
+
+Prefer the installed CLI; fall back to the plugin's bundled wrapper only if the
+installed binary is absent:
+
+1. `~/.rune/bin/rune update`
+2. `bash -c "${CLAUDE_PLUGIN_ROOT}/bin/rune update"` — only if `~/.rune/bin/rune`
+   does not exist yet (the wrapper downloads the Go CLI, then runs `update`).
+
+If the user asked to only *check* (e.g. `$ARGUMENTS` contains `check`), append
+`--check` to report available updates **without applying**:
+`~/.rune/bin/rune update --check`.
+
+Surface the command output verbatim, then interpret it per step 2. Do NOT loop
+or retry on failure — surface the result and stop.
+
+### 2. Interpret the result
+
+The CLI applies each outdated binary **independently** and prints one stdout
+line per binary it updated — **regardless of the overall exit code.** Relay
+every `updated …` line, then tell the user the exact next step:
+
+| CLI output contains | Meaning | Tell the user |
+|---|---|---|
+| `all binaries are up to date` | Nothing outdated | Already current — nothing to do. |
+| `Available updates:` (from `--check`) | Report-only; nothing applied | List the `step: from -> to` rows; run `/rune:update` (no `check`) to apply. |
+| `updated rune_mcp: … (applies on the next session; run /mcp to reconnect now)` | New rune-mcp is on disk | It applies automatically in a **new** session. To pick it up **now**, run `/mcp` to reconnect the server (re-runs the wrapper in-session). |
+| `updated runed: … (daemon reloaded)` | Supervisor restarted the live daemon onto the new binary | Done — the embedder is back online on the new version. (A brief embedder blip during restart is expected.) |
+| `updated runed: … (staged; applies on next daemon start)` | New runed staged, but no supervisor was running | Run `/rune:activate` to start the daemon now on the staged binary. |
+
+**Partial success:** runed is applied first and rune-mcp last, so when both are
+outdated and one fails you can get a **success line on stdout AND a non-zero
+exit with an error on stderr in the same run** (e.g. runed reload fails but
+rune-mcp updates fine). Always relay the succeeded binary's line and its
+next-step advice (e.g. `/mcp` for rune-mcp) **first**, then handle the failure
+per Step 3. Step 3 is **additive**, not a replacement — a failed reload does
+not negate a binary that updated in the same run.
+
+### 3. Errors (additive to any `updated …` lines from Step 2)
+
+- **Exit 1 with `supervisor reload failed: …` or `supervisor reload: …`** — the
+  runed restart failed, so the daemon **may be down**. The error already carries
+  a recovery hint (`… run \`rune runed --detach\` (or /rune:activate) …`).
+  Relay the hint verbatim and suggest **`/rune:activate`** to bring the daemon
+  back up on the staged binary. The recorded runed version was intentionally
+  **not** advanced. Do not retry automatically.
+- **Any other exit 1 (message starts `rune update:`, without `supervisor
+  reload`)** — an error while fetching/parsing the manifest, resolving paths, or
+  writing the install audit; the update did not complete cleanly. Relay the
+  message verbatim, suggest retrying later, and do not loop. This class usually
+  means nothing was applied (so `/rune:activate` is not needed); trust any
+  `updated …` line that did print on stdout.
+- **Exit 2 `no manifest URL configured`** — this build has no auto-update
+  channel wired (`RUNE_MANIFEST` unset and no baked manifest URL). This is
+  expected on builds that predate the release-channel graduation; report it
+  plainly and stop — it is not a user misconfiguration to fix.
+
+Surface all output verbatim. The user never types `rune update` themselves —
+the agent runs it.

--- a/internal/bootstrap/autocheck.go
+++ b/internal/bootstrap/autocheck.go
@@ -1,0 +1,51 @@
+package bootstrap
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAutoCheckInterval = 24 * time.Hour
+	envAutoCheckInterval     = "RUNE_UPDATE_CHECK_INTERVAL"
+	envNoAutoUpdate          = "RUNE_NO_AUTO_UPDATE"
+)
+
+func AutoUpdateDisabled() bool {
+	return os.Getenv(envNoAutoUpdate) != ""
+}
+
+func AutoCheckInterval() time.Duration {
+	if v := strings.TrimSpace(os.Getenv(envAutoCheckInterval)); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+
+	return defaultAutoCheckInterval
+}
+
+func ShouldAutoCheck(stampPath string, interval time.Duration, now time.Time) bool {
+	data, err := os.ReadFile(stampPath)
+	if err != nil {
+		return true
+	}
+
+	last, err := time.Parse(time.RFC3339, strings.TrimSpace(string(data)))
+	if err != nil {
+		return true
+	}
+
+	return now.Sub(last) >= interval
+}
+
+func RecordAutoCheck(stampPath string, now time.Time) error {
+	if err := os.MkdirAll(filepath.Dir(stampPath), 0o700); err != nil {
+		return err
+	}
+
+	// Stamp last check time
+	return os.WriteFile(stampPath, []byte(now.UTC().Format(time.RFC3339)), 0o600)
+}

--- a/internal/bootstrap/autocheck_test.go
+++ b/internal/bootstrap/autocheck_test.go
@@ -1,0 +1,87 @@
+package bootstrap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestShouldAutoCheck(t *testing.T) {
+	dir := t.TempDir()
+	stamp := filepath.Join(dir, "last-update-check")
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	interval := 24 * time.Hour
+
+	t.Run("missing stamp is due", func(t *testing.T) {
+		if !ShouldAutoCheck(stamp, interval, now) {
+			t.Error("a missing stamp must count as due")
+		}
+	})
+
+	t.Run("fresh stamp is not due", func(t *testing.T) {
+		if err := RecordAutoCheck(stamp, now.Add(-1*time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+		if ShouldAutoCheck(stamp, interval, now) {
+			t.Error("a 1h-old stamp must not be due under a 24h interval")
+		}
+	})
+
+	t.Run("stale stamp is due", func(t *testing.T) {
+		if err := RecordAutoCheck(stamp, now.Add(-25*time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+		if !ShouldAutoCheck(stamp, interval, now) {
+			t.Error("a 25h-old stamp must be due under a 24h interval")
+		}
+	})
+
+	t.Run("corrupt stamp is due", func(t *testing.T) {
+		if err := os.WriteFile(stamp, []byte("not-a-timestamp"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !ShouldAutoCheck(stamp, interval, now) {
+			t.Error("a corrupt stamp must fail toward due")
+		}
+	})
+}
+
+func TestAutoCheckInterval(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv(envAutoCheckInterval, "")
+		if got := AutoCheckInterval(); got != defaultAutoCheckInterval {
+			t.Errorf("interval = %s, want default %s", got, defaultAutoCheckInterval)
+		}
+	})
+
+	t.Run("env override", func(t *testing.T) {
+		t.Setenv(envAutoCheckInterval, "6h")
+		if got := AutoCheckInterval(); got != 6*time.Hour {
+			t.Errorf("interval = %s, want 6h", got)
+		}
+	})
+
+	t.Run("invalid env falls back to default", func(t *testing.T) {
+		t.Setenv(envAutoCheckInterval, "nonsense")
+		if got := AutoCheckInterval(); got != defaultAutoCheckInterval {
+			t.Errorf("interval = %s, want default on invalid env", got)
+		}
+	})
+}
+
+func TestAutoUpdateDisabled(t *testing.T) {
+	t.Run("unset is not disabled", func(t *testing.T) {
+		t.Setenv(envNoAutoUpdate, "")
+		if AutoUpdateDisabled() {
+			t.Error("unset RUNE_NO_AUTO_UPDATE must not disabled")
+		}
+	})
+
+	t.Run("set opts out", func(t *testing.T) {
+		t.Setenv(envNoAutoUpdate, "1")
+		if !AutoUpdateDisabled() {
+			t.Error("set RUNE_NO_AUTO_UPDATE must disabled")
+		}
+	})
+}

--- a/internal/bootstrap/manifest.go
+++ b/internal/bootstrap/manifest.go
@@ -31,10 +31,14 @@ const defaultManifestFetchTimeout = 30 * time.Second
 //	}
 
 type Manifest struct {
-	Version        int                          `json:"version"`
-	RuneMCPVersion string                       `json:"rune_mcp_version"`
-	RunedVersion   string                       `json:"runed_version"`
-	Platforms      map[string]PlatformArtifacts `json:"platforms"`
+	Version        int    `json:"version"`
+	RuneMCPVersion string `json:"rune_mcp_version"`
+	RunedVersion   string `json:"runed_version"`
+
+	PluginVersion    string `json:"plugin_version,omitempty"`     // plugin package version; optional
+	MinPluginVersion string `json:"min_plugin_version,omitempty"` // hard floor for `rune update`; optional
+
+	Platforms map[string]PlatformArtifacts `json:"platforms"`
 }
 
 type PlatformArtifacts struct {

--- a/internal/bootstrap/paths.go
+++ b/internal/bootstrap/paths.go
@@ -41,6 +41,8 @@ type Paths struct {
 	RuneMCPBinary     string // ~/.rune/bin/rune-mcp
 	RuneConfig        string // ~/.rune/config.json
 	InstalledManifest string // ~/.rune/installed.json - install audit log
+	AutoCheckStamp    string // ~/.rune/last-update-check
+	UpdateLog         string // ~/.rune/update.log - auto-update output
 
 	// Runed
 	RunedHome      string // ~/.runed
@@ -99,6 +101,8 @@ func newPaths(runeHome, runedHome string) *Paths {
 		RuneMCPBinary:     filepath.Join(runeBin, "rune-mcp"),
 		RuneConfig:        filepath.Join(runeHome, "config.json"),
 		InstalledManifest: filepath.Join(runeHome, "installed.json"),
+		AutoCheckStamp:    filepath.Join(runeHome, "last-update-check"),
+		UpdateLog:         filepath.Join(runeHome, "update.log"),
 
 		RunedHome:      runedHome,
 		RunedBin:       runedBin,

--- a/internal/bootstrap/plugin.go
+++ b/internal/bootstrap/plugin.go
@@ -1,0 +1,155 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const envPluginRoot = "CLAUDE_PLUGIN_ROOT"
+
+func InstalledPluginVersion(root string) (string, error) {
+	if root == "" {
+		root = os.Getenv(envPluginRoot)
+	}
+	if root == "" {
+		return "", nil // unknown;
+	}
+
+	path := filepath.Join(root, ".claude-plugin", "plugin.json") // <root>/.claude-plugin/plugin.json
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("plugin manifest: read %s: %w", path, err)
+	}
+
+	var pm struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &pm); err != nil {
+		return "", fmt.Errorf("plugin manifest: parse %s: %w", path, err)
+	}
+
+	return pm.Version, nil // ("", nil) returned if plugin root is unknown, not error
+}
+
+type PluginCompatibility struct {
+	Installed    string `json:"installed,omitempty"`     // installed plugin version ("" = unknown)
+	Expected     string `json:"expected,omitempty"`      // manifest plugin_version ("" = not declared)
+	Minimum      string `json:"minimum,omitempty"`       // manifest min_plugin_version ("" = not declared)
+	Known        bool   `json:"known"`                   // installed version checked
+	Behind       bool   `json:"behind,omitempty"`        // installed < expected
+	BelowMinimum bool   `json:"below_minimum,omitempty"` // installed < minimum
+}
+
+func EvaluatePluginCompatibility(installed string, m *Manifest) PluginCompatibility {
+	pc := PluginCompatibility{Installed: installed, Known: installed != ""}
+	if m != nil {
+		pc.Expected = m.PluginVersion
+		pc.Minimum = m.MinPluginVersion
+	}
+
+	if !pc.Known {
+		return pc
+	}
+	if pc.Expected != "" && compareVersions(installed, pc.Expected) < 0 {
+		pc.Behind = true
+	}
+	if pc.Minimum != "" && compareVersions(installed, pc.Minimum) < 0 {
+		pc.BelowMinimum = true
+	}
+
+	return pc
+}
+
+// Semver comparison
+func compareVersions(a, b string) int {
+	a, b = normalizeVersion(a), normalizeVersion(b)
+	aRel, aPre := cutPrerelease(a)
+	bRel, bPre := cutPrerelease(b)
+
+	if c := compareDotted(aRel, bRel, true); c != 0 {
+		return c
+	}
+
+	switch {
+	case aPre == "" && bPre == "":
+		return 0
+	case aPre == "": // a: release >  b: pre-release
+		return 1
+	case bPre == "":
+		return -1
+	default:
+		return compareDotted(aPre, bPre, false)
+	}
+}
+
+func cutPrerelease(v string) (release, prerelease string) {
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		return v[:i], v[i+1:]
+	}
+	return v, ""
+}
+
+func compareDotted(a, b string, numericPad bool) int {
+	// Missing field is treated as 0 -> "1.2" == "1.2.0"
+	as := strings.Split(a, ".")
+	bs := strings.Split(b, ".")
+	n := len(as)
+	if len(bs) > n {
+		n = len(bs)
+	}
+
+	for i := 0; i < n; i++ {
+		var x, y string
+		if i < len(as) {
+			x = as[i]
+		}
+		if i < len(bs) {
+			y = bs[i]
+		}
+		if x == y {
+			continue
+		}
+
+		if numericPad {
+			if x == "" {
+				x = "0"
+			}
+			if y == "" {
+				y = "0"
+			}
+		} else {
+			if x == "" {
+				return -1
+			}
+			if y == "" {
+				return 1
+			}
+		}
+
+		xi, xerr := strconv.Atoi(x)
+		yi, yerr := strconv.Atoi(y)
+		switch {
+		case xerr == nil && yerr == nil:
+			if xi != yi {
+				if xi < yi {
+					return -1
+				}
+				return 1
+			}
+		case xerr == nil: // numeric identifier < non-numeric
+			return -1
+		case yerr == nil:
+			return 1
+		default:
+			if x < y {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}

--- a/internal/bootstrap/plugin_test.go
+++ b/internal/bootstrap/plugin_test.go
@@ -1,0 +1,116 @@
+package bootstrap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCompareVersions(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"0.4.1", "0.5.0", -1},
+		{"0.5.0", "0.4.1", 1},
+		{"1.0.0", "1.0.0", 0},
+		{"v1.2", "1.2.0", 0},          // v-prefix + zero-pad
+		{"1.2.0+build.7", "1.2.0", 0}, // build metadata stripped
+		{"1.10.0", "1.9.0", 1},        // numeric, not lexical
+		{"2.0.0", "1.9.9", 1},
+		{"1.2.0-rc.1", "1.2.0", -1}, // pre-release < release
+		{"1.2.0", "1.2.0-rc.1", 1},
+		{"1.2.0-rc.1", "1.2.0-rc.2", -1},
+		{"1.2.0-rc.2", "1.2.0-rc.10", -1}, // numeric pre-release identifiers
+		{"1.2.0-alpha", "1.2.0-beta", -1}, // lexical pre-release identifiers
+	}
+
+	for _, c := range cases {
+		if got := compareVersions(c.a, c.b); got != c.want {
+			t.Errorf("compareVersions(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestPlugin_InstalledVersion(t *testing.T) {
+	t.Run("reads version from plugin.json", func(t *testing.T) {
+		root := t.TempDir()
+		dir := filepath.Join(root, ".claude-plugin")
+
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(`{"name":"rune","version":"0.4.1"}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		v, err := InstalledPluginVersion(root)
+		if err != nil {
+			t.Fatalf("InstalledPluginVersion: %v", err)
+		}
+		if v != "0.4.1" {
+			t.Errorf("version = %q, want 0.4.1", v)
+		}
+	})
+
+	t.Run("unknown root is not an error", func(t *testing.T) {
+		t.Setenv(envPluginRoot, "")
+		v, err := InstalledPluginVersion("")
+		if err != nil || v != "" {
+			t.Errorf("got (%q, %v), want (\"\", nil) when the plugin root is unknown", v, err)
+		}
+	})
+
+	t.Run("known root but missing manifest is an error", func(t *testing.T) {
+		if _, err := InstalledPluginVersion(t.TempDir()); err == nil {
+			t.Error("expected an error when plugin.json is absent under a known root")
+		}
+	})
+}
+
+func TestPlugin_EvaluateCompatibility(t *testing.T) {
+	m := &Manifest{Version: 1, PluginVersion: "0.5.0", MinPluginVersion: "0.5.0"}
+
+	t.Run("below minimum is both behind and below-floor", func(t *testing.T) {
+		pc := EvaluatePluginCompatibility("0.4.1", m)
+		if !pc.Known || !pc.Behind || !pc.BelowMinimum {
+			t.Errorf("compat = %+v, want known+behind+belowMinimum", pc)
+		}
+	})
+
+	t.Run("at minimum and expected is clean", func(t *testing.T) {
+		pc := EvaluatePluginCompatibility("0.5.0", m)
+		if pc.Behind || pc.BelowMinimum {
+			t.Errorf("compat = %+v, want no concern", pc)
+		}
+	})
+
+	t.Run("ahead of expected is clean", func(t *testing.T) {
+		pc := EvaluatePluginCompatibility("0.6.0", m)
+		if pc.Behind || pc.BelowMinimum {
+			t.Errorf("compat = %+v, want no concern", pc)
+		}
+	})
+
+	t.Run("behind expected but at/above floor is advisory only", func(t *testing.T) {
+		m2 := &Manifest{Version: 1, PluginVersion: "0.6.0", MinPluginVersion: "0.4.0"}
+		pc := EvaluatePluginCompatibility("0.4.1", m2)
+		if !pc.Behind || pc.BelowMinimum {
+			t.Errorf("compat = %+v, want behind but not belowMinimum", pc)
+		}
+	})
+
+	t.Run("unknown installed version flags nothing", func(t *testing.T) {
+		pc := EvaluatePluginCompatibility("", m)
+		if pc.Known || pc.Behind || pc.BelowMinimum {
+			t.Errorf("compat = %+v, want unknown/no-flags", pc)
+		}
+	})
+
+	t.Run("manifest without plugin fields flags nothing", func(t *testing.T) {
+		pc := EvaluatePluginCompatibility("0.1.0", &Manifest{Version: 1})
+		if pc.Behind || pc.BelowMinimum {
+			t.Errorf("compat = %+v, want no concern when manifest omits plugin fields", pc)
+		}
+	})
+}

--- a/internal/bootstrap/update.go
+++ b/internal/bootstrap/update.go
@@ -111,8 +111,7 @@ func CheckUpdate(ctx context.Context, manifestURL string, logf func(format strin
 	return &plan, nil
 }
 
-// Swap binary only; rune-mcp applies on next spawn and runed needs manual restart
-func UpdateArtifact(ctx context.Context, manifestURL, step string, logf func(format string, args ...any)) (string, error) {
+func UpdateArtifact(ctx context.Context, manifestURL, step string, afterInstall func() error, logf func(format string, args ...any)) (string, error) {
 	if logf == nil {
 		logf = func(string, ...any) {}
 	}
@@ -144,6 +143,13 @@ func UpdateArtifact(ctx context.Context, manifestURL, step string, logf func(for
 		Log:         logf,
 	}); err != nil {
 		return "", err
+	}
+
+	// Reload updated binary before recording
+	if afterInstall != nil {
+		if err := afterInstall(); err != nil {
+			return "", err
+		}
 	}
 
 	var spec ArtifactSpec

--- a/internal/bootstrap/update.go
+++ b/internal/bootstrap/update.go
@@ -99,6 +99,10 @@ func CheckUpdate(ctx context.Context, manifestURL string, logf func(format strin
 		return nil, err
 	}
 
+	return PlanFromManifest(manifest)
+}
+
+func PlanFromManifest(manifest *Manifest) (*UpdateList, error) {
 	paths, err := Resolve()
 	if err != nil {
 		return nil, err
@@ -106,7 +110,7 @@ func CheckUpdate(ctx context.Context, manifestURL string, logf func(format strin
 
 	// Get local installed info
 	installed, _ := ReadInstalledManifest(paths) // nil: unknown version
-	plan := planUpdate(installed, manifest)
+	plan := planUpdate(installed, manifest)      // build update plan
 
 	return &plan, nil
 }

--- a/internal/bootstrap/update_test.go
+++ b/internal/bootstrap/update_test.go
@@ -159,7 +159,7 @@ func TestUpdateArtifact_UpdateSingleArtifact(t *testing.T) {
 		t.Fatalf("EnsureDirs: %v", err)
 	}
 
-	// Simulate installed artfiact - rune-mcp: old, runed: latest
+	// Simulate installed artifact - rune-mcp: old, runed: latest
 	rec := &Manifest{Version: 1, RuneMCPVersion: "v0.0.1", RunedVersion: "v0.1.0-test"}
 	arts := map[string]InstalledArtifact{
 		StepRuneMCP: {Path: paths.RuneMCPBinary, SHA256: "old-mcp", DestSHA256: "old-mcp"},

--- a/internal/bootstrap/update_test.go
+++ b/internal/bootstrap/update_test.go
@@ -2,8 +2,10 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -167,7 +169,7 @@ func TestUpdateArtifact_UpdateSingleArtifact(t *testing.T) {
 		t.Fatalf("WriteInstalledManifest: %v", err)
 	}
 
-	got, err := UpdateArtifact(context.Background(), fx.manifestURL(), StepRuneMCP, nil)
+	got, err := UpdateArtifact(context.Background(), fx.manifestURL(), StepRuneMCP, nil, nil)
 	if err != nil {
 		t.Fatalf("UpdateArtifact: %v", err)
 	}
@@ -210,7 +212,73 @@ func TestUpdateArtifact_UpdateSingleArtifact(t *testing.T) {
 }
 
 func TestUpdateArtifact_UnknownArtifact(t *testing.T) {
-	if _, err := UpdateArtifact(context.Background(), "http://unused", "llama-server", nil); err == nil {
+	if _, err := UpdateArtifact(context.Background(), "http://unused", "llama-server", nil, nil); err == nil {
 		t.Error("expected error for an unknown artifact")
+	}
+}
+
+func outdatedRuneMCP(t *testing.T) (*Paths, string) {
+	t.Helper()
+	setRealms(t)
+	t.Setenv("RUNE_MANIFEST", "")
+	fx := newFixture(t) // v0.1.0-test
+
+	paths, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if err := paths.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	rec := &Manifest{Version: 1, RuneMCPVersion: "v0.0.1", RunedVersion: "v0.1.0-test"}
+	arts := map[string]InstalledArtifact{
+		StepRuneMCP: {Path: paths.RuneMCPBinary},
+		StepRuned:   {Path: paths.RunedBinary},
+	}
+	if err := WriteInstalledManifest(paths, fx.manifestURL(), rec, arts); err != nil {
+		t.Fatalf("WriteInstalledManifest: %v", err)
+	}
+
+	return paths, fx.manifestURL()
+}
+
+func TestUpdateArtifact_AfterInstallOK(t *testing.T) {
+	paths, url := outdatedRuneMCP(t)
+
+	called := false
+	v, err := UpdateArtifact(context.Background(), url, StepRuneMCP, func() error { called = true; return nil }, nil)
+	if err != nil {
+		t.Fatalf("UpdateArtifact: %v", err)
+	}
+	if !called {
+		t.Error("afterInstall was not called")
+	}
+	if v != "v0.1.0-test" {
+		t.Errorf("version = %q, want v0.1.0-test", v)
+	}
+
+	after, _ := ReadInstalledManifest(paths)
+	if after.RuneMCPVersion != "v0.1.0-test" {
+		t.Errorf("audit not bumped after afterInstall ok: %q", after.RuneMCPVersion)
+	}
+}
+
+func TestUpdateArtifact_AfterInstallErrorSkipsAudit(t *testing.T) {
+	paths, url := outdatedRuneMCP(t)
+
+	_, err := UpdateArtifact(context.Background(), url, StepRuneMCP, func() error {
+		return errors.New("restart failed")
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "restart failed") {
+		t.Fatalf("err = %v, want the afterInstall error surfaced", err)
+	}
+
+	if b, _ := os.ReadFile(paths.RuneMCPBinary); string(b) == "" {
+		t.Error("binary should have been staged before afterInstall")
+	}
+	after, _ := ReadInstalledManifest(paths)
+	if after.RuneMCPVersion != "v0.0.1" {
+		t.Errorf("rune_mcp_version = %q, want unchanged v0.0.1 (afterInstall failed)", after.RuneMCPVersion)
 	}
 }

--- a/internal/supervisor/control.go
+++ b/internal/supervisor/control.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Request struct {
-	Cmd string `json:"cmd"` // "status" (TODO: "reload", "stop")
+	Cmd string `json:"cmd"` // "status" | "reload" (TODO: "stop")
 }
 
 type Response struct {
@@ -20,7 +20,15 @@ type Response struct {
 }
 
 const connTimeout = 5 * time.Second
+const reloadDeadline = 30 * time.Second
 const maxControlMsg = 4 << 10 // 4 KB
+
+func responseDeadline(cmd string) time.Duration {
+	if cmd == "reload" {
+		return reloadDeadline
+	}
+	return connTimeout
+}
 
 func listenControl(path string) net.Listener {
 	_ = os.Remove(path)
@@ -36,32 +44,46 @@ func listenControl(path string) net.Listener {
 	return ln
 }
 
-func serveControl(ln net.Listener) {
+func serveControl(ln net.Listener, reload func() error) {
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
 			return // shutdown
 		}
 
-		go handleControlConn(conn)
+		go handleControlConn(conn, reload) // detached handler
 	}
 }
 
-func handleControlConn(conn net.Conn) {
+func handleControlConn(conn net.Conn, reload func() error) {
 	defer conn.Close()
-	_ = conn.SetDeadline(time.Now().Add(connTimeout))
+
+	_ = conn.SetReadDeadline(time.Now().Add(connTimeout))
 
 	var req Request
 	if err := json.NewDecoder(io.LimitReader(conn, maxControlMsg)).Decode(&req); err != nil {
+		_ = conn.SetWriteDeadline(time.Now().Add(connTimeout))
 		_ = json.NewEncoder(conn).Encode(Response{OK: false, Error: "bad request"})
 		return
 	}
-	_ = json.NewEncoder(conn).Encode(dispatchControl(req))
+
+	resp := dispatchControl(req, reload) // may block while the child restarts
+
+	_ = conn.SetWriteDeadline(time.Now().Add(connTimeout))
+	_ = json.NewEncoder(conn).Encode(resp)
 }
 
-func dispatchControl(req Request) Response {
+func dispatchControl(req Request, reload func() error) Response {
 	switch req.Cmd {
 	case "status":
+		return Response{OK: true, PID: os.Getpid()}
+	case "reload":
+		if reload == nil {
+			return Response{OK: false, Error: "reload not supported"}
+		}
+		if err := reload(); err != nil {
+			return Response{OK: false, Error: err.Error()}
+		}
 		return Response{OK: true, PID: os.Getpid()}
 	default:
 		return Response{OK: false, Error: "unknown command: " + req.Cmd}
@@ -75,11 +97,12 @@ func SupervisorRequest(socketPath string, req Request) (Response, error) {
 	}
 	defer conn.Close()
 
-	_ = conn.SetDeadline(time.Now().Add(connTimeout))
-
+	_ = conn.SetWriteDeadline(time.Now().Add(connTimeout))
 	if err := json.NewEncoder(conn).Encode(req); err != nil {
 		return Response{}, err
 	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(responseDeadline(req.Cmd)))
 
 	var resp Response
 	if err := json.NewDecoder(io.LimitReader(conn, maxControlMsg)).Decode(&resp); err != nil {

--- a/internal/supervisor/control.go
+++ b/internal/supervisor/control.go
@@ -2,12 +2,15 @@ package supervisor
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"time"
 )
+
+var ErrNoSupervisor = errors.New("no supervisor listening")
 
 type Request struct {
 	Cmd string `json:"cmd"` // "status" | "reload" (TODO: "stop")
@@ -93,7 +96,7 @@ func dispatchControl(req Request, reload func() error) Response {
 func SupervisorRequest(socketPath string, req Request) (Response, error) {
 	conn, err := net.DialTimeout("unix", socketPath, 2*time.Second)
 	if err != nil {
-		return Response{}, err
+		return Response{}, fmt.Errorf("%w: %v", ErrNoSupervisor, err)
 	}
 	defer conn.Close()
 

--- a/internal/supervisor/control_test.go
+++ b/internal/supervisor/control_test.go
@@ -1,0 +1,44 @@
+package supervisor
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestDispatchControl(t *testing.T) {
+	t.Run("status", func(t *testing.T) {
+		r := dispatchControl(Request{Cmd: "status"}, nil)
+		if !r.OK || r.PID == 0 {
+			t.Errorf("status = %+v, want OK with a pid", r)
+		}
+	})
+
+	t.Run("unknown command", func(t *testing.T) {
+		r := dispatchControl(Request{Cmd: "bogus"}, nil)
+		if r.OK || !strings.Contains(r.Error, "unknown command") {
+			t.Errorf("bogus = %+v, want OK=false with 'unknown command'", r)
+		}
+	})
+
+	t.Run("reload not supported when reload is nil", func(t *testing.T) {
+		r := dispatchControl(Request{Cmd: "reload"}, nil)
+		if r.OK || !strings.Contains(r.Error, "not supported") {
+			t.Errorf("reload(nil) = %+v, want OK=false 'reload not supported'", r)
+		}
+	})
+
+	t.Run("check reload error", func(t *testing.T) {
+		r := dispatchControl(Request{Cmd: "reload"}, func() error { return errors.New("boom") })
+		if r.OK || r.Error != "boom" {
+			t.Errorf("reload(err) = %+v, want OK=false error=boom", r)
+		}
+	})
+
+	t.Run("reload ok", func(t *testing.T) {
+		r := dispatchControl(Request{Cmd: "reload"}, func() error { return nil })
+		if !r.OK || r.PID == 0 {
+			t.Errorf("reload(ok) = %+v, want OK with a pid", r)
+		}
+	})
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -2,6 +2,7 @@ package supervisor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -105,11 +106,32 @@ func runWatcher(ctx context.Context, cfg Config) error {
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
 
+	reloadCh := make(chan chan error)
+
 	// Listen control channel
 	if cfg.SocketPath != "" {
 		if ln := listenControl(cfg.SocketPath); ln != nil {
 			defer ln.Close()
-			go serveControl(ln)
+
+			reload := func() error { // restart child and block until active
+				reply := make(chan error, 1)
+
+				select {
+				case reloadCh <- reply:
+					select {
+					case err := <-reply:
+						return err
+					case <-time.After(2*cfg.ShutdownGrace + 5*time.Second):
+						return errors.New("reload: timed out waiting for restart")
+					}
+				case <-ctx.Done():
+					return errors.New("reload: supervisor shutting down")
+				case <-time.After(connTimeout):
+					return errors.New("reload: supervisor busy, try again")
+				}
+			}
+
+			go serveControl(ln, reload)
 		}
 	}
 
@@ -147,6 +169,8 @@ func runWatcher(ctx context.Context, cfg Config) error {
 		}
 	}
 
+	var pendingReload chan error
+
 	for {
 		cmd := exec.Command(cfg.RunedBinary, cfg.RunedArgs...)
 		cmd.Stdin = nil
@@ -160,6 +184,11 @@ func runWatcher(ctx context.Context, cfg Config) error {
 		if err := cmd.Start(); err != nil {
 			fmt.Fprintf(os.Stderr, "supervisor: start %s: %v\n", cfg.RunedBinary, err)
 
+			if pendingReload != nil { // reloaded new binary failed to start
+				pendingReload <- fmt.Errorf("restart failed to start %s: %w", cfg.RunedBinary, err)
+				pendingReload = nil
+			}
+
 			count, giveUp := recordCrash(time.Now())
 			if giveUp {
 				return fmt.Errorf("supervisor: start %s: %w (%d failures within %s - giving up)", cfg.RunedBinary, err, count, cfg.MaxCrashWindow)
@@ -171,16 +200,27 @@ func runWatcher(ctx context.Context, cfg Config) error {
 			continue
 		}
 
+		if pendingReload != nil { // new child exec'd reloaded successfully
+			pendingReload <- nil
+			pendingReload = nil
+		}
+
 		done := make(chan error, 1)
 		go func() { done <- cmd.Wait() }()
 
-		// Forward SIGINT/SIGTERM to child, detect child exited
+		// Forward SIGINT/SIGTERM to child, detect child exited, serve reload
 		select {
 		case <-ctx.Done():
 			return shutdownChild(cmd, cfg.ShutdownGrace, done)
 		case sig := <-sigCh:
 			fmt.Fprintf(os.Stderr, "supervisor: received %s, forwarding to child\n", sig)
 			return shutdownChild(cmd, cfg.ShutdownGrace, done)
+		case reply := <-reloadCh:
+			fmt.Fprintln(os.Stderr, "supervisor: reload requested, restarting child")
+			shutdownChild(cmd, cfg.ShutdownGrace, done)
+			backoffIdx = 0
+			pendingReload = reply
+			continue
 		case err := <-done:
 			exitCode := -1
 			if cmd.ProcessState != nil {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -268,6 +268,63 @@ func TestWatcher_ControlStatus(t *testing.T) {
 	}
 }
 
+func TestWatcher_ControlSocketReload(t *testing.T) {
+	countFile := t.TempDir() + "/invoke.log"
+	t.Setenv(fakeRunedEnv, "sleep") // child block until SIGTERM, then exits 0
+	t.Setenv(crashCountFileEnv, countFile)
+
+	cfg := testWatcherConfig(t)
+	cfg.SocketPath = filepath.Join(t.TempDir(), "supervisor.sock")
+	cfg.ShutdownGrace = 500 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runWatcher(ctx, cfg) }()
+
+	// Wait until the control socket response
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := SupervisorRequest(cfg.SocketPath, Request{Cmd: "status"}); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("control socket not up within 2s")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Reload: stop current child and restart
+	resp, err := SupervisorRequest(cfg.SocketPath, Request{Cmd: "reload"})
+	if err != nil || !resp.OK {
+		t.Fatalf("reload: resp=%+v err=%v, want OK", resp, err)
+	}
+
+	deadline = time.Now().Add(2 * time.Second)
+	for {
+		data, _ := os.ReadFile(countFile)
+		if strings.Count(string(data), "\n") >= 2 { // fake append newline per invocation
+			break
+		}
+
+		if time.Now().After(deadline) {
+			data, _ := os.ReadFile(countFile)
+			t.Fatalf("child not restarted after reload; invocations=%q", data)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if st, err := SupervisorRequest(cfg.SocketPath, Request{Cmd: "status"}); err != nil || !st.OK {
+		t.Errorf("supervisor should still alive after reload: resp=%+v err=%v", st, err)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("watcher did not exit after cancel")
+	}
+}
+
 func TestWatcher_RetriesStartFailure(t *testing.T) {
 	cfg := testWatcherConfig(t)
 	cfg.RunedBinary = filepath.Join(t.TempDir(), "no-such-runed")

--- a/test/update-e2e.sh
+++ b/test/update-e2e.sh
@@ -1,0 +1,447 @@
+#!/usr/bin/env bash
+#
+# End to end offline test for `rune update`
+#
+# Requirements: go, python3, curl, tar
+# Test env: RUNE_UPDATE_TEST_WORK (default /tmp/rune-update-test)
+#
+# Options (default "all"):
+#   mcp       - rune-mcp raw binary update test
+#   runed     - runed update test as real tar.gz with live supervisor
+#   plugin    - version outdated guard test
+#   autocheck - automatic update test
+#   noauto    - RUNE_NO_AUTO_UPDATE disable auto check
+#   lock      - concurrent install test
+#   all       - run all tests
+
+set -euo pipefail
+
+# Helper
+PASS=0
+green() { printf '\033[32m%s\033[0m' "$1"; }
+red() { printf '\033[31m%s\033[0m' "$1"; }
+pass() {
+  PASS=$((PASS + 1))
+  printf '  %s %s\n' "$(green PASS)" "$1"
+}
+fail() {
+  printf '  %s %s\n' "$(red FAIL)" "$1"
+  [ -f "$RUNED_HOME/logs/daemon.log" ] && {
+    echo "  --- daemon.log ---"
+    sed 's/^/  /' "$RUNED_HOME/logs/daemon.log"
+  }
+  exit 1
+}
+need() { command -v "$1" >/dev/null 2>&1 || { echo "missing dependency: $1" >&2; exit 2; }; }
+
+OUT="" # output
+RC=0   # exit code
+run() {
+  set +e
+  OUT="$("$@" 2>&1)"
+  RC=$?
+  set -e
+}
+
+assert_contains() { case "$1" in *"$2"*) pass "$3" ;; *) fail "$3 (got: $1)" ;; esac; }
+assert_missing() { case "$1" in *"$2"*) fail "$3 (unexpectedly present: $2)" ;; *) pass "$3" ;; esac; }
+assert_eq() { [ "$1" = "$2" ] && pass "$3" || fail "$3 (want $2, got $1)"; }
+
+# Setup temporary isolated env for test
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="${RUNE_UPDATE_TEST_WORK:-/tmp/rune-update-test}"
+TUPLE="$(go env GOOS)-$(go env GOARCH)"
+SCENARIO="${1:-all}"
+
+export RUNE_HOME="$WORK/home/.rune"
+export RUNED_HOME="$WORK/home/.runed"
+
+RUNE="$WORK/rune"
+PORT=""
+BASE=""
+SRV_PID=""
+MCP_PID=""
+declare -a SUP_PIDS=()
+
+STAMP="$RUNE_HOME/last-update-check" # RFC3339 stamp
+UPDATE_LOG="$RUNE_HOME/update.log"   # detached `rune update` log
+INSTALL_LOCK="$RUNED_HOME/install.lock"
+
+# fake binary: raw_binary <dest-in-release> <marker text>
+raw_binary() { printf '#!/bin/sh\n# %s\nexec tail -f /dev/null\n' "$2" >"$WORK/release/$1"; chmod +x "$WORK/release/$1"; }
+
+# tarball with fake binary: runed_tgz <marker text> - build release/runed.tgz containing an executable `runed`
+runed_tgz() {
+  local d="$WORK/stage-runed"
+  rm -rf "$d"; mkdir -p "$d"
+  printf '#!/bin/sh\n# %s\nexec tail -f /dev/null\n' "$1" >"$d/runed"
+  chmod +x "$d/runed"
+  tar -C "$d" -czf "$WORK/release/runed.tgz" runed
+}
+
+# Read MCP_*/RUNED_*/PLUGIN_* from env, compute sha and size
+write_manifest() { OUT_MANIFEST="$WORK/release/manifest.json" TUPLE="$TUPLE" python3 "$WORK/gen_manifest.py"; }
+
+sha_of() { python3 - "$1" <<'PY'
+import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())
+PY
+}
+audit_field() { python3 - "$RUNE_HOME/installed.json" "$@" <<'PY'
+import json,sys
+d=json.load(open(sys.argv[1]))
+for k in sys.argv[2:]:
+    d=d[k]
+print(d)
+PY
+}
+
+# Server
+start_server() {
+  PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+  BASE="http://127.0.0.1:${PORT}"
+  export RUNE_MANIFEST="${BASE}/manifest.json"
+  python3 -m http.server -d "$WORK/release" -b 127.0.0.1 "$PORT" >/dev/null 2>&1 &
+  SRV_PID=$!
+}
+
+wait_socket() {
+  python3 - "$1" <<'PY'
+import os,sys,time
+p=sys.argv[1]
+for _ in range(150):
+    if os.path.exists(p): sys.exit(0)
+    time.sleep(0.1)
+sys.exit(1)
+PY
+}
+
+# Simulate `rune mcp-server`
+spawn_mcp() {
+  env "$@" timeout 60 "$RUNE" mcp-server </dev/null >>"$WORK/mcp-server.log" 2>&1 &
+  MCP_PID=$!
+}
+stop_mcp() { { [ -n "${MCP_PID:-}" ] && kill "$MCP_PID" 2>/dev/null && wait "$MCP_PID" 2>/dev/null; } || true; MCP_PID=""; }
+
+# poll until file <f> matches regex <re>
+poll_contains() {
+  local f="$1" re="$2" t="${3:-30}" i=0
+  while :; do
+    [ -f "$f" ] && grep -qE "$re" "$f" 2>/dev/null && return 0
+    i=$((i + 1)); [ "$i" -ge "$t" ] && return 1
+    sleep 1
+  done
+}
+
+cleanup() {
+  # Kill whole group
+  for p in "${SUP_PIDS[@]:-}"; do
+    [ -n "${p:-}" ] || continue
+    kill -TERM "-$p" 2>/dev/null || true # negative pid = process group
+    kill -TERM "$p" 2>/dev/null || true  # leader
+  done
+
+  [ -n "${MCP_PID:-}" ] && kill "$MCP_PID" 2>/dev/null || true
+  if command -v pkill >/dev/null 2>&1; then
+    pkill -TERM -f "$WORK/rune runed" 2>/dev/null || true
+    pkill -TERM -f "$WORK/rune mcp-server" 2>/dev/null || true
+    pkill -TERM -f "$WORK/rune update" 2>/dev/null || true
+  fi
+  [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+reset_home() { rm -rf "$WORK/home"; }
+
+### Tests
+scenario_mcp() {
+  echo "=== scenario: rune-mcp raw update + integrity check ==="
+  reset_home
+  raw_binary rune-mcp "rune-mcp v0.1.0"
+  raw_binary runed "runed v0.1.0"
+  MCP_URL="$BASE/rune-mcp" MCP_FILE="$WORK/release/rune-mcp" MCP_VER=v0.1.0 MCP_EXTRACT="" \
+    RUNED_URL="$BASE/runed" RUNED_FILE="$WORK/release/runed" RUNED_VER=v0.1.0 RUNED_EXTRACT="" \
+    write_manifest
+
+  run "$RUNE" install
+  assert_eq "$RC" 0 "install seeds v0.1.0"
+  assert_eq "$(audit_field rune_mcp_version)" v0.1.0 "audit rune_mcp = v0.1.0"
+
+  # Publish new version of rune-mcp
+  raw_binary rune-mcp "rune-mcp v0.2.0 UPDATED"
+  MCP_URL="$BASE/rune-mcp" MCP_FILE="$WORK/release/rune-mcp" MCP_VER=v0.2.0 MCP_EXTRACT="" \
+    RUNED_URL="$BASE/runed" RUNED_FILE="$WORK/release/runed" RUNED_VER=v0.1.0 RUNED_EXTRACT="" \
+    write_manifest
+
+  run "$RUNE" update --check
+  assert_contains "$OUT" "rune_mcp: v0.1.0 -> v0.2.0" "--check reports rune_mcp outdated"
+
+  run "$RUNE" update --only rune_mcp
+  assert_eq "$RC" 0 "update --only rune_mcp exits 0"
+  assert_contains "$OUT" "updated rune_mcp: v0.1.0 -> v0.2.0" "reports the apply"
+  assert_contains "$(cat "$RUNE_HOME/bin/rune-mcp")" "v0.2.0 UPDATED" "on-disk rune-mcp swapped"
+  assert_eq "$(audit_field rune_mcp_version)" v0.2.0 "audit bumped to v0.2.0"
+
+  # Integrity test
+  raw_binary rune-mcp "rune-mcp v0.3.0 CORRUPTED" # new version with wrong sha
+  MCP_URL="$BASE/rune-mcp" MCP_FILE="$WORK/release/rune-mcp" MCP_VER=v0.3.0 MCP_EXTRACT="" MCP_SHA_OVERRIDE="$(printf '0%.0s' {1..64})" \
+    RUNED_URL="$BASE/runed" RUNED_FILE="$WORK/release/runed" RUNED_VER=v0.1.0 RUNED_EXTRACT="" \
+    write_manifest
+
+  run "$RUNE" update --only rune_mcp
+  assert_eq "$RC" 1 "checksum mismatch fails the update"
+  assert_contains "$OUT" "checksum mismatch" "reports the mismatch"
+  assert_contains "$(cat "$RUNE_HOME/bin/rune-mcp")" "v0.2.0 UPDATED" "bad download did NOT swap the binary"
+  assert_eq "$(audit_field rune_mcp_version)" v0.2.0 "audit unchanged after failed update"
+}
+
+scenario_runed() {
+  echo "=== scenario: runed tar.gz + live supervisor reload ==="
+  reset_home
+  raw_binary rune-mcp "rune-mcp v0.1.0"
+  runed_tgz "runed v0.1.0"
+  MCP_URL="$BASE/rune-mcp" MCP_FILE="$WORK/release/rune-mcp" MCP_VER=v0.1.0 MCP_EXTRACT="" \
+    RUNED_URL="$BASE/runed.tgz" RUNED_FILE="$WORK/release/runed.tgz" RUNED_VER=v0.1.0 RUNED_EXTRACT="tar.gz" \
+    write_manifest
+
+  run "$RUNE" install
+  assert_eq "$RC" 0 "install extracts runed tarball"
+  assert_contains "$(cat "$RUNED_HOME/bin/runed")" "runed v0.1.0" "extracted runed present"
+  assert_eq "$(audit_field artifacts runed dest_sha256)" "$(sha_of "$RUNED_HOME/bin/runed")" \
+    "audit dest_sha256 == extracted runed hash (not archive)"
+
+  # Start runed supervisor and runed daemon
+  run "$RUNE" runed --detach
+  assert_eq "$RC" 0 "rune runed --detach launch the supervisor"
+  wait_socket "$RUNED_HOME/supervisor.sock" || fail "supervisor socket never appeared"
+  run "$RUNE" runed --status
+  assert_contains "$OUT" "running (pid" "supervisor is running"
+  local sup_before
+  sup_before="$(printf '%s' "$OUT" | sed -n 's/.*pid \([0-9][0-9]*\).*/\1/p')"
+  SUP_PIDS+=("$sup_before")
+
+  # Publish new runed
+  runed_tgz "runed v0.2.0 RELOADED"
+  MCP_URL="$BASE/rune-mcp" MCP_FILE="$WORK/release/rune-mcp" MCP_VER=v0.1.0 MCP_EXTRACT="" \
+    RUNED_URL="$BASE/runed.tgz" RUNED_FILE="$WORK/release/runed.tgz" RUNED_VER=v0.2.0 RUNED_EXTRACT="tar.gz" \
+    write_manifest
+
+  run "$RUNE" update --only runed
+  assert_eq "$RC" 0 "update --only runed exits 0"
+  assert_contains "$OUT" "daemon reloaded" "live daemon was reloaded"
+  assert_contains "$(cat "$RUNED_HOME/bin/runed")" "v0.2.0 RELOADED" "on-disk runed swapped"
+  assert_eq "$(audit_field runed_version)" v0.2.0 "audit runed bumped to v0.2.0"
+  assert_eq "$(audit_field artifacts runed dest_sha256)" "$(sha_of "$RUNED_HOME/bin/runed")" \
+    "post-update audit dest_sha256 == extracted v0.2.0 runed hash (not archive)"
+
+  run "$RUNE" runed --status
+  assert_contains "$OUT" "running (pid" "supervisor still running after reload"
+  local sup_after
+  sup_after="$(printf '%s' "$OUT" | sed -n 's/.*pid \([0-9][0-9]*\).*/\1/p')"
+  assert_eq "$sup_after" "$sup_before" "same supervisor running after reload (child restarted, not the supervisor)"
+}
+
+scenario_plugin() {
+  echo "=== scenario: plugin/binary outdated version guard ==="
+  reset_home
+  raw_binary rune-mcp "rune-mcp v0.1.0"
+  raw_binary runed "runed v0.1.0"
+  MCP_URL="$BASE/rune-mcp" MCP_FILE="$WORK/release/rune-mcp" MCP_VER=v0.1.0 MCP_EXTRACT="" \
+    RUNED_URL="$BASE/runed" RUNED_FILE="$WORK/release/runed" RUNED_VER=v0.1.0 RUNED_EXTRACT="" \
+    write_manifest
+
+  run "$RUNE" install
+  assert_eq "$RC" 0 "seed install"
+
+  # Fake plugin package 0.4.1
+  local proot="$WORK/plugin"
+  mkdir -p "$proot/.claude-plugin"
+  printf '{"name":"rune","version":"0.4.1"}\n' >"$proot/.claude-plugin/plugin.json"
+
+  # Refuse: min_plugin_version (0.5.0) > installed (0.4.1)
+  raw_binary rune-mcp "rune-mcp v0.2.0 FLOOR"
+  MCP_URL="$BASE/rune-mcp" MCP_FILE="$WORK/release/rune-mcp" MCP_VER=v0.2.0 MCP_EXTRACT="" \
+    RUNED_URL="$BASE/runed" RUNED_FILE="$WORK/release/runed" RUNED_VER=v0.1.0 RUNED_EXTRACT="" \
+    PLUGIN_VER=0.5.0 MIN_PLUGIN_VER=0.5.0 write_manifest
+
+  run "$RUNE" update --only rune_mcp --plugin-root "$proot"
+  assert_eq "$RC" 1 "below minimum version is refused"
+  assert_contains "$OUT" "refusing to apply" "refusal is surfaced"
+  assert_contains "$(cat "$RUNE_HOME/bin/rune-mcp")" "v0.1.0" "refused update did NOT swap"
+  assert_eq "$(audit_field rune_mcp_version)" v0.1.0 "audit unchanged on refusal"
+
+  # Skip check outdated with '--allow-plugin-oudtaed'
+  run "$RUNE" update --only rune_mcp --plugin-root "$proot" --allow-plugin-outdated
+  assert_eq "$RC" 0 "bypass applies"
+  assert_contains "$(cat "$RUNE_HOME/bin/rune-mcp")" "v0.2.0 FLOOR" "bypass swapped the binary"
+  assert_contains "$OUT" "allow-plugin-outdated" "bypass warns about skew"
+
+  # Installed 0.4.1 is >= min 0.4.0 but < expected 0.6.0
+  raw_binary rune-mcp "rune-mcp v0.3.0 ADVISORY"
+  MCP_URL="$BASE/rune-mcp" MCP_FILE="$WORK/release/rune-mcp" MCP_VER=v0.3.0 MCP_EXTRACT="" \
+    RUNED_URL="$BASE/runed" RUNED_FILE="$WORK/release/runed" RUNED_VER=v0.1.0 RUNED_EXTRACT="" \
+    PLUGIN_VER=0.6.0 MIN_PLUGIN_VER=0.4.0 write_manifest
+
+  run "$RUNE" update --only rune_mcp --plugin-root "$proot"
+  assert_eq "$RC" 0 "advisory-only update applies"
+  assert_contains "$OUT" "plugin package is 0.4.1" "advisory note surfaced"
+  assert_contains "$(cat "$RUNE_HOME/bin/rune-mcp")" "v0.3.0 ADVISORY" "advisory update swapped"
+}
+
+scenario_autocheck() {
+  echo "=== scenario: auto-check ==="
+  need timeout
+  reset_home
+  raw_binary rune-mcp "rune-mcp v0.1.0"
+  raw_binary runed "runed v0.1.0"
+  MCP_URL="$BASE/rune-mcp" MCP_FILE="$WORK/release/rune-mcp" MCP_VER=v0.1.0 MCP_EXTRACT="" \
+    RUNED_URL="$BASE/runed" RUNED_FILE="$WORK/release/runed" RUNED_VER=v0.1.0 RUNED_EXTRACT="" \
+    write_manifest
+
+  run "$RUNE" install
+  assert_eq "$RC" 0 "seed install v0.1.0"
+
+  # Publish new rune-mcp to trigger auto-check
+  raw_binary rune-mcp "rune-mcp v0.2.0 AUTO"
+  MCP_URL="$BASE/rune-mcp" MCP_FILE="$WORK/release/rune-mcp" MCP_VER=v0.2.0 MCP_EXTRACT="" \
+    RUNED_URL="$BASE/runed" RUNED_FILE="$WORK/release/runed" RUNED_VER=v0.1.0 RUNED_EXTRACT="" \
+    write_manifest
+
+  # Run auto check
+  rm -f "$STAMP" "$UPDATE_LOG"
+  spawn_mcp
+  if poll_contains "$STAMP" 'T' 15; then # RFC3339 stamp always contains 'T'
+    pass "stale stamp -> spawn ran the auto-check (stamp recorded)"
+  else
+    fail "spawn did not run the auto-check (no stamp)"
+  fi
+  if poll_contains "$RUNE_HOME/bin/rune-mcp" "v0.2.0 AUTO" 30 || poll_contains "$UPDATE_LOG" "rune_mcp" 5; then
+    pass "spawn fired a detached rune update (rune-mcp swapped to v0.2.0)"
+  else
+    fail "spawn did not fire the detached rune update (no swap and no update.log within timeout)"
+  fi
+  stop_mcp
+
+  # Initial setup -> no auto check
+  date -u +%Y-%m-%dT%H:%M:%SZ >"$STAMP"
+  rm -f "$UPDATE_LOG"
+  spawn_mcp
+  sleep 8
+  [ ! -s "$UPDATE_LOG" ] && pass "fresh stamp -> auto-check suppressed" || fail "fresh stamp did not suppress the update"
+  stop_mcp
+
+  # Terminate detached `rune update`
+  if command -v pkill >/dev/null 2>&1; then pkill -f "$WORK/rune update" 2>/dev/null || true; fi
+  for _ in $(seq 1 50); do pgrep -f "$WORK/rune update" >/dev/null 2>&1 || break; sleep 0.1; done
+}
+
+scenario_noauto() {
+  echo "=== scenario: RUNE_NO_AUTO_UPDATE disable auto-check ==="
+  need timeout
+  reset_home
+  raw_binary rune-mcp "rune-mcp v0.1.0"
+  raw_binary runed "runed v0.1.0"
+  MCP_URL="$BASE/rune-mcp" MCP_FILE="$WORK/release/rune-mcp" MCP_VER=v0.1.0 MCP_EXTRACT="" \
+    RUNED_URL="$BASE/runed" RUNED_FILE="$WORK/release/runed" RUNED_VER=v0.1.0 RUNED_EXTRACT="" \
+    write_manifest
+
+  run "$RUNE" install
+  assert_eq "$RC" 0 "seed install v0.1.0"
+
+  raw_binary rune-mcp "rune-mcp v0.2.0 AUTO"
+  MCP_URL="$BASE/rune-mcp" MCP_FILE="$WORK/release/rune-mcp" MCP_VER=v0.2.0 MCP_EXTRACT="" \
+    RUNED_URL="$BASE/runed" RUNED_FILE="$WORK/release/runed" RUNED_VER=v0.1.0 RUNED_EXTRACT="" \
+    write_manifest
+  rm -f "$STAMP" "$UPDATE_LOG"
+  spawn_mcp RUNE_NO_AUTO_UPDATE=1
+  sleep 6
+  stop_mcp
+  assert_eq "$([ -s "$UPDATE_LOG" ] && echo fired || echo none)" none "RUNE_NO_AUTO_UPDATE=1 -> no detached update"
+  assert_eq "$([ -f "$STAMP" ] && echo stamped || echo none)" none "no stamp written"
+  assert_contains "$(cat "$RUNE_HOME/bin/rune-mcp")" "v0.1.0" "installed rune-mcp intact"
+}
+
+scenario_lock() {
+  echo "=== scenario: concurrent install lock ==="
+  need flock
+  reset_home
+  raw_binary rune-mcp "rune-mcp v0.1.0"
+  raw_binary runed "runed v0.1.0"
+  MCP_URL="$BASE/rune-mcp" MCP_FILE="$WORK/release/rune-mcp" MCP_VER=v0.1.0 MCP_EXTRACT="" \
+    RUNED_URL="$BASE/runed" RUNED_FILE="$WORK/release/runed" RUNED_VER=v0.1.0 RUNED_EXTRACT="" \
+    write_manifest
+
+  run "$RUNE" install
+  assert_eq "$RC" 0 "seed install v0.1.0"
+
+  # Hold install lock to trigger ErrInstallInProgress
+  mkdir -p "$RUNED_HOME"
+  exec 9>"$INSTALL_LOCK"
+  flock -x 9
+
+  run "$RUNE" install
+  flock -u 9 2>/dev/null || true
+  exec 9>&-
+  assert_eq "$RC" 1 "concurrent install refused"
+  assert_contains "$OUT" "another install in progress" "reports ErrInstallInProgress"
+  assert_contains "$(cat "$RUNE_HOME/bin/rune-mcp")" "v0.1.0" "installed rune-mcp intact after refusal"
+}
+
+# Test main
+need go; need python3; need curl; need tar
+
+rm -rf "$WORK"; mkdir -p "$WORK/release"
+echo "==+ build CLI ==="
+( cd "$REPO" && go build -o "$RUNE" ./cmd/rune )
+
+cat >"$WORK/gen_manifest.py" <<'PY'
+import json, os, hashlib
+def art(url, path, extract):
+    b = open(path, "rb").read()
+    d = {"url": url, "sha256": hashlib.sha256(b).hexdigest(), "size": len(b)}
+    if extract:
+        d["extract"] = extract
+    return d
+tuple_ = os.environ["TUPLE"]
+m = {
+    "version": 1,
+    "rune_mcp_version": os.environ["MCP_VER"],
+    "runed_version": os.environ["RUNED_VER"],
+    "platforms": {tuple_: {
+        "runed": art(os.environ["RUNED_URL"], os.environ["RUNED_FILE"], os.environ.get("RUNED_EXTRACT", "")),
+        "rune_mcp": art(os.environ["MCP_URL"], os.environ["MCP_FILE"], os.environ.get("MCP_EXTRACT", "")),
+    }},
+}
+if os.environ.get("PLUGIN_VER"):
+    m["plugin_version"] = os.environ["PLUGIN_VER"]
+if os.environ.get("MIN_PLUGIN_VER"):
+    m["min_plugin_version"] = os.environ["MIN_PLUGIN_VER"]
+# optional integrity-test override: advertise a wrong rune-mcp hash
+if os.environ.get("MCP_SHA_OVERRIDE"):
+    m["platforms"][tuple_]["rune_mcp"]["sha256"] = os.environ["MCP_SHA_OVERRIDE"]
+json.dump(m, open(os.environ["OUT_MANIFEST"], "w"), indent=2)
+PY
+
+start_server
+
+if ! curl --retry 50 --retry-connrefused --connect-timeout 2 --retry-max-time 15 -sf "${BASE}/" >/dev/null; then
+  if kill -0 "$SRV_PID" 2>/dev/null; then
+    echo "local server did not become ready on $BASE" >&2
+  else
+    echo "local http server failed to start (maybe check port $PORT is available) - re-run" >&2
+  fi
+  exit 1
+fi
+
+case "$SCENARIO" in
+  mcp) scenario_mcp ;;
+  runed) scenario_runed ;;
+  plugin) scenario_plugin ;;
+  autocheck) scenario_autocheck ;;
+  noauto) scenario_noauto ;;
+  lock) scenario_lock ;;
+  all) scenario_mcp; echo; scenario_runed; echo; scenario_plugin; echo; scenario_autocheck; echo; scenario_noauto; echo; scenario_lock ;;
+  *) echo "unknown scenario: $SCENARIO (want: mcp|runed|plugin|autocheck|noauto|lock|all)" >&2; exit 2 ;;
+esac
+
+echo
+echo "$(green "ALL PASS") - $PASS checks"


### PR DESCRIPTION
Implement in-place update mechanism for Rune's runtime binaries, `rune-mcp` and `runed`.
They can be refreshed according to the published manifest without plugin un/re-install.