### PR TITLE
Fix/readme

### DIFF
--- a/.github/assets/rune-hero.svg
+++ b/.github/assets/rune-hero.svg
@@ -30,10 +30,6 @@
     <pattern id="dots" width="28" height="28" patternUnits="userSpaceOnUse">
       <circle cx="1.5" cy="1.5" r="1.5" fill="#b8fff0" fill-opacity="0.08"/>
     </pattern>
-    <filter id="mark-shadow" x="-25%" y="-20%" width="150%" height="160%" color-interpolation-filters="sRGB">
-      <feDropShadow dx="0" dy="20" stdDeviation="20" flood-color="#020a12" flood-opacity="0.42"/>
-      <feDropShadow dx="0" dy="0" stdDeviation="12" flood-color="#5cffd6" flood-opacity="0.1"/>
-    </filter>
     <clipPath id="frame">
       <rect width="1280" height="420" rx="28"/>
     </clipPath>
@@ -44,7 +40,7 @@
     <rect width="1280" height="420" fill="url(#dots)"/>
     <rect width="560" height="420" fill="url(#glow)"/>
 
-    <g transform="translate(44 15) scale(0.72)" filter="url(#mark-shadow)">
+    <g transform="translate(44 15) scale(0.72)" shape-rendering="geometricPrecision">
       <path d="M365 281 L440 341 L259 475 L259 352 Z" fill="url(#mark-right)"/>
       <path d="M257 64 L440 201 L440 341 L365 281 L258 201 Z" fill="url(#mark-top)"/>
       <path d="M257 64 L95 185 L95 351 L164 401 L265 313 L190 260 L258 201 Z" fill="url(#mark-left)"/>


### PR DESCRIPTION
## Summary

- What changed:
- Why:
- Scope:

## Validation

- [ ] Tests run (or explain why not):
- [ ] Docs updated (if behavior/setup changed)

## Cross-Agent Invariants

- [ ] No agent-specific script duplicates bootstrap/setup logic
- [ ] Agent-specific scripts remain thin adapters (registration/wiring only)
- [ ] Codex-only commands (`codex mcp ...`) are clearly separated from cross-agent/common instructions
- [ ] Claude/Gemini/OpenAI instructions do not include Codex-only commands
- [ ] `SKILL.md`, `commands/rune/*.toml`, and `AGENT_INTEGRATION.md` stay consistent on boundaries

## Notes for Reviewers

- Risk areas:
- Backward compatibility impact:
- Follow-up work (if any):
