### PR TITLE
fix(bootstrap): resolve CLI via /releases/latest with a registration_string pin guard

### DIFF
--- a/.github/workflows/release-rune-cli.yml
+++ b/.github/workflows/release-rune-cli.yml
@@ -172,6 +172,45 @@ jobs:
           [ "$fail" -eq 0 ] || exit 1
           echo "Both pinned releases are published."
 
+      - name: Verify pinned releases support registration_string
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # bin/rune resolves the CLI via /releases/latest, so whichever rune
+          # release is "Latest" hands new users the rune-mcp/runed its manifest
+          # pins. The console<->rune-mcp handshake in commands/*/configure.md
+          # needs a rune-mcp/runed whose configure tool accepts a
+          # registration_string (the 3-stage bootstrap). That path first ships
+          # in the 1.0 line; every 0.x release predates it. Publishing a rune
+          # release that pins a 0.x rune-mcp/runed would, once promoted to
+          # "Latest", make bin/rune hand new users a CLI that cannot configure.
+          # Fail here so an incompatible pin can never become "Latest".
+          MIN_MAJOR=1
+
+          RUNE_MCP_VERSION=$(awk '/^rune_mcp_version:/ {print $2}' .release-pins.yaml)
+          RUNED_VERSION=$(awk    '/^runed_version:/    {print $2}' .release-pins.yaml)
+
+          # Numeric major from a vMAJOR.MINOR.PATCH[-pre] tag (strip leading v).
+          major_of() { printf '%s' "$1" | sed -E 's/^v//; s/^([0-9]+).*/\1/'; }
+
+          fail=0
+          for pair in "rune-mcp:${RUNE_MCP_VERSION}" "runed:${RUNED_VERSION}"; do
+            name=${pair%%:*}; ver=${pair#*:}
+            major=$(major_of "$ver")
+            if ! printf '%s' "$major" | grep -qE '^[0-9]+$'; then
+              echo "::error::cannot parse a major version from ${name} pin '${ver}' in .release-pins.yaml" >&2
+              fail=1; continue
+            fi
+            if [ "$major" -lt "$MIN_MAJOR" ]; then
+              echo "::error::${name} ${ver} (pinned in .release-pins.yaml) predates the registration_string 3-stage bootstrap (needs >= v${MIN_MAJOR}.0.0). Bump the pin before tagging rune." >&2
+              fail=1
+            fi
+          done
+
+          [ "$fail" -eq 0 ] || exit 1
+          echo "Pinned releases support registration_string (rune-mcp=${RUNE_MCP_VERSION}, runed=${RUNED_VERSION})."
+
       - name: Generate manifest
         shell: bash
         env:

--- a/bin/rune
+++ b/bin/rune
@@ -180,12 +180,25 @@ if [ -x "$TARGET" ]; then
 fi
 
 # Lazy version evaluation
-# Priority: RUNE_VERSION > latest release (including pre-release for now)
-# TODO: switch to .../rune/releases/latest
+# Priority: RUNE_VERSION > newest published release marked "Latest".
+#
+# /releases/latest returns the release GitHub flags "Latest" and EXCLUDES
+# pre-releases. Preferred over releases?per_page=1 (created_at order), which
+# can surface an unintended tag after a re-tag/rebuild reshuffles creation
+# time. If no stable release exists yet the endpoint 404s, the body is empty,
+# and the "cannot determine the latest release" path below tells the caller to
+# pin RUNE_VERSION explicitly.
+#
+# Safety: whichever release is "Latest" hands new users the rune-mcp/runed its
+# manifest pins. Those must accept the configure registration_string (3-stage
+# bootstrap) or configure breaks. The release workflow enforces this — a rune
+# tag whose .release-pins.yaml points at pre-1.0 rune-mcp/runed fails to
+# publish (see .github/workflows/release-rune-cli.yml), so an incompatible pin
+# can never become "Latest".
 RUNE_VERSION="${RUNE_VERSION:-}"
 if [ -z "$RUNE_VERSION" ]; then
   echo "rune: resolving latest release..." >&2
-  api="https://api.github.com/repos/CryptoLabInc/rune/releases?per_page=1"
+  api="https://api.github.com/repos/CryptoLabInc/rune/releases/latest"
 
   # Use token if exist
   token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"


### PR DESCRIPTION
## What

`bin/rune` (the plugin bootstrap) resolved the CLI version from
`releases?per_page=1`. That endpoint orders by `created_at`, so a re-tag or a
rebuild that reshuffles creation time can surface an unintended tag as "latest".
It also includes pre-releases, which is why it currently resolves `v1.0.0-alpha`.

This switches resolution to **`/releases/latest`** — the release GitHub flags
"Latest", which **excludes pre-releases** and is stable across re-tagging. This
is the resolution GA needs (the long-standing `TODO: switch to
.../rune/releases/latest`).

## Why the guard

`/releases/latest` is only safe once a **stable** rune release whose
`manifest.json` pins **registration_string-capable** rune-mcp/runed is "Latest".
The console↔rune-mcp handshake in `commands/*/configure.md` needs a rune-mcp
whose `configure` tool accepts a `registration_string` (the 3-stage bootstrap).
That path first ships in the 1.0 line; **every 0.x release predates it**.

Concretely, today:

- GitHub "Latest" is `v0.4.1` (stable) → its manifest pins `rune-mcp v0.1.0` +
  `runed v0.1.0` (verified against the published `manifest.json` asset).
- `v0.1.0` has no `registration_string` path → `configure`'s 3-stage bootstrap
  cannot run → new users cannot connect.

So a naive switch would immediately regress new installs. To make the switch
self-protecting, the release workflow gains a step that **fails publishing when
`.release-pins.yaml` pins a pre-1.0 rune-mcp/runed**, so an incompatible pin can
never be promoted to "Latest".

## Changes

- `bin/rune`: `releases?per_page=1` → `releases/latest`; comment documents the
  rationale and the workflow guard. Empty-body (404, i.e. no stable release yet)
  still falls through to the existing "pin RUNE_VERSION explicitly" error.
- `.github/workflows/release-rune-cli.yml`: new **"Verify pinned releases
  support registration_string"** step (major-version guard, `MIN_MAJOR=1`),
  after the existing existence check.

## ⚠️ Merge / release sequencing — do NOT merge-and-release as-is

This rides with the **v1.0.0 GA cutover**, not before it:

- `main`'s `.release-pins.yaml` currently pins `v0.1.0` (the compatible
  `v1.0.0-alpha` pins live only on `release/v1.0.0`).
- With `main` pins as-is, the new guard will (correctly) **fail** any release
  tagged from `main`, and `/releases/latest` still points at `v0.4.1`.

Land this together with the pins bump to registration_string-capable
rune-mcp/runed and the v1.0.0 stable release, so that a compatible stable
release becomes "Latest" at the same time the resolution flips.

## Verification

- Guard logic unit-tested locally: `v0.1.0`→fail, `v1.0.0-alpha`/`v1.0.0`→pass,
  mixed `v0.4.1`+`v1.0.0`→fail, unparseable→fail, `v2.x`→pass.
- `release-rune-cli.yml` parses as valid YAML; `bin/rune` passes `bash -n`.