### PR TITLE
docs(commands): guide the agent through a consumed-but-unsaved invite

### DIFF
--- a/commands/claude/configure.md
+++ b/commands/claude/configure.md
@@ -33,8 +33,16 @@ Do NOT ask for endpoint, token, or CA separately.
    consumed on first use, so a second `configure` with the SAME string will fail
    ("already used") — that is the tamper signal; the user must request a fresh
    invite.
-3. Branch on the response exactly as in "Decide what to do next" (§5) below, then
-   call `mcp__plugin_rune_rune__activate`. Skip the manual collection steps.
+3. **If the FIRST call returns `ok:false` with
+   `error.code == "REGISTRATION_CONSUMED"`**: the handle was redeemed but
+   writing `~/.rune/config.json` failed afterward, so nothing was saved. The
+   string is now spent — do NOT retry it. Surface `error.recovery_hint`
+   verbatim, have the user clear the local problem (disk space / `~/.rune`
+   permissions), and tell them to request a **fresh invite**. Do not call
+   `activate`.
+4. Otherwise branch on the response exactly as in "Decide what to do next" (§5)
+   below, then call `mcp__plugin_rune_rune__activate`. Skip the manual
+   collection steps.
 
 Fall through to the manual flow only when the user has no registration string.
 


### PR DESCRIPTION
## What

Teaches `/rune:configure` to handle a new failure mode from the registration-string bootstrap: the one-time handle was **redeemed** but persisting the resolved credentials to `~/.rune/config.json` **failed afterward**.

In that state the handle is spent, so retrying the same `runev1_…` string is futile (the next attempt fails at unwrap with "already used"). The prompt now branches on `error.code == "REGISTRATION_CONSUMED"`:

- surface `error.recovery_hint` verbatim
- have the user clear the local problem (disk space / `~/.rune` permissions)
- tell them to request a **fresh invite**
- do **not** retry the string or call `activate`

This is distinct from the pre-existing "second call with the same string" note (that is a *second* call failing; this is the *first* call succeeding at unwrap but failing to save).

## Why

Without this, a benign local I/O failure after unwrap surfaced as a generic save error, and the agent would push the user to retry the same string — which then dead-ends at a confusing "already used" tamper signal.

## Dependency

Pairs with the rune-mcp change that emits the `REGISTRATION_CONSUMED` code (rune-mcp PR #23). This prompt change is harmless ahead of that: the new branch simply never triggers until the server emits the code.